### PR TITLE
Shift_JIS, EUC-JPでエンコードされたページのOGP取得対応

### DIFF
--- a/app/MetadataResolver/OGPResolver.php
+++ b/app/MetadataResolver/OGPResolver.php
@@ -18,7 +18,7 @@ class OGPResolver implements Resolver
     public function parse(string $html): Metadata
     {
         $dom = new \DOMDocument();
-        @$dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+        @$dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'ASCII,JIS,UTF-8,eucJP-win,SJIS-win'));
         $xpath = new \DOMXPath($dom);
 
         $metadata = new Metadata();


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/1352154/51440021-62bb6100-1d05-11e9-913d-3e1b834114e6.png)

## After
![image](https://user-images.githubusercontent.com/1352154/51440023-6818ab80-1d05-11e9-8f61-10fa4cf136be.png)

refs #61 
