### PR TITLE
新規登録時に、Gravatarの利用についての案内を表示

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -12,6 +12,10 @@
 <div class="container">
     <h2>新規登録</h2>
     <hr>
+    <div class="alert alert-warning">
+        <p class="mb-0"><strong>注意！</strong> Tissueでは、登録に使用したメールアドレスの <a href="https://ja.gravatar.com/" rel="noreferrer">Gravatar</a> を使用します。</p>
+        <p class="mb-0">他の場所での活動と紐付いてほしくない場合、使用予定のメールアドレスにGravatarが設定されていないかを確認することを推奨します。</p>
+    </div>
     <div class="row justify-content-center my-5">
         <div class="col-lg-6">
             <form method="post" action="{{ route('register') }}">


### PR DESCRIPTION
ref #46 

登録メールアドレスに紐付いたGravatarを利用することを明示します。登録をもって同意とすることまで書くべきでしょうか……。

「使用しているメールシステムによってはエイリアス機能が提供されていることがあるので、そちらで回避することもできます」みたいな、回避策には触れませんでした。

![image](https://user-images.githubusercontent.com/1352154/52281949-91426880-29a2-11e9-86ea-7ca8a06aec04.png)
