### PR TITLE
DLsiteResolverをdlsite.jpの形式に対応させる

### DIFF
--- a/app/MetadataResolver/MetadataResolver.php
+++ b/app/MetadataResolver/MetadataResolver.php
@@ -16,6 +16,7 @@ class MetadataResolver implements Resolver
         '~ec\.toranoana\.jp/tora_r/ec/item/.*~' => ToranoanaResolver::class,
         '~iwara\.tv/videos/.*~' => IwaraResolver::class,
         '~www\.dlsite\.com/.*/work/=/product_id/..\d+\.html~' => DLsiteResolver::class,
+        '~dlsite\.jp/mawtw/..\d+~' => DLsiteResolver::class,
         '~www\.pixiv\.net/member_illust\.php\?illust_id=\d+~' => PixivResolver::class,
         '~fantia\.jp/posts/\d+~' => FantiaResolver::class,
         '~dmm\.co\.jp/~' => FanzaResolver::class,

--- a/tests/Unit/MetadataResolver/DLsiteResolverTest.php
+++ b/tests/Unit/MetadataResolver/DLsiteResolverTest.php
@@ -47,4 +47,19 @@ class DLsiteResolverTest extends TestCase
             $this->assertSame('https://www.dlsite.com/home/work/=/product_id/RJ234446.html', (string) $this->handler->getLastRequest()->getUri());
         }
     }
+
+    public function testProductShortLink()
+    {
+        $responseText = file_get_contents(__DIR__.'/../../fixture/DLsite/testProduct.html');
+
+        $this->createResolver(DLsiteResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://dlsite.jp/mawtw/RJ171695.html');
+        $this->assertEquals('【骨伝導風】道草屋 たびらこ-一緒にはみがき【耳かき&はみがき】 [桃色CODE] | DLsite', $metadata->title);
+        $this->assertStringStartsWith('少しお母さんっぽい店員さんに、歯磨きからおやすみまでお世話されます。はみがきで興奮しちゃった旦那様のも、しっかりお世話してくれます。歯磨き音は特殊なマイクを使用、骨伝導風ハイレゾバイノーラル音声です。', $metadata->description);
+        $this->assertEquals('https://img.dlsite.jp/modpub/images2/work/doujin/RJ172000/RJ171695_img_main.jpg', $metadata->image);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://dlsite.jp/mawtw/RJ171695.html', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
 }


### PR DESCRIPTION
DLsiteではツイートボタンを押したときに `https://dlsite.jp/mawtw/作品ID` のURLが使われます。

これは現在の正規表現パターンに一致しないためパターンを追加しました。