### PR TITLE
Dockerでmailcatcherを使えるようにする

### DIFF
--- a/docker-compose.mailcatcher.yml
+++ b/docker-compose.mailcatcher.yml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  mailcatcher:
+    image: schickling/mailcatcher
+    ports:
+      - 1080:1080
+    networks:
+      - backend
+


### PR DESCRIPTION
[mailcatcher](https://mailcatcher.me/)で開発時の送信メールをDocker完結で扱えるようにする

```example up
docker-compose -f docker-compose.yml -f docker-compose.mailcatcher.yml up -d
```

## SMTP `.env`

```.env
MAIL_DRIVER=smtp
MAIL_HOST=mailcatcher
MAIL_PORT=1025
MAIL_USERNAME=
MAIL_PASSWORD=
MAIL_ENCRYPTION=
MAIL_FROM_ADDRESS=support@mail.shikorism.net
MAIL_FROM_NAME=Tissue
```

