### PR TITLE
FanzaResolver追加

### DIFF
--- a/app/MetadataResolver/FanzaResolver.php
+++ b/app/MetadataResolver/FanzaResolver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\MetadataResolver;
+
+class FanzaResolver implements Resolver
+{
+    public function resolve(string $url): Metadata
+    {
+        $client = new \GuzzleHttp\Client();
+        $res = $client->get($url);
+        if ($res->getStatusCode() === 200) {
+            $ogpResolver = new OGPResolver();
+            $metadata = $ogpResolver->parse($res->getBody());
+            $metadata->image =  preg_replace("~(pr|ps).jpg$~", "pl.jpg", $metadata->image);
+
+            return $metadata;
+        } else {
+            throw new \RuntimeException("{$res->getStatusCode()}: $url");
+        }
+    }
+}

--- a/app/MetadataResolver/MetadataResolver.php
+++ b/app/MetadataResolver/MetadataResolver.php
@@ -14,6 +14,7 @@ class MetadataResolver implements Resolver
         '~www\.dlsite\.com/.*/work/=/product_id/..\d+\.html~' => DLsiteResolver::class,
         '~www\.pixiv\.net/member_illust\.php\?illust_id=\d+~' => PixivResolver::class,
         '~fantia\.jp/posts/\d+~' => FantiaResolver::class,
+        '~dmm\.co\.jp/~' => FanzaResolver::class,
         '/.*/' => OGPResolver::class
     ];
 


### PR DESCRIPTION
![2019-01-16_23-58-00_chrome](https://user-images.githubusercontent.com/3516343/51257416-eb2ac080-19ea-11e9-9296-311f2b97161c.png)

比較画像

FanzaのOGP画像は `ps.jpg` か `pr.jpg` で終わっている。 `pl.jpg` で高解像度なものが取得できる。
