### PR TITLE
メール欄のtypeをemailに変更

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -13,7 +13,7 @@
 
                 <div class="form-group">
                     <label for="email"><span class="oi oi-envelope-closed"></span> メールアドレス</label>
-                    <input id="email" name="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" type="text" value="{{ old('email') }}" required autofocus>
+                    <input id="email" name="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" type="email" value="{{ old('email') }}" required autofocus>
 
                     @if ($errors->has('email'))
                         <div class="invalid-feedback">{{ $errors->first('email') }}</div>

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -16,7 +16,7 @@
 
                 <div class="form-group">
                     <label for="email"><span class="oi oi-envelope-closed"></span> メールアドレス</label>
-                    <input id="email" name="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" type="text" value="{{ old('email') }}" required autofocus>
+                    <input id="email" name="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" type="email" value="{{ old('email') }}" required autofocus>
 
                     @if ($errors->has('email'))
                         <div class="invalid-feedback">{{ $errors->first('email') }}</div>

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -18,7 +18,7 @@
 
                 <div class="form-group">
                     <label for="email"><span class="oi oi-envelope-closed"></span> メールアドレス</label>
-                    <input id="email" name="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" type="text" value="{{ old('email') }}" required>
+                    <input id="email" name="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" type="email" value="{{ old('email') }}" required>
 
                     @if ($errors->has('email'))
                         <div class="invalid-feedback">{{ $errors->first('email') }}</div>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -27,7 +27,7 @@
                 </div>
                 <div class="form-group">
                     <label for="email"><span class="oi oi-envelope-closed"></span> メールアドレス</label>
-                    <input id="email" name="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" type="text" value="{{ old('email') }}" required>
+                    <input id="email" name="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" type="email" value="{{ old('email') }}" required>
 
                     @if ($errors->has('email'))
                         <div class="invalid-feedback">{{ $errors->first('email') }}</div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3516343/51208652-9be48180-1951-11e9-9e3f-c8b7c8a107ee.png)

`type="email"` にするとブラウザ側でメールアドレスのバリデーションを行えます。

また環境によってはスクリーンキーボードに `@` や `.` が追加され、UXの向上に繋がります。