### PR TITLE
DLsiteResolverで余分な説明文を削除・整形する

### DIFF
--- a/app/MetadataResolver/DLsiteResolver.php
+++ b/app/MetadataResolver/DLsiteResolver.php
@@ -32,8 +32,8 @@ class DLsiteResolver implements Resolver
             $maker = $match[1];
 
             // 余分な文を消す
-            $metadata->title = preg_replace('~\[.+\] \| DLsite$~', '', $metadata->title);
-            $metadata->description = preg_replace('~「DLsite.+」は同人誌・同人ゲーム・同人音声のダウンロードショップ。お気に入りの作品をすぐダウンロードできてすぐ楽しめる！毎日更新しているのであなたが探している作品にきっと出会えます。国内最大級の二次元総合ダウンロードショップ「DLsite」！$~', '', $metadata->description);
+            $metadata->title = trim(preg_replace('~ \[.+\] \| DLsite$~', '', $metadata->title));
+            $metadata->description = trim(preg_replace('~「DLsite.+」は同人誌・同人ゲーム・同人音声のダウンロードショップ。お気に入りの作品をすぐダウンロードできてすぐ楽しめる！毎日更新しているのであなたが探している作品にきっと出会えます。国内最大級の二次元総合ダウンロードショップ「DLsite」！$~', '', $metadata->description));
 
             // 整形
             $metadata->description = 'サークル: ' . $maker . PHP_EOL . $metadata->description;

--- a/app/MetadataResolver/DLsiteResolver.php
+++ b/app/MetadataResolver/DLsiteResolver.php
@@ -26,6 +26,17 @@ class DLsiteResolver implements Resolver
         $res = $this->client->get($url);
         if ($res->getStatusCode() === 200) {
             $metadata = $this->ogpResolver->parse($res->getBody());
+
+            // 抽出
+            preg_match('~\[(.+)\] \| DLsite$~', $metadata->title, $match);
+            $maker = $match[1];
+
+            // 余分な文を消す
+            $metadata->title = preg_replace('~\[.+\] \| DLsite$~', '', $metadata->title);
+            $metadata->description = preg_replace('~「DLsite.+」は同人誌・同人ゲーム・同人音声のダウンロードショップ。お気に入りの作品をすぐダウンロードできてすぐ楽しめる！毎日更新しているのであなたが探している作品にきっと出会えます。国内最大級の二次元総合ダウンロードショップ「DLsite」！$~', '', $metadata->description);
+
+            // 整形
+            $metadata->description = 'サークル: ' . $maker . PHP_EOL . $metadata->description;
             $metadata->image = str_replace('img_sam.jpg', 'img_main.jpg', $metadata->image);
 
             return $metadata;

--- a/tests/Unit/MetadataResolver/DLsiteResolverTest.php
+++ b/tests/Unit/MetadataResolver/DLsiteResolverTest.php
@@ -25,8 +25,8 @@ class DLsiteResolverTest extends TestCase
         $this->createResolver(DLsiteResolver::class, $responseText);
 
         $metadata = $this->resolver->resolve('https://www.dlsite.com/maniax/work/=/product_id/RJ171695.html');
-        $this->assertEquals('【骨伝導風】道草屋 たびらこ-一緒にはみがき【耳かき&はみがき】 [桃色CODE] | DLsite', $metadata->title);
-        $this->assertStringStartsWith('少しお母さんっぽい店員さんに、歯磨きからおやすみまでお世話されます。はみがきで興奮しちゃった旦那様のも、しっかりお世話してくれます。歯磨き音は特殊なマイクを使用、骨伝導風ハイレゾバイノーラル音声です。', $metadata->description);
+        $this->assertEquals('【骨伝導風】道草屋 たびらこ-一緒にはみがき【耳かき&はみがき】', $metadata->title);
+        $this->assertStringEndsWith('少しお母さんっぽい店員さんに、歯磨きからおやすみまでお世話されます。はみがきで興奮しちゃった旦那様のも、しっかりお世話してくれます。歯磨き音は特殊なマイクを使用、骨伝導風ハイレゾバイノーラル音声です。', $metadata->description);
         $this->assertEquals('https://img.dlsite.jp/modpub/images2/work/doujin/RJ172000/RJ171695_img_main.jpg', $metadata->image);
         if ($this->shouldUseMock()) {
             $this->assertSame('https://www.dlsite.com/maniax/work/=/product_id/RJ171695.html', (string) $this->handler->getLastRequest()->getUri());
@@ -40,8 +40,8 @@ class DLsiteResolverTest extends TestCase
         $this->createResolver(DLsiteResolver::class, $responseText);
 
         $metadata = $this->resolver->resolve('https://www.dlsite.com/home/work/=/product_id/RJ234446.html');
-        $this->assertEquals('【大人向け耳かき】道草屋 はこべら5 時計修理のはこべらさん。他【汗の匂い】 [桃色CODE] | DLsite', $metadata->title);
-        $this->assertStringStartsWith('夏の終わり、二人で遠くの花火を眺めます。耳かきの他、クラシックシェービング、氷を含んだあまがみ、冷紅茶、ジャズ、時計の修理、それから大人向けの汗の匂い。色々な事のある、二泊三日の田舎宿音声です。', $metadata->description);
+        $this->assertEquals('【大人向け耳かき】道草屋 はこべら5 時計修理のはこべらさん。他【汗の匂い】', $metadata->title);
+        $this->assertStringEndsWith('夏の終わり、二人で遠くの花火を眺めます。耳かきの他、クラシックシェービング、氷を含んだあまがみ、冷紅茶、ジャズ、時計の修理、それから大人向けの汗の匂い。色々な事のある、二泊三日の田舎宿音声です。', $metadata->description);
         $this->assertEquals('https://img.dlsite.jp/modpub/images2/work/doujin/RJ235000/RJ234446_img_main.jpg', $metadata->image);
         if ($this->shouldUseMock()) {
             $this->assertSame('https://www.dlsite.com/home/work/=/product_id/RJ234446.html', (string) $this->handler->getLastRequest()->getUri());


### PR DESCRIPTION
冗長な定型文を削除します。

改行文字を使用しているため、使用する場合は #87 の対処が必要です。