### PR TITLE
pixivのOGP画像で常にプロキシURLを使用する

### DIFF
--- a/app/MetadataResolver/PixivResolver.php
+++ b/app/MetadataResolver/PixivResolver.php
@@ -8,6 +8,7 @@ class PixivResolver implements Resolver
      * サムネイル画像 URL から最大長辺 1200px の画像 URL に変換する
      *
      * @param string $thumbnailUrl サムネイル画像 URL
+     *
      * @return string 1200px の画像 URL
      */
     public function thumbnailToMasterUrl(string $thumbnailUrl): string
@@ -23,6 +24,7 @@ class PixivResolver implements Resolver
      * HUGE THANKS TO PIXIV.CAT!
      *
      * @param string $pixivUrl i.pximg URL
+     *
      * @return string i.pixiv.cat URL
      */
     public function proxize(string $pixivUrl): string
@@ -54,7 +56,7 @@ class PixivResolver implements Resolver
 
             $illustUrl = $this->thumbnailToMasterUrl($illustThumbnailUrl);
 
-            $metadata->image =  $this->proxize($illustUrl);
+            $metadata->image = $this->proxize($illustUrl);
 
             return $metadata;
         } else {

--- a/app/MetadataResolver/PixivResolver.php
+++ b/app/MetadataResolver/PixivResolver.php
@@ -41,52 +41,24 @@ class PixivResolver implements Resolver
 
             // 未ログインでは漫画ページを開けないため、URL を作品ページに変換する
             $url = preg_replace('~mode=manga(_big)?~', 'mode=medium', $url);
+        }
 
-            $client = new \GuzzleHttp\Client();
-            $res = $client->get($url);
-            if ($res->getStatusCode() === 200) {
-                $ogpResolver = new OGPResolver();
-                $metadata = $ogpResolver->parse($res->getBody());
+        $client = new \GuzzleHttp\Client();
+        $res = $client->get($url);
+        if ($res->getStatusCode() === 200) {
+            $ogpResolver = new OGPResolver();
+            $metadata = $ogpResolver->parse($res->getBody());
 
-                preg_match("~https://i\.pximg\.net/c/128x128/img-master/img/\d{4}/\d{2}/\d{2}/\d{2}/\d{2}/\d{2}/{$illustId}_p0_square1200\.jpg~", $res->getBody(), $match);
-                $illustThumbnailUrl = $match[0];
+            preg_match("~https://i\.pximg\.net/c/128x128/img-master/img/\d{4}/\d{2}/\d{2}/\d{2}/\d{2}/\d{2}/{$illustId}(_p0)?_square1200\.jpg~", $res->getBody(), $match);
+            $illustThumbnailUrl = $match[0];
 
-                $illustUrl = $this->thumbnailToMasterUrl($illustThumbnailUrl);
+            $illustUrl = $this->thumbnailToMasterUrl($illustThumbnailUrl);
 
-                // 指定ページに変換
-                $illustUrl = str_replace('p0_master', "p{$page}_master", $illustUrl);
+            $metadata->image =  $this->proxize($illustUrl);
 
-                $metadata->image =  $this->proxize($illustUrl);
-
-                return $metadata;
-            } else {
-                throw new \RuntimeException("{$res->getStatusCode()}: $url");
-            }
+            return $metadata;
         } else {
-            $client = new \GuzzleHttp\Client();
-            $res = $client->get($url);
-            if ($res->getStatusCode() === 200) {
-                $ogpResolver = new OGPResolver();
-                $metadata = $ogpResolver->parse($res->getBody());
-
-                // OGP がデフォルト画像であるようならなんとかして画像を取得する
-                if (strpos($metadata->image, 'pixiv_logo.gif') || strpos($metadata->image, 'pictures.jpg')) {
-
-                    // 作品ページの場合のみ対応
-                    if ($params['mode'] === 'medium') {
-                        preg_match("~https://i\.pximg\.net/c/128x128/img-master/img/\d{4}/\d{2}/\d{2}/\d{2}/\d{2}/\d{2}/{$illustId}(_p0)?_square1200\.jpg~", $res->getBody(), $match);
-                        $illustThumbnailUrl = $match[0];
-
-                        $illustUrl = $this->thumbnailToMasterUrl($illustThumbnailUrl);
-
-                        $metadata->image =  $this->proxize($illustUrl);
-                    }
-                }
-
-                return $metadata;
-            } else {
-                throw new \RuntimeException("{$res->getStatusCode()}: $url");
-            }
+            throw new \RuntimeException("{$res->getStatusCode()}: $url");
         }
     }
 }


### PR DESCRIPTION
PixivのOGPに指定されている `embed.pixiv.net` はIDやタイトルも表示されていて有用でしたが、それらは表示されなくなったうえ、画像の一部しか見えないようになってしまいました。
このPRでは `embed.pixiv.net` を使用しないで、すべての作品（全年齢/R-18/漫画）でプロキシURLを使用するようにします。

ついでに正規表現の置き換えの重複箇所がなくなりシンプルになります。