### PR TITLE
DLsiteResolverを追加

### DIFF
--- a/app/MetadataResolver/DLsiteResolver.php
+++ b/app/MetadataResolver/DLsiteResolver.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\MetadataResolver;
+
+use Illuminate\Support\Facades\Log;
+
+class DLsiteResolver implements Resolver
+{
+    public function resolve(string $url): Metadata
+    {
+        $client = new \GuzzleHttp\Client();
+        $res = $client->get($url);
+        if ($res->getStatusCode() === 200) {
+            $ogpResolver = new OGPResolver();
+            $metadata = $ogpResolver->parse($res->getBody());
+            $metadata->image =  str_replace("img_sam.jpg", "img_main.jpg", $metadata->image);
+            return $metadata;
+        } else {
+            throw new \RuntimeException("{$res->getStatusCode()}: $url");
+        }
+    }
+}

--- a/app/MetadataResolver/MetadataResolver.php
+++ b/app/MetadataResolver/MetadataResolver.php
@@ -11,6 +11,7 @@ class MetadataResolver implements Resolver
         '~www\.melonbooks\.co\.jp/detail/detail\.php~' => MelonbooksResolver::class,
         '~ec\.toranoana\.jp/tora_r/ec/item/.*~' => ToranoanaResolver::class,
         '~iwara\.tv/videos/.*~' => IwaraResolver::class,
+        '~www\.dlsite\.com/.*/work/=/product_id/..\d+\.html~' => DLsiteResolver::class,
         '/.*/' => OGPResolver::class
     ];
 


### PR DESCRIPTION
DLsiteのOGPURL
```
https://img.dlsite.jp/modpub/images2/work/doujin/RJ******/RJ******_img_sam.jpg
```
から、
メイン画像
```
https://img.dlsite.jp/modpub/images2/work/doujin/RJ******/RJ******_img_main.jpg
```
に変換するリゾルバです。

`MetadataResolver.php`の正規表現(\d+あたり)に不安があるので見てもらえると助かります。