### PR TITLE
ActivityPubResolverを追加

### DIFF
--- a/app/MetadataResolver/ActivityPubResolver.php
+++ b/app/MetadataResolver/ActivityPubResolver.php
@@ -40,7 +40,8 @@ class ActivityPubResolver implements Resolver, Parser
         $metadata = new Metadata();
 
         $metadata->title = isset($object['attributedTo']) ? $this->getTitleFromActor($object['attributedTo']) : '';
-        $metadata->description = isset($object['content']) ? $this->html2text($object['content']) : '';
+        $metadata->description .= isset($object['summary']) ? $object['summary'] . " | " : '';
+        $metadata->description .= isset($object['content']) ? $this->html2text($object['content']) : '';
         $metadata->image = $object['attachment'][0]['url'] ?? '';
 
         return $metadata;

--- a/app/MetadataResolver/ActivityPubResolver.php
+++ b/app/MetadataResolver/ActivityPubResolver.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\MetadataResolver;
+
+use Psr\Http\Message\ResponseInterface;
+
+class ActivityPubResolver implements Resolver, Parser
+{
+    /**
+     * @var \GuzzleHttp\Client
+     */
+    private $activityClient;
+
+    public function __construct()
+    {
+        $this->activityClient = new \GuzzleHttp\Client([
+            'headers' => [
+                'Accept' => 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+            ]
+        ]);
+    }
+
+    public function resolve(string $url): Metadata
+    {
+        $res = $this->activityClient->get($url);
+        if ($res->getStatusCode() === 200) {
+            return $this->parse($res->getBody());
+        } else {
+            throw new \RuntimeException("{$res->getStatusCode()}: $url");
+        }
+    }
+
+    public function parse(string $json): Metadata
+    {
+        $activityOrObject = json_decode($json, true);
+        $object = $activityOrObject['object'] ?? $activityOrObject;
+
+        $metadata = new Metadata();
+
+        $metadata->title = isset($object['attributedTo']) ? $this->getTitleFromActor($object['attributedTo']) : '';
+        $metadata->description = isset($object['content']) ? $this->html2text($object['content']) : '';
+        $metadata->image = $object['attachment'][0]['url'] ?? '';
+
+        return $metadata;
+    }
+
+    private function getTitleFromActor(string $url): string
+    {
+        $res = $this->activityClient->get($url);
+        if ($res->getStatusCode() !== 200) {
+            return '';
+        }
+
+        $actor = json_decode($res->getBody(), true);
+        $title = $actor['name'] ?? '';
+        if (isset($actor['preferredUsername'])) {
+            $title .= ' (@' . $actor['preferredUsername'] . '@' . parse_url($actor['id'], PHP_URL_HOST) . ')';
+        }
+
+        return $title;
+    }
+
+    private function html2text(string $html): string
+    {
+        $html = mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8');
+        $html = preg_replace('~<br\s*/?\s*>|</p>\s*<p[^>]*>~i', "\n", $html);
+        $dom = new \DOMDocument();
+        $dom->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        return $dom->textContent;
+    }
+}

--- a/app/MetadataResolver/MetadataResolver.php
+++ b/app/MetadataResolver/MetadataResolver.php
@@ -58,10 +58,16 @@ class MetadataResolver implements Resolver
     public function resolveWithAcceptHeader(string $url): ?Metadata
     {
         try {
+            // Rails等はAcceptに */* が入っていると、ブラウザの適当なAcceptヘッダだと判断して全部無視してしまう。
+            // c.f. https://github.com/rails/rails/issues/9940
+            // そこでここでは */* を「Acceptヘッダを無視してきたレスポンス（よくある）」のハンドラとして扱い、
+            // Acceptヘッダには */* を足さないことにする。
+            $acceptTypes = array_diff(array_keys($this->mimeTypes), ['*/*']);
+
             $client = new \GuzzleHttp\Client();
             $res = $client->request('GET', $url, [
                 'headers' => [
-                    'Accept' => implode(', ', array_keys($this->mimeTypes))
+                    'Accept' => implode(', ', $acceptTypes)
                 ]
             ]);
 

--- a/app/MetadataResolver/OGPResolver.php
+++ b/app/MetadataResolver/OGPResolver.php
@@ -2,7 +2,7 @@
 
 namespace App\MetadataResolver;
 
-class OGPResolver implements Resolver
+class OGPResolver implements Resolver, Parser
 {
     public function resolve(string $url): Metadata
     {

--- a/app/MetadataResolver/Parser.php
+++ b/app/MetadataResolver/Parser.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\MetadataResolver;
+
+interface Parser
+{
+    public function parse(string $body): Metadata;
+}


### PR DESCRIPTION
要するにMastodon対応です。Mastodonのog風のメタデータをActivityPubのNoteとActorから自力で構築しています。

![image](https://user-images.githubusercontent.com/705555/52500392-34081a80-2c21-11e9-97a4-500fa6cdcd36.png)

MetadataResolverはこれまでURLとの正規表現マッチでResolverを選択するのみでしたが、今回ActivityPub対応のため「対応形式をAcceptに突っこんでGETした時のContent-Type」を見て分岐するロジックを新たに追加しました。元々は単にActivityPubResolverからOGPResolverにフォールバックしようかと考えていたんですが、その依存もなんだかなあと思ったのでこうなりました。

今後の展開としては画像直リンとかにも使えるんじゃないですかね（？）

optional:

* 画像以外の添付（動画とか）は蹴る
* メディアがなければ著者近影にフォールバックする
* CWもdescriptionに取り込む
* テストを書く