### PR TITLE
PatreonResolverにてtoken-timeがある場合のみexpires_atを指定するように変更

### DIFF
--- a/app/MetadataResolver/PatreonResolver.php
+++ b/app/MetadataResolver/PatreonResolver.php
@@ -28,11 +28,11 @@ class PatreonResolver implements Resolver
         if ($res->getStatusCode() === 200) {
             $metadata = $this->ogpResolver->parse($res->getBody());
 
-            parse_str(parse_url($metadata->image, PHP_URL_QUERY), $temp);
-            $expires_at_unixtime = $temp['token-time'];
-            $expires_at = Carbon::createFromTimestamp($expires_at_unixtime);
-
-            $metadata->expires_at = $expires_at;
+            parse_str(parse_url($metadata->image, PHP_URL_QUERY), $query);
+            if(isset($query['token-time'])){
+                $expires_at_unixtime = $query['token-time'];
+                $metadata->expires_at = Carbon::createFromTimestamp($expires_at_unixtime);
+            }
 
             return $metadata;
         } else {

--- a/app/MetadataResolver/PatreonResolver.php
+++ b/app/MetadataResolver/PatreonResolver.php
@@ -29,7 +29,7 @@ class PatreonResolver implements Resolver
             $metadata = $this->ogpResolver->parse($res->getBody());
 
             parse_str(parse_url($metadata->image, PHP_URL_QUERY), $query);
-            if(isset($query['token-time'])){
+            if (isset($query['token-time'])) {
                 $expires_at_unixtime = $query['token-time'];
                 $metadata->expires_at = Carbon::createFromTimestamp($expires_at_unixtime);
             }


### PR DESCRIPTION
token-timeがない場合（有料限定のため汎用画像が使われる場合）にエラーが出るので。