### PR TITLE
KomifloResolverに画像の取得を追加

### DIFF
--- a/app/MetadataResolver/KomifloResolver.php
+++ b/app/MetadataResolver/KomifloResolver.php
@@ -21,6 +21,7 @@ class KomifloResolver implements Resolver
             $metadata->description = ($json['content']['attributes']['artists']['children'][0]['data']['name'] ?? '?') .
                 ' - ' .
                 ($json['content']['parents'][0]['data']['title'] ?? '?');
+            $metadata->image = $json['content']['cdn_public'] . "/564_mobile_large_3x/" . $json['content']['named_imgs']['cover']['filename'] . $json['content']['signature'];
 
             return $metadata;
         } else {

--- a/app/MetadataResolver/KomifloResolver.php
+++ b/app/MetadataResolver/KomifloResolver.php
@@ -2,6 +2,8 @@
 
 namespace App\MetadataResolver;
 
+use Carbon\Carbon;
+
 class KomifloResolver implements Resolver
 {
     public function resolve(string $url): Metadata
@@ -22,7 +24,7 @@ class KomifloResolver implements Resolver
                 ' - ' .
                 ($json['content']['parents'][0]['data']['title'] ?? '?');
             $metadata->image = $json['content']['cdn_public'] . "/564_mobile_large_3x/" . $json['content']['named_imgs']['cover']['filename'] . $json['content']['signature'];
-            $metadata->expires_at = date('Y-m-d H:i:s', strtotime($json['content']['signature_expires']));
+            $metadata->expires_at = Carbon::parse($json['content']['signature_expires']);
 
             return $metadata;
         } else {

--- a/app/MetadataResolver/KomifloResolver.php
+++ b/app/MetadataResolver/KomifloResolver.php
@@ -22,6 +22,7 @@ class KomifloResolver implements Resolver
                 ' - ' .
                 ($json['content']['parents'][0]['data']['title'] ?? '?');
             $metadata->image = $json['content']['cdn_public'] . "/564_mobile_large_3x/" . $json['content']['named_imgs']['cover']['filename'] . $json['content']['signature'];
+            $metadata->expires_at = date('Y-m-d H:i:s', strtotime($json['content']['signature_expires']));
 
             return $metadata;
         } else {

--- a/app/MetadataResolver/KomifloResolver.php
+++ b/app/MetadataResolver/KomifloResolver.php
@@ -24,7 +24,7 @@ class KomifloResolver implements Resolver
                 ' - ' .
                 ($json['content']['parents'][0]['data']['title'] ?? '?');
             $metadata->image = $json['content']['cdn_public'] . "/564_mobile_large_3x/" . $json['content']['named_imgs']['cover']['filename'] . $json['content']['signature'];
-            $metadata->expires_at = Carbon::parse($json['content']['signature_expires']);
+            $metadata->expires_at = Carbon::parse($json['content']['signature_expires'])->setTimezone(config('app.timezone'));
 
             return $metadata;
         } else {


### PR DESCRIPTION
未ログインで取得できる情報なので問題ないと考えていますが、問題があるようであればcloseしてください。

## 画像のサイズについて

Komiflo APIで取得できるサムネイル画像のサイズは
```
0: "148_desktop_small"
1: "296_desktop_small_2x"
2: "198_desktop_medium"
3: "396_desktop_medium_2x"
4: "247_desktop_large"
5: "494_desktop_large_2x"
6: "160_mobile_narrow"
7: "320_mobile_narrow_2x"
8: "207_mobile_medium"
9: "414_mobile_medium_2x"
10: "188_mobile_large"
11: "376_mobile_large_2x"
12: "564_mobile_large_3x"
13: "346_mobile"
```

があるようです。

現在Tissueでは `.col-md-6` でオカズリンクの `.card` を表示していて、そのコンテナが `.col-lg-8` のため、画像は最大で342pxで表示されるようです。

高DPIな環境を想定して342pxの2倍、684px程度あると良さそうだったので取得できる最も大きなサムネイルの `564_mobile_large_3x` を使用しています。