### PR TITLE
ホーム画面の微リニューアル

### DIFF
--- a/public/css/tissue.css
+++ b/public/css/tissue.css
@@ -24,6 +24,16 @@
     transition: filter .15s liner;
 }
 
+.list-group-item.no-side-border {
+    border-left: none;
+    border-right: none;
+    border-radius: 0;
+}
+
+.list-group-item.border-bottom-only:first-child {
+    border-top: none;
+}
+
 .list-group-item.border-bottom-only {
     border-left: none;
     border-right: none;

--- a/public/css/tissue.css
+++ b/public/css/tissue.css
@@ -37,3 +37,9 @@
 .timeline-action-item {
     margin-left: 16px;
 }
+
+@media (min-width: 992px) {
+    .tis-sidebar-info {
+        font-size: small;
+    }
+}

--- a/public/css/tissue.css
+++ b/public/css/tissue.css
@@ -48,6 +48,11 @@
     margin-left: 16px;
 }
 
+.tis-global-count-graph {
+    height: 90px;
+    border-bottom: 1px solid rgba(0, 0, 0, .125);
+}
+
 @media (min-width: 992px) {
     .tis-sidebar-info {
         font-size: small;

--- a/public/js/tissue.js
+++ b/public/js/tissue.js
@@ -1,0 +1,49 @@
+// app.jsの名はモジュールバンドラーを投入する日まで予約しておく。CSSも同じ。
+
+(function ($) {
+
+    $.fn.linkCard = function (options) {
+        var settings = $.extend({
+            endpoint: '/api/checkin/card'
+        }, options);
+
+        return this.each(function () {
+            var $this = $(this);
+            $.ajax({
+                url: settings.endpoint,
+                method: 'get',
+                type: 'json',
+                data: {
+                    url: $this.find('a').attr('href')
+                }
+            }).then(function (data) {
+                var $title = $this.find('.card-title');
+                var $desc = $this.find('.card-text');
+                var $image = $this.find('img');
+
+                if (data.title === '') {
+                    $title.hide();
+                } else {
+                    $title.text(data.title);
+                }
+
+                if (data.description === '') {
+                    $desc.hide();
+                } else {
+                    $desc.text(data.description);
+                }
+
+                if (data.image === '') {
+                    $image.hide();
+                } else {
+                    $image.attr('src', data.image);
+                }
+
+                if (data.title !== '' || data.description !== '' || data.image !== '') {
+                    $this.removeClass('d-none');
+                }
+            });
+        });
+    };
+
+})(jQuery);

--- a/resources/views/ejaculation/show.blade.php
+++ b/resources/views/ejaculation/show.blade.php
@@ -112,42 +112,8 @@
             form.submit();
         });
 
-        $('.link-card').each(function () {
-            var $this = $(this);
-            $.ajax({
-                url: '{{ url('/api/checkin/card') }}',
-                method: 'get',
-                type: 'json',
-                data: {
-                    url: $this.find('a').attr('href')
-                }
-            }).then(function (data) {
-                var $title = $this.find('.card-title');
-                var $desc = $this.find('.card-text');
-                var $image = $this.find('img');
-
-                if (data.title === '') {
-                    $title.hide();
-                } else {
-                    $title.text(data.title);
-                }
-
-                if (data.description === '') {
-                    $desc.hide();
-                } else {
-                    $desc.text(data.description);
-                }
-
-                if (data.image === '') {
-                    $image.hide();
-                } else {
-                    $image.attr('src', data.image);
-                }
-
-                if (data.title !== '' || data.description !== '' || data.image !== '') {
-                    $this.removeClass('d-none');
-                }
-            });
+        $('.link-card').linkCard({
+            endpoint: '{{ url('/api/checkin/card') }}'
         });
     </script>
 @endpush

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -44,59 +44,55 @@
         </div>
         <div class="col-lg-8">
             @if (!empty($publicLinkedEjaculations))
-                <div class="card mb-4">
-                    <div class="card-header">お惣菜コーナー</div>
-                    <div class="card-body">
-                        <p class="card-text">最近の公開チェックインから、オカズリンク付きのものを表示しています。</p>
-                    </div>
-                    <ul class="list-group list-group-flush">
-                        @foreach ($publicLinkedEjaculations as $ejaculation)
-                            <li class="list-group-item pt-3 pb-3">
-                                <!-- span -->
-                                <div class="d-flex justify-content-between">
-                                    <h5>
-                                        <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> {{ $ejaculation->user->display_name }}</a>
-                                        <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
-                                    </h5>
-                                    <div>
-                                        <a class="text-secondary timeline-action-item" href="{{ route('checkin', ['link' => $ejaculation->link, 'tags' => $ejaculation->textTags()]) }}"><span class="oi oi-reload" data-toggle="tooltip" data-placement="bottom" title="同じオカズでチェックイン"></span></a>
-                                    </div>
+                <h5 class="mb-3">お惣菜コーナー</h5>
+                <p class="text-secondary">最近の公開チェックインから、オカズリンク付きのものを表示しています。</p>
+                <ul class="list-group">
+                    @foreach ($publicLinkedEjaculations as $ejaculation)
+                        <li class="list-group-item no-side-border pt-3 pb-3 tis-word-wrap">
+                            <!-- span -->
+                            <div class="d-flex justify-content-between">
+                                <h5>
+                                    <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> {{ $ejaculation->user->display_name }}</a>
+                                    <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
+                                </h5>
+                                <div>
+                                    <a class="text-secondary timeline-action-item" href="{{ route('checkin', ['link' => $ejaculation->link, 'tags' => $ejaculation->textTags()]) }}"><span class="oi oi-reload" data-toggle="tooltip" data-placement="bottom" title="同じオカズでチェックイン"></span></a>
                                 </div>
-                                <!-- tags -->
-                                @if ($ejaculation->tags->isNotEmpty())
-                                    <p class="mb-2">
-                                        @foreach ($ejaculation->tags as $tag)
-                                            <a class="badge badge-secondary" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag"></span> {{ $tag->name }}</a>
-                                        @endforeach
-                                    </p>
-                                @endif
-                                <!-- okazu link -->
-                                @if (!empty($ejaculation->link))
-                                    <div class="row mx-0">
-                                        <div class="card link-card mb-2 px-0 col-12 col-md-6 d-none" style="font-size: small;">
-                                            <a class="text-dark card-link" href="{{ $ejaculation->link }}" target="_blank" rel="noopener">
-                                                <img src="" alt="Thumbnail" class="card-img-top bg-secondary">
-                                                <div class="card-body">
-                                                    <h6 class="card-title font-weight-bold">タイトル</h6>
-                                                    <p class="card-text">コンテンツの説明文</p>
-                                                </div>
-                                            </a>
-                                        </div>
-                                        <p class="d-flex align-items-baseline mb-2 col-12 px-0">
-                                            <span class="oi oi-link-intact mr-1"></span><a class="overflow-hidden" href="{{ $ejaculation->link }}" target="_blank" rel="noopener">{{ $ejaculation->link }}</a>
-                                        </p>
+                            </div>
+                            <!-- tags -->
+                            @if ($ejaculation->tags->isNotEmpty())
+                                <p class="mb-2">
+                                    @foreach ($ejaculation->tags as $tag)
+                                        <a class="badge badge-secondary" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag"></span> {{ $tag->name }}</a>
+                                    @endforeach
+                                </p>
+                            @endif
+                            <!-- okazu link -->
+                            @if (!empty($ejaculation->link))
+                                <div class="row mx-0">
+                                    <div class="card link-card mb-2 px-0 col-12 col-md-6 d-none" style="font-size: small;">
+                                        <a class="text-dark card-link" href="{{ $ejaculation->link }}" target="_blank" rel="noopener">
+                                            <img src="" alt="Thumbnail" class="card-img-top bg-secondary">
+                                            <div class="card-body">
+                                                <h6 class="card-title font-weight-bold">タイトル</h6>
+                                                <p class="card-text">コンテンツの説明文</p>
+                                            </div>
+                                        </a>
                                     </div>
-                                @endif
-                                <!-- note -->
-                                @if (!empty($ejaculation->note))
-                                    <p class="mb-0 tis-word-wrap">
-                                        {!! Formatter::linkify(nl2br(e($ejaculation->note))) !!}
+                                    <p class="d-flex align-items-baseline mb-2 col-12 px-0">
+                                        <span class="oi oi-link-intact mr-1"></span><a class="overflow-hidden" href="{{ $ejaculation->link }}" target="_blank" rel="noopener">{{ $ejaculation->link }}</a>
                                     </p>
-                                @endif
-                            </li>
-                        @endforeach
-                    </ul>
-                </div>
+                                </div>
+                            @endif
+                            <!-- note -->
+                            @if (!empty($ejaculation->note))
+                                <p class="mb-0 tis-word-wrap">
+                                    {!! Formatter::linkify(nl2br(e($ejaculation->note))) !!}
+                                </p>
+                            @endif
+                        </li>
+                    @endforeach
+                </ul>
             @endif
         </div>
     </div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -108,42 +108,8 @@
 @push('script')
     <script type="text/javascript" src="//cdn.jsdelivr.net/npm/chart.js@2.7.1/dist/Chart.min.js"></script>
     <script>
-        $('.link-card').each(function () {
-            var $this = $(this);
-            $.ajax({
-                url: '{{ url('/api/checkin/card') }}',
-                method: 'get',
-                type: 'json',
-                data: {
-                    url: $this.find('a').attr('href')
-                }
-            }).then(function (data) {
-                var $title = $this.find('.card-title');
-                var $desc = $this.find('.card-text');
-                var $image = $this.find('img');
-
-                if (data.title === '') {
-                    $title.hide();
-                } else {
-                    $title.text(data.title);
-                }
-
-                if (data.description === '') {
-                    $desc.hide();
-                } else {
-                    $desc.text(data.description);
-                }
-
-                if (data.image === '') {
-                    $image.hide();
-                } else {
-                    $image.attr('src', data.image);
-                }
-
-                if (data.title !== '' || data.description !== '' || data.image !== '') {
-                    $this.removeClass('d-none');
-                }
-            });
+        $('.link-card').linkCard({
+            endpoint: '{{ url('/api/checkin/card') }}'
         });
 
         new Chart(document.getElementById('global-count-graph').getContext('2d'), {

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -146,40 +146,37 @@
             });
         });
 
-        (function () {
-            var context = document.getElementById('global-count-graph').getContext('2d');
-            var chart = new Chart(context, {
-                type: 'bar',
-                data: {
-                    labels: @json(array_keys($globalEjaculationCounts)),
-                    datasets: [{
-                        data: @json(array_values($globalEjaculationCounts)),
-                        backgroundColor: 'rgba(0, 0, 0, .1)',
-                        borderColor: 'rgba(0, 0, 0, .25)',
-                        borderWidth: 1
-                    }]
+        new Chart(document.getElementById('global-count-graph').getContext('2d'), {
+            type: 'bar',
+            data: {
+                labels: @json(array_keys($globalEjaculationCounts)),
+                datasets: [{
+                    data: @json(array_values($globalEjaculationCounts)),
+                    backgroundColor: 'rgba(0, 0, 0, .1)',
+                    borderColor: 'rgba(0, 0, 0, .25)',
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                maintainAspectRatio: false,
+                legend: {
+                    display: false
                 },
-                options: {
-                    maintainAspectRatio: false,
-                    legend: {
+                elements: {
+                    line: {}
+                },
+                scales: {
+                    xAxes: [{
                         display: false
-                    },
-                    elements: {
-                        line: {}
-                    },
-                    scales: {
-                        xAxes: [{
-                            display: false
-                        }],
-                        yAxes: [{
-                            display: false,
-                            ticks: {
-                                beginAtZero: true
-                            }
-                        }]
-                    }
+                    }],
+                    yAxes: [{
+                        display: false,
+                        ticks: {
+                            beginAtZero: true
+                        }
+                    }]
                 }
-            });
-        }());
+            }
+        });
     </script>
 @endpush

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -43,6 +43,12 @@
             </div>
         </div>
         <div class="col-lg-8">
+            @if (!empty($globalEjaculationCounts))
+                <h5>チェックインの動向</h5>
+                <div class="w-100 mb-3 position-relative" style="height: 70px;">
+                    <canvas id="global-count-graph"></canvas>
+                </div>
+            @endif
             @if (!empty($publicLinkedEjaculations))
                 <h5 class="mb-3">お惣菜コーナー</h5>
                 <p class="text-secondary">最近の公開チェックインから、オカズリンク付きのものを表示しています。</p>
@@ -100,6 +106,7 @@
 @endsection
 
 @push('script')
+    <script type="text/javascript" src="//cdn.jsdelivr.net/npm/chart.js@2.7.1/dist/Chart.min.js"></script>
     <script>
         $('.link-card').each(function () {
             var $this = $(this);
@@ -138,5 +145,41 @@
                 }
             });
         });
+
+        (function () {
+            var context = document.getElementById('global-count-graph').getContext('2d');
+            var chart = new Chart(context, {
+                type: 'bar',
+                data: {
+                    labels: @json(array_keys($globalEjaculationCounts)),
+                    datasets: [{
+                        data: @json(array_values($globalEjaculationCounts)),
+                        backgroundColor: 'rgba(0, 0, 0, .1)',
+                        borderColor: 'rgba(0, 0, 0, .25)',
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    maintainAspectRatio: false,
+                    legend: {
+                        display: false
+                    },
+                    elements: {
+                        line: {}
+                    },
+                    scales: {
+                        xAxes: [{
+                            display: false
+                        }],
+                        yAxes: [{
+                            display: false,
+                            ticks: {
+                                beginAtZero: true
+                            }
+                        }]
+                    }
+                }
+            });
+        }());
     </script>
 @endpush

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -27,22 +27,22 @@
                     @endcomponent
                 </div>
             </div>
-        </div>
-        <div class="col-lg-8">
             <div class="card mb-4">
                 <div class="card-header">サイトからのお知らせ</div>
-                <div class="list-group list-group-flush">
+                <div class="list-group list-group-flush tis-sidebar-info">
                     @foreach($informations as $info)
                         <a class="list-group-item" href="{{ route('info.show', ['id' => $info->id]) }}">
-                        @if ($info->pinned)
-                            <span class="badge badge-secondary"><span class="oi oi-pin"></span>ピン留め</span>
-                        @endif
+                            @if ($info->pinned)
+                                <span class="badge badge-secondary"><span class="oi oi-pin"></span>ピン留め</span>
+                            @endif
                             <span class="badge {{ $categories[$info->category]['class'] }}">{{ $categories[$info->category]['label'] }}</span> {{ $info->title }} <small class="text-secondary">- {{ $info->created_at->format('n月j日') }}</small>
                         </a>
                     @endforeach
                     <a href="{{ route('info') }}" class="list-group-item text-right">お知らせ一覧 &raquo;</a>
                 </div>
             </div>
+        </div>
+        <div class="col-lg-8">
             @if (!empty($publicLinkedEjaculations))
                 <div class="card mb-4">
                     <div class="card-header">お惣菜コーナー</div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -45,7 +45,7 @@
         <div class="col-lg-8">
             @if (!empty($globalEjaculationCounts))
                 <h5>チェックインの動向</h5>
-                <div class="w-100 mb-3 position-relative" style="height: 70px;">
+                <div class="w-100 mb-4 position-relative tis-global-count-graph">
                     <canvas id="global-count-graph"></canvas>
                 </div>
             @endif

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -134,6 +134,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.2.0/js.cookie.js"></script>
 <script type="text/javascript" src="{{ asset('js/bootstrap.min.js') }}"></script>
+<script type="text/javascript" src="{{ asset('js/tissue.js') }}"></script>
 <script>
     $(function(){
         @guest

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -80,42 +80,8 @@
 
 @push('script')
     <script>
-        $('.link-card').each(function () {
-            var $this = $(this);
-            $.ajax({
-                url: '{{ url('/api/checkin/card') }}',
-                method: 'get',
-                type: 'json',
-                data: {
-                    url: $this.find('a').attr('href')
-                }
-            }).then(function (data) {
-                var $title = $this.find('.card-title');
-                var $desc = $this.find('.card-text');
-                var $image = $this.find('img');
-
-                if (data.title === '') {
-                    $title.hide();
-                } else {
-                    $title.text(data.title);
-                }
-
-                if (data.description === '') {
-                    $desc.hide();
-                } else {
-                    $desc.text(data.description);
-                }
-
-                if (data.image === '') {
-                    $image.hide();
-                } else {
-                    $image.attr('src', data.image);
-                }
-
-                if (data.title !== '' || data.description !== '' || data.image !== '') {
-                    $this.removeClass('d-none');
-                }
-            });
+        $('.link-card').linkCard({
+            endpoint: '{{ url('/api/checkin/card') }}'
         });
     </script>
 @endpush

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -136,42 +136,8 @@
             form.submit();
         });
 
-        $('.link-card').each(function () {
-            var $this = $(this);
-            $.ajax({
-                url: '{{ url('/api/checkin/card') }}',
-                method: 'get',
-                type: 'json',
-                data: {
-                    url: $this.find('a').attr('href')
-                }
-            }).then(function (data) {
-                var $title = $this.find('.card-title');
-                var $desc = $this.find('.card-text');
-                var $image = $this.find('img');
-
-                if (data.title === '') {
-                    $title.hide();
-                } else {
-                    $title.text(data.title);
-                }
-
-                if (data.description === '') {
-                    $desc.hide();
-                } else {
-                    $desc.text(data.description);
-                }
-
-                if (data.image === '') {
-                    $image.hide();
-                } else {
-                    $image.attr('src', data.image);
-                }
-
-                if (data.title !== '' || data.description !== '' || data.image !== '') {
-                    $this.removeClass('d-none');
-                }
-            });
+        $('.link-card').linkCard({
+            endpoint: '{{ url('/api/checkin/card') }}'
         });
     </script>
 @endpush


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1352154/52534588-d7bf0b00-2d86-11e9-958a-ff24c16543b5.png)

## 変更点
* (PCのみ) お知らせ欄を小さい方のカラムに移動。お惣菜の領域を稼いだ。
* サーバ内全体の日々のチェックイン数を集計して表示。致し日和なのかが可視化される。
* お惣菜コーナーから大枠を削除。ユーザープロフィール画面と見た目を合わせた。
* ついでにカード表示処理を共通化して、インラインJSを減らした。