### PR TITLE
正規化対象のURLにクエリパラメータとURLフラグメントが両方とも含まれる場合、正規化時に順序が崩れて不正なURLになってしまうバグの修正

### DIFF
--- a/app/Utilities/Formatter.php
+++ b/app/Utilities/Formatter.php
@@ -52,12 +52,25 @@ class Formatter
         $url = preg_replace('~/#!/~u', '/', $url);
 
         // Sort query parameters
-        $query = parse_url($url, PHP_URL_QUERY);
-        if (!empty($query)) {
-            $url = str_replace_last('?' . $query, '', $url);
-            parse_str($query, $params);
+        $parts = parse_url($url);
+        if (!empty($parts['query'])) {
+            // Remove query parameters
+            $url = str_replace_last('?' . $parts['query'], '', $url);
+            if (!empty($parts['fragment'])) {
+                // Remove fragment identifier
+                $url = str_replace_last('#' . $parts['fragment'], '', $url);
+            } else {
+                // "http://example.com/?query#" の場合 $parts['fragment'] は unset になるので、個別に判定して除去する必要がある
+                $url = preg_replace('/#\z/u', '', $url);
+            }
+
+            parse_str($parts['query'], $params);
             ksort($params);
+
             $url = $url . '?' . http_build_query($params);
+            if (!empty($parts['fragment'])) {
+                $url .= '#' . $parts['fragment'];
+            }
         }
 
         return $url;

--- a/tests/Unit/Utilities/FormatterTest.php
+++ b/tests/Unit/Utilities/FormatterTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit\Utilities;
+
+use App\Utilities\Formatter;
+use Tests\TestCase;
+
+class FormatterTest extends TestCase
+{
+    public function testNormalizeUrlWithoutQuery()
+    {
+        $formatter = new Formatter();
+
+        $url = 'http://example.com/path/to';
+        $this->assertEquals($url, $formatter->normalizeUrl($url));
+    }
+
+    public function testNormalizeUrlWithSortedQuery()
+    {
+        $formatter = new Formatter();
+
+        $url = 'http://example.com/path/to?foo=bar&hoge=fuga';
+        $this->assertEquals($url, $formatter->normalizeUrl($url));
+    }
+
+    public function testNormalizeUrlWithUnsortedQuery()
+    {
+        $formatter = new Formatter();
+
+        $url = 'http://example.com/path/to?hoge=fuga&foo=bar';
+        $this->assertEquals('http://example.com/path/to?foo=bar&hoge=fuga', $formatter->normalizeUrl($url));
+    }
+
+    public function testNormalizeUrlWithSortedQueryAndFragment()
+    {
+        $formatter = new Formatter();
+
+        $url = 'http://example.com/path/to?foo=bar&hoge=fuga#fragment';
+        $this->assertEquals($url, $formatter->normalizeUrl($url));
+    }
+
+    public function testNormalizeUrlWithFragment()
+    {
+        $formatter = new Formatter();
+
+        $url = 'http://example.com/path/to#fragment';
+        $this->assertEquals($url, $formatter->normalizeUrl($url));
+    }
+
+    public function testNormalizeUrlWithSortedQueryAndZeroLengthFragment()
+    {
+        $formatter = new Formatter();
+
+        $url = 'http://example.com/path/to?foo=bar&hoge=fuga#';
+        $this->assertEquals('http://example.com/path/to?foo=bar&hoge=fuga', $formatter->normalizeUrl($url));
+    }
+}


### PR DESCRIPTION
`http://example.com/?query#fragment` のように、クエリパラメータとURLフラグメントが両方とも含まれるURLを正規化処理にかけた際、`http://example.com/#fragment?query` といったように入れ替わってしまい、不正なURLになっていました。

本PRの変更で、クエリパラメータに対する処理が必要な場合はURLフラグメントが含まれているか確認し、それを考慮してURLを出力するように修正しました。

refs #56 
