### PR TITLE
ページャーの改善

### DIFF
--- a/public/css/tissue.css
+++ b/public/css/tissue.css
@@ -53,6 +53,13 @@
     border-bottom: 1px solid rgba(0, 0, 0, .125);
 }
 
+.tis-page-selector {
+    margin-left: -1px;
+    width: calc(100% + 2px);
+    border: 1px solid #dee2e6;
+    border-radius: 0;
+}
+
 @media (min-width: 992px) {
     .tis-sidebar-info {
         font-size: small;

--- a/public/css/tissue.css
+++ b/public/css/tissue.css
@@ -56,8 +56,10 @@
 .tis-page-selector {
     margin-left: -1px;
     width: calc(100% + 2px);
+    height: 100%;
     border: 1px solid #dee2e6;
     border-radius: 0;
+    line-height: 1.25;
 }
 
 @media (min-width: 992px) {

--- a/public/js/tissue.js
+++ b/public/js/tissue.js
@@ -46,4 +46,10 @@
         });
     };
 
+    $.fn.pageSelector = function () {
+        return this.on('change', function () {
+            location.href = $(this).find(':selected').data('href');
+        });
+    };
+
 })(jQuery);

--- a/resources/views/info/index.blade.php
+++ b/resources/views/info/index.blade.php
@@ -16,22 +16,6 @@
         </a>
         @endforeach
     </div>
-    <ul class="pagination mt-4 justify-content-center">
-        <li class="page-item {{ $informations->currentPage() === 1 ? 'disabled' : '' }}">
-            <a class="page-link" href="{{ $informations->previousPageUrl() }}" aria-label="Previous">
-                <span aria-hidden="true">&laquo;</span>
-                <span class="sr-only">Previous</span>
-            </a>
-        </li>
-        @for ($i = 1; $i <= $informations->lastPage(); $i++)
-            <li class="page-item {{ $i === $informations->currentPage() ? 'active' : '' }}"><a href="{{ $informations->url($i) }}" class="page-link">{{ $i }}</a></li>
-        @endfor
-        <li class="page-item {{ $informations->currentPage() === $informations->lastPage() ? 'disabled' : '' }}">
-            <a class="page-link" href="{{ $informations->nextPageUrl() }}" aria-label="Next">
-                <span aria-hidden="true">&raquo;</span>
-                <span class="sr-only">Next</span>
-            </a>
-        </li>
-    </ul>
+    {{ $informations->links(null, ['className' => 'mt-4 justify-content-center']) }}
 </div>
 @endsection

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -160,6 +160,7 @@
         @endguest
         $('[data-toggle="tooltip"]').tooltip();
         $('.alert').alert();
+        $('.tis-page-selector').pageSelector();
         @if (session('status'))
         setTimeout(function () {
             $('#status').alert('close');

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -58,23 +58,7 @@
             </li>
         @endforeach
         </ul>
-        <ul class="pagination mt-4 justify-content-center">
-            <li class="page-item {{ $results->currentPage() === 1 ? 'disabled' : '' }}">
-                <a class="page-link" href="{{ $results->previousPageUrl() }}" aria-label="Previous">
-                    <span aria-hidden="true">&laquo;</span>
-                    <span class="sr-only">Previous</span>
-                </a>
-            </li>
-            @for ($i = 1; $i <= $results->lastPage(); $i++)
-                <li class="page-item {{ $i === $results->currentPage() ? 'active' : '' }}"><a href="{{ $results->url($i) }}" class="page-link">{{ $i }}</a></li>
-            @endfor
-            <li class="page-item {{ $results->currentPage() === $results->lastPage() ? 'disabled' : '' }}">
-                <a class="page-link" href="{{ $results->nextPageUrl() }}" aria-label="Next">
-                    <span aria-hidden="true">&raquo;</span>
-                    <span class="sr-only">Next</span>
-                </a>
-            </li>
-        </ul>
+        {{ $results->links(null, ['className' => 'mt-4 justify-content-center']) }}
     @endif
 @endsection
 

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -87,23 +87,7 @@
             </li>
         @endforelse
     </ul>
-    <ul class="pagination mt-4 justify-content-center">
-        <li class="page-item {{ $ejaculations->currentPage() === 1 ? 'disabled' : '' }}">
-            <a class="page-link" href="{{ $ejaculations->previousPageUrl() }}" aria-label="Previous">
-                <span aria-hidden="true">&laquo;</span>
-                <span class="sr-only">Previous</span>
-            </a>
-        </li>
-        @for ($i = 1; $i <= $ejaculations->lastPage(); $i++)
-            <li class="page-item {{ $i === $ejaculations->currentPage() ? 'active' : '' }}"><a href="{{ $ejaculations->url($i) }}" class="page-link">{{ $i }}</a></li>
-        @endfor
-        <li class="page-item {{ $ejaculations->currentPage() === $ejaculations->lastPage() ? 'disabled' : '' }}">
-            <a class="page-link" href="{{ $ejaculations->nextPageUrl() }}" aria-label="Next">
-                <span aria-hidden="true">&raquo;</span>
-                <span class="sr-only">Next</span>
-            </a>
-        </li>
-    </ul>
+    {{ $ejaculations->links(null, ['className' => 'mt-4 justify-content-center']) }}
 @endif
 
 @component('components.modal', ['id' => 'deleteCheckinModal'])

--- a/resources/views/vendor/pagination/default.blade.php
+++ b/resources/views/vendor/pagination/default.blade.php
@@ -1,0 +1,36 @@
+@if ($paginator->hasPages())
+    <ul class="pagination">
+        {{-- Previous Page Link --}}
+        @if ($paginator->onFirstPage())
+            <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+        @else
+            <li class="page-item"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
+        @endif
+
+        {{-- Pagination Elements --}}
+        @foreach ($elements as $element)
+            {{-- "Three Dots" Separator --}}
+            @if (is_string($element))
+                <li class="page-item disabled"><span class="page-link">{{ $element }}</span></li>
+            @endif
+
+            {{-- Array Of Links --}}
+            @if (is_array($element))
+                @foreach ($element as $page => $url)
+                    @if ($page == $paginator->currentPage())
+                        <li class="page-item active"><span class="page-link">{{ $page }}</span></li>
+                    @else
+                        <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                    @endif
+                @endforeach
+            @endif
+        @endforeach
+
+        {{-- Next Page Link --}}
+        @if ($paginator->hasMorePages())
+            <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
+        @else
+            <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+        @endif
+    </ul>
+@endif

--- a/resources/views/vendor/pagination/default.blade.php
+++ b/resources/views/vendor/pagination/default.blade.php
@@ -48,6 +48,7 @@
                     <option value="{{ $i }}" {{ $i === $paginator->currentPage() ? 'selected' : '' }} data-href="{{ $paginator->url($i) }}">{{ $i }}</option>
                 @endfor
             </select>
+            <small class="text-muted">/ {{ $paginator->lastPage() }}</small>
         </li>
 
         @if ($paginator->hasMorePages())

--- a/resources/views/vendor/pagination/default.blade.php
+++ b/resources/views/vendor/pagination/default.blade.php
@@ -1,5 +1,6 @@
 @if ($paginator->hasPages())
-    <ul class="pagination">
+    {{-- for PC : >= lg --}}
+    <ul class="pagination d-none d-lg-flex {{ $className ?? '' }}">
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
             <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
@@ -31,6 +32,22 @@
             <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
         @else
             <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+        @endif
+    </ul>
+    {{-- for Phone : <= md --}}
+    <ul class="pagination d-flex d-lg-none {{ $className ?? '' }}">
+        @if ($paginator->onFirstPage())
+            <li class="page-item w-25 text-center disabled"><span class="page-link">&laquo;</span></li>
+        @else
+            <li class="page-item w-25 text-center"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
+        @endif
+
+        <li class="page-item w-25 text-center"><span class="page-link">{{ $paginator->currentPage() }}</span></li>
+
+        @if ($paginator->hasMorePages())
+            <li class="page-item w-25 text-center"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
+        @else
+            <li class="page-item w-25 text-center disabled"><span class="page-link">&raquo;</span></li>
         @endif
     </ul>
 @endif

--- a/resources/views/vendor/pagination/default.blade.php
+++ b/resources/views/vendor/pagination/default.blade.php
@@ -48,7 +48,6 @@
                     <option value="{{ $i }}" {{ $i === $paginator->currentPage() ? 'selected' : '' }} data-href="{{ $paginator->url($i) }}">{{ $i }}</option>
                 @endfor
             </select>
-            <small class="text-muted">/ {{ $paginator->lastPage() }}</small>
         </li>
 
         @if ($paginator->hasMorePages())

--- a/resources/views/vendor/pagination/default.blade.php
+++ b/resources/views/vendor/pagination/default.blade.php
@@ -42,7 +42,13 @@
             <li class="page-item w-25 text-center"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
         @endif
 
-        <li class="page-item w-25 text-center"><span class="page-link">{{ $paginator->currentPage() }}</span></li>
+        <li class="page-item w-25 text-center">
+            <select class="custom-select tis-page-selector" aria-label="Page">
+                @for ($i = 1; $i <= $paginator->lastPage(); $i++)
+                    <option value="{{ $i }}" {{ $i === $paginator->currentPage() ? 'selected' : '' }} data-href="{{ $paginator->url($i) }}">{{ $i }}</option>
+                @endfor
+            </select>
+        </li>
 
         @if ($paginator->hasMorePages())
             <li class="page-item w-25 text-center"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>


### PR DESCRIPTION
#68 を修正するためのPRです。

## 全般的な部分
* Laravelのページネーターの仕組みにちゃんと乗ることで、各ページにページネーションレイアウトを直書きするのをやめました。

## PC
* 全てのページ番号が表示されてレイアウトが崩壊するような事態を回避しました。

![image](https://user-images.githubusercontent.com/1352154/52901765-ea37b980-324a-11e9-8960-e6550d164699.png)

## Phone
* PC同様のページャーは表示しきれないので、現在ページ番号と前後リンクだけ置きました。
* 現在ページ番号は選択可能になっていて、ページジャンプが可能です。
* 全ページ数はどれくらい需要があるか分からないです。とりあえずで置きましたが、こんなならあってもなくても……と個人的には思います。

![image](https://user-images.githubusercontent.com/1352154/52901789-34209f80-324b-11e9-99df-f90f890a8947.png)
