### PR TITLE
重すぎるので xdebug.remote_autostart の利用を廃止

### DIFF
--- a/dist/php.d/99-xdebug.ini
+++ b/dist/php.d/99-xdebug.ini
@@ -1,5 +1,4 @@
 ; Dockerでのデバッグ用設定
 zend_extension=xdebug.so
 xdebug.remote_enable=true
-xdebug.remote_autostart=true
 xdebug.remote_host=host.docker.internal


### PR DESCRIPTION
`xdebug.remote_autostart` を有効にすると、ブラウザでの特別な操作の必要なくデバッガーを立ち上げられて便利。

しかし、デバッガーを使う必要のない時まで接続待ちをしてしまって、アプリケーションコードが走るまでの時間が長びいてしまう。これはやる気を削ぐ理由になるので、設定を削除する。

この設定を使わずにデバッガーを起動したい場合、 `XDEBUG_SESSION` というキーでCookieをセットすれば起動できる。これは[拡張機能](https://www.jetbrains.com/help/phpstorm/browser-debugging-extensions.html)や[ブックマークレット](https://www.jetbrains.com/phpstorm/marklets/)で簡単にセットできるので、こちらを利用すると楽。