### PR TITLE
構築手順の最後に.envの読み直しを追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ docker-compose exec web php artisan key:generate
 docker-compose exec web php artisan migrate
 ```
 
+6. 最後に `.env` を読み込み直すために起動し直します。
+
+```
+docker-compose up -d
+```
+
 これで準備は完了です。Tissue が動いていれば `http://localhost:4545/` でアクセスができます。
 
 ## 環境構築上の諸注意


### PR DESCRIPTION
`artisan key:generate` で作成したキーを読むために必要です。