### PR TITLE
パブリックタイムラインと検索画面で出るチェックインユーザーの名前をdisplay_nameにする

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -34,7 +34,7 @@
                                 <!-- span -->
                                 <div class="d-flex justify-content-between">
                                     <h5>
-                                        <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> &commat;{{ $ejaculation->user->name }}</a>
+                                        <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> {{ $ejaculation->user->display_name }}</a>
                                         <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
                                     </h5>
                                     <div>

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -10,7 +10,7 @@
                 <!-- span -->
                 <div class="d-flex justify-content-between">
                     <h5>
-                        <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> &commat;{{ $ejaculation->user->name }}</a>
+                        <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> {{ $ejaculation->user->display_name }}</a>
                         <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
                     </h5>
                     <div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3516343/51214329-f1745a80-1960-11e9-9b40-fedddd14e89b.png)

現状ではdisplay_nameは設定できないため同じだが、こちらのほうが好ましいはず。