### PR TITLE
カードのレイアウトを横向きに

### DIFF
--- a/public/css/tissue.css
+++ b/public/css/tissue.css
@@ -85,3 +85,15 @@
 #navbarAccountDropdownSp {
     max-width: calc(100vw - 5em);
 }
+
+.card-img-left {
+    width: 100%;
+    border-top-left-radius: calc(.25rem - 1px);
+    border-bottom-left-radius: calc(.25rem - 1px);
+}
+
+.card-img-right {
+    width: 100%;
+    border-top-right-radius: calc(.25rem - 1px);
+    border-bottom-right-radius: calc(.25rem - 1px);
+}

--- a/public/js/tissue.js
+++ b/public/js/tissue.js
@@ -17,9 +17,11 @@
                     url: $this.find('a').attr('href')
                 }
             }).then(function (data) {
+                var $metaColumn = $this.find('.col-12:last-of-type');
+                var $imageColumn = $this.find('.col-12:first-of-type');
                 var $title = $this.find('.card-title');
                 var $desc = $this.find('.card-text');
-                var $image = $this.find('img');
+                var $image = $imageColumn.find('img');
 
                 if (data.title === '') {
                     $title.hide();
@@ -34,7 +36,8 @@
                 }
 
                 if (data.image === '') {
-                    $image.hide();
+                    $imageColumn.hide();
+                    $metaColumn.removeClass('col-md-6');
                 } else {
                     $image.attr('src', data.image);
                 }

--- a/resources/views/components/link-card.blade.php
+++ b/resources/views/components/link-card.blade.php
@@ -1,9 +1,15 @@
-<div class="card link-card mb-2 px-0 col-12 col-md-6 d-none" style="font-size: small;">
+<div class="card link-card mb-2 px-0 col-12 d-none" style="font-size: small;">
     <a class="text-dark card-link" href="{{ $link }}" target="_blank" rel="noopener">
-        <img src="" alt="Thumbnail" class="card-img-top bg-secondary">
-        <div class="card-body">
-            <h6 class="card-title font-weight-bold">タイトル</h6>
-            <p class="card-text">コンテンツの説明文</p>
+        <div class="row no-gutters">
+            <div class="col-12 col-md-6">
+                <img src="" alt="Thumbnail" class="card-img-left bg-secondary">
+            </div>
+            <div class="col-12 col-md-6">
+                <div class="card-body">
+                    <h6 class="card-title font-weight-bold">タイトル</h6>
+                    <p class="card-text">コンテンツの説明文</p>
+                </div>
+            </div>
         </div>
     </a>
 </div>


### PR DESCRIPTION
![localhost_4545_checkin_101019 ipad 1](https://user-images.githubusercontent.com/3516343/53499769-5f797900-3aec-11e9-8381-1b590ef5e090.png)

カードのレイアウトを横向きにします。

現状の縦向きだと右に空きスペースがあるので横のほうがいい感じなきがしています。

![localhost_4545_checkin_101019 pixel 2](https://user-images.githubusercontent.com/3516343/53500019-e6c6ec80-3aec-11e9-90e0-9c33f7d2b257.png)

モバイルだと縦向きになります。