### PR TITLE
DLsiteResolverのテストを追加

### DIFF
--- a/tests/Unit/MetadataResolver/DLsiteResolverTest.php
+++ b/tests/Unit/MetadataResolver/DLsiteResolverTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit\MetadataResolver;
+
+use App\MetadataResolver\DLsiteResolver;
+use Tests\TestCase;
+
+class DLsiteResolverTest extends TestCase
+{
+    use CreateMockedResolver;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (!$this->shouldUseMock()) {
+            sleep(1);
+        }
+    }
+
+    public function testProduct()
+    {
+        $responseText = file_get_contents(__DIR__.'/../../fixture/DLsite/testProduct.html');
+
+        $this->createResolver(DLsiteResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://www.dlsite.com/maniax/work/=/product_id/RJ171695.html');
+        $this->assertEquals('【骨伝導風】道草屋 たびらこ-一緒にはみがき【耳かき&はみがき】 [桃色CODE] | DLsite', $metadata->title);
+        $this->assertStringStartsWith('少しお母さんっぽい店員さんに、歯磨きからおやすみまでお世話されます。はみがきで興奮しちゃった旦那様のも、しっかりお世話してくれます。歯磨き音は特殊なマイクを使用、骨伝導風ハイレゾバイノーラル音声です。', $metadata->description);
+        $this->assertEquals('https://img.dlsite.jp/modpub/images2/work/doujin/RJ172000/RJ171695_img_main.jpg', $metadata->image);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://www.dlsite.com/maniax/work/=/product_id/RJ171695.html', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
+
+    public function testProductSP()
+    {
+        $responseText = file_get_contents(__DIR__.'/../../fixture/DLsite/testProductSP.html');
+
+        $this->createResolver(DLsiteResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://www.dlsite.com/home/work/=/product_id/RJ234446.html');
+        $this->assertEquals('【大人向け耳かき】道草屋 はこべら5 時計修理のはこべらさん。他【汗の匂い】 [桃色CODE] | DLsite', $metadata->title);
+        $this->assertStringStartsWith('夏の終わり、二人で遠くの花火を眺めます。耳かきの他、クラシックシェービング、氷を含んだあまがみ、冷紅茶、ジャズ、時計の修理、それから大人向けの汗の匂い。色々な事のある、二泊三日の田舎宿音声です。', $metadata->description);
+        $this->assertEquals('https://img.dlsite.jp/modpub/images2/work/doujin/RJ235000/RJ234446_img_main.jpg', $metadata->image);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://www.dlsite.com/home/work/=/product_id/RJ234446.html', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
+}

--- a/tests/fixture/DLsite/testProduct.html
+++ b/tests/fixture/DLsite/testProduct.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:og="http://ogp.me/ns#" xmlns:mixi="http://mixi-platform.com/ns#" xmlns:fb="http://www.facebook.com/2008/fbml">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta name="viewport" content="width=991">
+        <meta http-equiv="Content-Style-Type" content="text/css" />
+        <meta http-equiv="Content-Script-Type" content="text/javascript" />
+        <meta name="google-site-verification" content="S2Jzwn_Dm4hGoyTfPnxEUSKnbHSuT73N6SZbTanWbEM" />
+        <link rel="apple-touch-icon" href="/images/web/common/apple_touch_icon_57x57.png">
+        <link rel="apple-touch-icon" sizes="72x72" href="/images/web/common/apple_touch_icon_72x72.png">
+        <link rel="apple-touch-icon" sizes="76x76" href="/images/web/common/apple_touch_icon_76x76.png">
+        <link rel="apple-touch-icon" sizes="114x114" href="/images/web/common/apple_touch_icon_114x114.png">
+        <link rel="apple-touch-icon" sizes="120x120" href="/images/web/common/apple_touch_icon_120x120.png">
+        <link rel="apple-touch-icon" sizes="144x144" href="/images/web/common/apple_touch_icon_144x144.png">
+        <link rel="apple-touch-icon" sizes="152x152" href="/images/web/common/apple_touch_icon_152x152.png">
+        <meta name="msapplication-config" content="/browserconfig.xml" />
+        <link rel="shortcut icon" href="/images/web/common/favicon.ico">
+
+
+
+        <link rel="canonical" href="https://www.dlsite.com/maniax/work/=/product_id/RJ171695.html" />
+        <link rel="alternate" media="only screen and (max-width: 640px)" href="https://www.dlsite.com/maniax-touch/work/=/product_id/RJ171695.html" class="alternate_smartphone" />
+        <link rel="alternate" hreflang="ja" href="https://www.dlsite.com/maniax/work/=/product_id/RJ171695.html" />
+        <link rel="alternate" hreflang="en" href="https://www.dlsite.com/ecchi-eng/work/=/product_id/RE171695.html" />  <meta name="description" content="少しお母さんっぽい店員さんに、歯磨きからおやすみまでお世話されます。はみがきで興奮しちゃった旦那様のも、しっかりお世話してくれます。歯磨き音は特殊なマイクを使用、骨伝導風ハイレゾバイノーラル音声です。「DLsite 同人 - R18」は同人誌・同人ゲーム・同人音声のダウンロードショップ。お気に入りの作品をすぐダウンロードできてすぐ楽しめる！毎日更新しているのであなたが探している作品にきっと出会えます。国内最大級の二次元総合ダウンロードショップ「DLsite」！">
+        <title>【骨伝導風】道草屋 たびらこ-一緒にはみがき【耳かき&amp;はみがき】 [桃色CODE] | DLsite 同人 - R18</title>
+
+
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:site" content="@DLsiteManiax">
+        <meta name="twitter:image:src" content="https://img.dlsite.jp/modpub/images2/work/doujin/RJ172000/RJ171695_img_main.jpg" />
+
+        <meta property="og:title" content="【骨伝導風】道草屋 たびらこ-一緒にはみがき【耳かき&amp;はみがき】 [桃色CODE] | DLsite" />
+        <meta property="og:type" content="website" />
+        <meta property="og:description" content="少しお母さんっぽい店員さんに、歯磨きからおやすみまでお世話されます。はみがきで興奮しちゃった旦那様のも、しっかりお世話してくれます。歯磨き音は特殊なマイクを使用、骨伝導風ハイレゾバイノーラル音声です。「DLsite 同人 - R18」は同人誌・同人ゲーム・同人音声のダウンロードショップ。お気に入りの作品をすぐダウンロードできてすぐ楽しめる！毎日更新しているのであなたが探している作品にきっと出会えます。国内最大級の二次元総合ダウンロードショップ「DLsite」！" />
+        <meta property="og:url" content="https://www.dlsite.com/maniax/work/=/product_id/RJ171695.html" />
+        <meta property="og:image" content="https://img.dlsite.jp/modpub/images2/work/doujin/RJ172000/RJ171695_img_sam.jpg" />
+        <meta property="og:site_name" content="DLsite" />
+        <meta property="fb:app_id" content="226115600829997" />
+        <meta property="mixi:content-rating" content="1" />
+        <meta property="mixi:device-smartphone" content="https://www.dlsite.com/maniax-touch/work/=/product_id/RJ171695.html" />
+    </head>
+
+    <body></body>
+</html>

--- a/tests/fixture/DLsite/testProductSP.html
+++ b/tests/fixture/DLsite/testProductSP.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns="http://www.w3.org/1999/xhtml" xmlns:og="http://ogp.me/ns#" xmlns:mixi="http://mixi-platform.com/ns#" xmlns:fb="http://www.facebook.com/2008/fbml" >
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <meta name="format-detection" content="telephone=no">
+        <meta http-equiv="Content-Style-Type" content="text/css">
+        <meta http-equiv="Content-Script-Type" content="text/javascript">
+        <meta name="google-site-verification" content="S2Jzwn_Dm4hGoyTfPnxEUSKnbHSuT73N6SZbTanWbEM">
+        <link rel="apple-touch-icon" href="/images/web/common/apple_touch_icon_57x57.png">
+        <link rel="apple-touch-icon" sizes="72x72" href="/images/web/common/apple_touch_icon_72x72.png">
+        <link rel="apple-touch-icon" sizes="76x76" href="/images/web/common/apple_touch_icon_76x76.png">
+        <link rel="apple-touch-icon" sizes="114x114" href="/images/web/common/apple_touch_icon_114x114.png">
+        <link rel="apple-touch-icon" sizes="120x120" href="/images/web/common/apple_touch_icon_120x120.png">
+        <link rel="apple-touch-icon" sizes="144x144" href="/images/web/common/apple_touch_icon_144x144.png">
+        <link rel="apple-touch-icon" sizes="152x152" href="/images/web/common/apple_touch_icon_152x152.png">
+        <meta name="msapplication-config" content="/browserconfig.xml" />
+        <link rel="shortcut icon" href="/images/web/common/favicon.ico">
+
+
+
+        <link rel="canonical" href="https://www.dlsite.com/maniax/work/=/product_id/RJ234446.html" />
+        <link rel="alternate" hreflang="ja" href="https://www.dlsite.com/maniax/work/=/product_id/RJ234446.html" />
+        <link rel="alternate" hreflang="en" href="https://www.dlsite.com/ecchi-eng/work/=/product_id/RE234446.html" />  <meta name="description" content="夏の終わり、二人で遠くの花火を眺めます。耳かきの他、クラシックシェービング、氷を含んだあまがみ、冷紅茶、ジャズ、時計の修理、それから大人向けの汗の匂い。色々な事のある、二泊三日の田舎宿音声です。「DLsite 同人 - R18」は同人誌・同人ゲーム・同人音声のダウンロードショップ。お気に入りの作品をすぐダウンロードできてすぐ楽しめる！毎日更新しているのであなたが探している作品にきっと出会えます。国内最大級の二次元総合ダウンロードショップ「DLsite」！">
+        <title>【大人向け耳かき】道草屋 はこべら5 時計修理のはこべらさん。他【汗の匂い】 [桃色CODE] | DLsite 同人 - R18</title>
+
+
+
+        <meta property="og:title" content="【大人向け耳かき】道草屋 はこべら5 時計修理のはこべらさん。他【汗の匂い】 [桃色CODE] | DLsite" />
+        <meta property="og:type" content="website" />
+        <meta property="og:description" content="夏の終わり、二人で遠くの花火を眺めます。耳かきの他、クラシックシェービング、氷を含んだあまがみ、冷紅茶、ジャズ、時計の修理、それから大人向けの汗の匂い。色々な事のある、二泊三日の田舎宿音声です。「DLsite 同人 - R18」は同人誌・同人ゲーム・同人音声のダウンロードショップ。お気に入りの作品をすぐダウンロードできてすぐ楽しめる！毎日更新しているのであなたが探している作品にきっと出会えます。国内最大級の二次元総合ダウンロードショップ「DLsite」！" />
+        <meta property="og:url" content="https://www.dlsite.com/maniax-touch/work/=/product_id/RJ234446.html" />
+        <meta property="og:image" content="https://img.dlsite.jp/modpub/images2/work/doujin/RJ235000/RJ234446_img_sam.jpg" />
+        <meta property="og:site_name" content="DLsite" />
+        <meta property="fb:app_id" content="226115600829997" />
+        <meta property="mixi:content-rating" content="1" />
+    </head>
+
+    <body></body>
+</html>


### PR DESCRIPTION
DLsiteResolverのテストを追加します。

DLsiteには`home`(全年齢向け 同人作品)、`maniax`(R18 男性向け 同人作品)、`eng`(全年齢向け 英語)などの販売項目がありますが、OGPの出力に差はないようでしたので、R18作品のPCサイトとSPサイトのテストのみを追加しました。

ref #42 