### PR TITLE
Pixivのmode=mangaに対応

### DIFF
--- a/app/MetadataResolver/PixivResolver.php
+++ b/app/MetadataResolver/PixivResolver.php
@@ -37,7 +37,7 @@ class PixivResolver implements Resolver
 
         // 漫画ページ（ページ数はmanga_bigならあるかも）
         if ($params['mode'] === 'manga_big' || $params['mode'] === 'manga') {
-            $page = isset($params['page']) ? $params['page'] : 0;
+            $page = $params['page'] ?? 0;
 
             // 未ログインでは漫画ページを開けないため、URL を作品ページに変換する
             $url = preg_replace('~mode=manga(_big)?~', 'mode=medium', $url);

--- a/app/MetadataResolver/PixivResolver.php
+++ b/app/MetadataResolver/PixivResolver.php
@@ -73,7 +73,7 @@ class PixivResolver implements Resolver
                 if (strpos($metadata->image, 'pixiv_logo.gif') || strpos($metadata->image, 'pictures.jpg')) {
 
                     // 作品ページの場合のみ対応
-                    if ($params['mode'] == 'medium') {
+                    if ($params['mode'] === 'medium') {
                         preg_match("~https://i\.pximg\.net/c/128x128/img-master/img/\d{4}/\d{2}/\d{2}/\d{2}/\d{2}/\d{2}/{$illustId}(_p0)?_square1200\.jpg~", $res->getBody(), $match);
                         $illustThumbnailUrl = $match[0];
 

--- a/app/MetadataResolver/PixivResolver.php
+++ b/app/MetadataResolver/PixivResolver.php
@@ -36,7 +36,7 @@ class PixivResolver implements Resolver
         $illustId = $params['illust_id'];
 
         // 漫画ページ（ページ数はmanga_bigならあるかも）
-        if ($params['mode'] == 'manga_big' || $params['mode'] == 'manga') {
+        if ($params['mode'] === 'manga_big' || $params['mode'] === 'manga') {
             $page = isset($params['page']) ? $params['page'] : 0;
 
             // 未ログインでは漫画ページを開けないため、URL を作品ページに変換する


### PR DESCRIPTION
fix #76

mode=mangaもログイン必須だったのでmediumではなくmanga_bigに寄せて、どちらの場合でもページ数がなければ最初のページを取得する形にしました。