### PR TITLE
年齢確認の画面で隠されているところのリンクをクリックできないように修正

### DIFF
--- a/public/css/tissue.css
+++ b/public/css/tissue.css
@@ -17,6 +17,7 @@
 
 .tis-need-agecheck .container {
     filter: blur(45px);
+    pointer-events: none;
 }
 
 .container {


### PR DESCRIPTION
わけわからんことになりそうなのでブラーのかかっているところはリンクをクリックできないようにする。