### PR TITLE
Web Share Target 実装（のためにPWA対応）

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,30 @@
+{
+    "name": "Tissue",
+    "short_name": "Tissue",
+    "description": "気持ちよくティッシュを使った、そのあとの感想戦。",
+    "display": "minimal-ui",
+    "start_url": "/",
+    "share_target": {
+        "action": "/checkin",
+        "method": "GET",
+        "enctype": "application/x-www-form-urlencoded",
+        "url_template": "/checkin?link={url}",
+        "params": {
+            "title": "",
+            "text": "link",
+            "url": "link"
+        }
+    },
+    "icons": [
+        {
+            "src": "apple-touch-icon.png",
+            "type": "image/png",
+            "sizes": "180x180"
+        },
+        {
+            "src": "chrome-touch-icon-192x192.png",
+            "type": "image/png",
+            "sizes": "192x192"
+        }
+    ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,1 @@
+self.addEventListener('fetch', function() {});

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -12,6 +12,7 @@
         <title>{{ config('app.name', 'Tissue') }}</title>
     @endif
 
+    <link href="{{ asset('manifest.json') }}" rel="manifest">
     <link href="{{ asset('css/bootstrap.min.css') }}" rel="stylesheet">
     <link href="{{ asset('css/open-iconic-bootstrap.min.css') }}" rel="stylesheet">
     <link href="{{ asset('css/tissue.css') }}" rel="stylesheet">
@@ -236,6 +237,9 @@
             });
         }
         @endguest
+        if (navigator.serviceWorker) {
+            navigator.serviceWorker.register('/sw.js');
+        }
         $('[data-toggle="tooltip"]').tooltip();
         $('.alert').alert();
         $('.tis-page-selector').pageSelector();


### PR DESCRIPTION
fixes #96 

Web Share Target API （っていうかPWA）は https で配信しないと動かないので、試す時はngrokとか使うとよいです。Laravelがプロトコル誤判定するようなら [TrustProxies](https://laravel.com/docs/5.5/requests#configuring-trusted-proxies) 入れましょう。わたしは入れました。

## 使い方

* Android版Chromeの場合:
  * 画面下に出てくる「ホーム画面に Tissue を追加」、もしくは右上のメニューから追加。
  * 任意のアプリからURLを共有 → Tissue を選択 → チェックイン画面
* PC版Chrome（少なくともWindows版）の場合:
  * Experimental Web Platform features を有効にする必要がある
    `chrome://flags/#enable-experimental-web-platform-features`
  * Tissueを開いて、右上のメニューから `「Tissue」をインストールしています‥」` を選択
  * Web Share API を使ったサイト*1から共有 → Tissue を選択 → チェックイン画面
    *1: Mastodon、Qiita、etc.
* その他ブラウザ・iOSの場合:
  * https://www.chromestatus.com/feature/5662315307335680

<details><summary>demo gif</summary>

![default](https://user-images.githubusercontent.com/705555/52916399-5a653e80-3322-11e9-9cdc-b578e6880597.gif)
</details>

## やったこと

* Web Share Target を実装
  * 共有されると `/checkin?link={url}` を開きます。
  * title, text, url の3つのパラメータを共有元から受け取れますが、Chrome for Android からの共有ではURLもtextに入ることがわかったので、今回はtextとurlをlinkパラメータに引き渡しています。titleは無視します。
* Android 上で Web Share Target を動作させるのに必要だったのでPWA化
  * ホーム画面に追加すると独立したアプリのように開けるようになります。
    * 引き続きブラウザでも見ることができますが、URL共有で開くのはPWA版です。
  * manifet.jsonは適当に埋めました。内容の追加変更があればコメントください。
    参考: [Google Developers](https://developers.google.com/web/fundamentals/web-app-manifest/?hl=ja), [Mastodon](https://mastodon.social/manifest.json), [Pinafore](https://pinafore.social/manifest.json)
  * アイコンはとりあえずeaiさんの海老を置いています。どうしましょうね。
    （万が一これをそのまま使うとしてもCC-BYのクレジットを書いたほうがよさそう）
  * なにもしないServiceWorkerを追加しています。多分害はないはず…。
  * demo gif では `display: minimal-ui` で、これを `standalone` にすると上のバーも消せます。が、右上のメニューからページ内検索とか共有とかできるので、このままの方がよさそう。
    （むしろ `browser` が使えるならそれでもよかったまである）