### PR TITLE
composer installでdistから取れるようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM php:7.1-apache
 ENV APACHE_DOCUMENT_ROOT /var/www/html/public
 
 RUN apt-get update \
-    && apt-get install -y git libpq-dev \
+    && apt-get install -y git libpq-dev unzip \
     && docker-php-ext-install pdo_pgsql \
     && curl -sS https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer \


### PR DESCRIPTION
```
Package operations: 84 installs, 0 updates, 0 removals
    Failed to download symfony/thanks from dist: The zip extension and unzip command are both missing, skipping.
The php.ini used by your command-line PHP is: /usr/local/etc/php/conf.d/docker-php-ext-pdo_pgsql.ini                                                          
    Now trying to download from source
  - Installing symfony/thanks (v1.1.0): Cloning 9474a631b5 from cache
    Failed to download vlucas/phpdotenv from dist: The zip extension and unzip command are both missing, skipping.
The php.ini used by your command-line PHP is: /usr/local/etc/php/conf.d/docker-php-ext-pdo_pgsql.ini                                                          
    Now trying to download from source
```

のような警告を出さないようにする