### PR TITLE
プロフィール設定機能の強化 (自己紹介文, URL)

### DIFF
--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -17,9 +17,13 @@ class SettingController extends Controller
     {
         $inputs = $request->all();
         $validator = Validator::make($inputs, [
-            'display_name' => 'required|string|max:20'
+            'display_name' => 'required|string|max:20',
+            'bio' => 'nullable|string|max:160',
+            'url' => 'nullable|url|max:2000'
         ], [], [
-            'display_name' => '名前'
+            'display_name' => '名前',
+            'bio' => '自己紹介',
+            'url' => 'URL'
         ]);
 
         if ($validator->fails()) {
@@ -28,6 +32,8 @@ class SettingController extends Controller
 
         $user = Auth::user();
         $user->display_name = $inputs['display_name'];
+        $user->bio = $inputs['bio'] ?? '';
+        $user->url = $inputs['url'] ?? '';
         $user->save();
 
         return redirect()->route('setting')->with('status', 'プロフィールを更新しました。');

--- a/app/Http/ViewComposers/ProfileStatsComposer.php
+++ b/app/Http/ViewComposers/ProfileStatsComposer.php
@@ -7,7 +7,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 
-class ProfileComposer
+class ProfileStatsComposer
 {
     public function __construct()
     {

--- a/app/Providers/ViewComposerServiceProvider.php
+++ b/app/Providers/ViewComposerServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace App\Providers;
 
-use App\Http\ViewComposers\ProfileComposer;
+use App\Http\ViewComposers\ProfileStatsComposer;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 
@@ -15,7 +15,7 @@ class ViewComposerServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        View::composer('components.profile', ProfileComposer::class);
+        View::composer('components.profile-stats', ProfileStatsComposer::class);
     }
 
     /**

--- a/database/migrations/2019_02_06_235832_add_bio_and_url_to_users.php
+++ b/database/migrations/2019_02_06_235832_add_bio_and_url_to_users.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddBioAndUrlToUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('bio', 160)->default('');
+            $table->text('url')->default('');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('bio');
+            $table->dropColumn('url');
+        });
+    }
+}

--- a/resources/views/components/profile-stats.blade.php
+++ b/resources/views/components/profile-stats.blade.php
@@ -1,0 +1,15 @@
+<h6 class="font-weight-bold"><span class="oi oi-timer"></span> 現在のセッション</h6>
+@if (isset($currentSession))
+    <p class="card-text mb-0">{{ $currentSession }}経過</p>
+    <p class="card-text">({{ $latestEjaculation->ejaculated_date->format('Y/m/d H:i') }} にリセット)</p>
+@else
+    <p class="card-text mb-0">計測がまだ始まっていません</p>
+    <p class="card-text">(一度チェックインすると始まります)</p>
+@endif
+
+<h6 class="font-weight-bold"><span class="oi oi-graph"></span> 概況</h6>
+<p class="card-text mb-0">平均記録: {{ Formatter::formatInterval($summary[0]->average) }}</p>
+<p class="card-text mb-0">最長記録: {{ Formatter::formatInterval($summary[0]->longest) }}</p>
+<p class="card-text mb-0">最短記録: {{ Formatter::formatInterval($summary[0]->shortest) }}</p>
+<p class="card-text mb-0">合計時間: {{ Formatter::formatInterval($summary[0]->total_times) }}</p>
+<p class="card-text">通算回数: {{ $summary[0]->total_checkins }}回</p>

--- a/resources/views/components/profile.blade.php
+++ b/resources/views/components/profile.blade.php
@@ -1,19 +1,15 @@
 <div class="card mb-4">
     <div class="card-body">
-        <div class="d-flex flex-row align-items-end">
-            <img src="{{ $user->getProfileImageUrl(64) }}" class="rounded mr-2">
-            <div class="d-flex flex-column overflow-hidden">
-                <h4 class="card-title @if (Route::currentRouteName() === 'home') text-truncate @endif">
-                    <a class="text-dark" href="{{ route('user.profile', ['name' => $user->name]) }}">{{ $user->display_name }}</a>
-                </h4>
-                <h6 class="card-subtitle">
-                    <a class="text-muted" href="{{ route('user.profile', ['name' => $user->name]) }}">&commat;{{ $user->name }}</a>
-                    @if ($user->is_protected)
-                        <span class="oi oi-lock-locked text-muted"></span>
-                    @endif
-                </h6>
-            </div>
-        </div>
+        <img src="{{ $user->getProfileImageUrl(128) }}" class="rounded mb-1">
+        <h4 class="card-title">
+            <a class="text-dark" href="{{ route('user.profile', ['name' => $user->name]) }}">{{ $user->display_name }}</a>
+        </h4>
+        <h6 class="card-subtitle">
+            <a class="text-muted" href="{{ route('user.profile', ['name' => $user->name]) }}">&commat;{{ $user->name }}</a>
+            @if ($user->is_protected)
+                <span class="oi oi-lock-locked text-muted"></span>
+            @endif
+        </h6>
 
         {{-- Bio --}}
         @if (!empty($user->bio))
@@ -35,21 +31,8 @@
 @if (!$user->is_protected || $user->isMe())
     <div class="card mb-4">
         <div class="card-body">
-            <h6 class="font-weight-bold"><span class="oi oi-timer"></span> 現在のセッション</h6>
-            @if (isset($currentSession))
-                <p class="card-text mb-0">{{ $currentSession }}経過</p>
-                <p class="card-text">({{ $latestEjaculation->ejaculated_date->format('Y/m/d H:i') }} にリセット)</p>
-            @else
-                <p class="card-text mb-0">計測がまだ始まっていません</p>
-                <p class="card-text">(一度チェックインすると始まります)</p>
-            @endif
-
-            <h6 class="font-weight-bold"><span class="oi oi-graph"></span> 概況</h6>
-            <p class="card-text mb-0">平均記録: {{ Formatter::formatInterval($summary[0]->average) }}</p>
-            <p class="card-text mb-0">最長記録: {{ Formatter::formatInterval($summary[0]->longest) }}</p>
-            <p class="card-text mb-0">最短記録: {{ Formatter::formatInterval($summary[0]->shortest) }}</p>
-            <p class="card-text mb-0">合計時間: {{ Formatter::formatInterval($summary[0]->total_times) }}</p>
-            <p class="card-text">通算回数: {{ $summary[0]->total_checkins }}回</p>
+            @component('components.profile-stats', ['user' => $user])
+            @endcomponent
         </div>
     </div>
 @endif

--- a/resources/views/components/profile.blade.php
+++ b/resources/views/components/profile.blade.php
@@ -15,8 +15,27 @@
             </div>
         </div>
 
-        @if (!$user->is_protected || $user->isMe())
-            <h6 class="font-weight-bold mt-4"><span class="oi oi-timer"></span> 現在のセッション</h6>
+        {{-- Bio --}}
+        @if (!empty($user->bio))
+            <p class="card-text mt-3 mb-0">
+                {!! Formatter::linkify(nl2br(e($user->bio))) !!}
+            </p>
+        @endif
+
+        {{-- URL --}}
+        @if (!empty($user->url))
+            <p class="card-text d-flex mt-3">
+                <span class="oi oi-link-intact mr-1 mt-1"></span>
+                <a href="{{ $user->url }}" rel="me nofollow noopener" target="_blank" class="text-truncate">{{ preg_replace('~\Ahttps?://~', '', $user->url) }}</a>
+            </p>
+        @endif
+    </div>
+</div>
+
+@if (!$user->is_protected || $user->isMe())
+    <div class="card mb-4">
+        <div class="card-body">
+            <h6 class="font-weight-bold"><span class="oi oi-timer"></span> 現在のセッション</h6>
             @if (isset($currentSession))
                 <p class="card-text mb-0">{{ $currentSession }}経過</p>
                 <p class="card-text">({{ $latestEjaculation->ejaculated_date->format('Y/m/d H:i') }} にリセット)</p>
@@ -31,6 +50,6 @@
             <p class="card-text mb-0">最短記録: {{ Formatter::formatInterval($summary[0]->shortest) }}</p>
             <p class="card-text mb-0">合計時間: {{ Formatter::formatInterval($summary[0]->total_times) }}</p>
             <p class="card-text">通算回数: {{ $summary[0]->total_checkins }}回</p>
-        @endif
+        </div>
     </div>
-</div>
+@endif

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -7,8 +7,26 @@
 <div class="container">
     <div class="row">
         <div class="col-lg-4">
-            @component('components.profile', ['user' => Auth::user()])
-            @endcomponent
+            <div class="card mb-4">
+                <div class="card-body">
+                    <div class="d-flex flex-row align-items-end mb-4">
+                        <img src="{{ Auth::user()->getProfileImageUrl(48) }}" class="rounded mr-2">
+                        <div class="d-flex flex-column overflow-hidden">
+                            <h5 class="card-title text-truncate">
+                                <a class="text-dark" href="{{ route('user.profile', ['name' => Auth::user()->name]) }}">{{ Auth::user()->display_name }}</a>
+                            </h5>
+                            <h6 class="card-subtitle">
+                                <a class="text-muted" href="{{ route('user.profile', ['name' => Auth::user()->name]) }}">&commat;{{ Auth::user()->name }}</a>
+                                @if (Auth::user()->is_protected)
+                                    <span class="oi oi-lock-locked text-muted"></span>
+                                @endif
+                            </h6>
+                        </div>
+                    </div>
+                    @component('components.profile-stats', ['user' => Auth::user()])
+                    @endcomponent
+                </div>
+            </div>
         </div>
         <div class="col-lg-8">
             <div class="card mb-4">

--- a/resources/views/setting/profile.blade.php
+++ b/resources/views/setting/profile.blade.php
@@ -16,7 +16,7 @@
                 <div class="invalid-feedback">{{ $errors->first('display_name') }}</div>
             @endif
         </div>
-        <div class="from-group mt-2">
+        <div class="from-group mt-3">
             <label for="name">ユーザー名</label>
             <div class="input-group">
                 <div class="input-group-prepend">
@@ -25,6 +25,24 @@
                 <input id="name" name="name" type="text" class="form-control" value="{{ Auth::user()->name }}" disabled>
             </div>
             <small class="form-text text-muted">現在は変更できません。</small>
+        </div>
+        <div class="form-group mt-3">
+            <label for="bio">自己紹介</label>
+            <textarea id="bio" name="bio" rows="3" class="form-control {{ $errors->has('bio') ? ' is-invalid' : '' }}">{{ old('bio') ?? Auth::user()->bio }}</textarea>
+            <small class="form-text text-muted">最大 160 文字</small>
+
+            @if ($errors->has('bio'))
+                <div class="invalid-feedback">{{ $errors->first('bio') }}</div>
+            @endif
+        </div>
+        <div class="form-group mt-3">
+            <label for="url">URL</label>
+            <input id="url" name="url" type="url" class="form-control {{ $errors->has('url') ? ' is-invalid' : '' }}"
+                   value="{{ old('url') ?? Auth::user()->url }}" autocomplete="off">
+
+            @if ($errors->has('url'))
+                <div class="invalid-feedback">{{ $errors->first('url') }}</div>
+            @endif
         </div>
 
         <button type="submit" class="btn btn-primary mt-4">更新</button>


### PR DESCRIPTION
ユーザーページの情報欄に、自己紹介とURLを書けるようにしました。~~後者はTissueのURLをMastodonに貼って認証済みにしたかっただけです。~~

また、この機能追加の影響で情報欄の内容量が増えてきたため、ユーザーページとホームのユーザ情報レイアウトを別のものにしました。  
セッション・概況部分を `components.profile` から分割して、各レイアウトから参照する風にしています。

![](https://g.gravizo.com/svg?digraph%20G%20%7B%0A%20%20%22home%22%20-%3E%20%22components.profile-stats%22%3B%0A%20%20%22user.base%22%20-%3E%20%22components.profile%22%20-%3E%20%22components.profile-stats%22%3B%0A%7D)

`components.profile` の名前回りの段組みをリバートしていますが、ホームで表示されるほうには引き続き採用しています。

## スクリーンショット
### ユーザーページ
![image](https://user-images.githubusercontent.com/1352154/52355146-20b84c00-2a75-11e9-884f-62ff700dcb9c.png)

### ホーム
ユーザーページとレイアウトを分けたついでに、前よりコンパクトにしました。

![image](https://user-images.githubusercontent.com/1352154/52354233-67a54200-2a73-11e9-9aa5-f06991906112.png)

