### PR TITLE
メタデータのdescriptionに含まれる改行を表示に反映する

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -6,3 +6,6 @@
 
 // Legacy app styles
 @import "tissue.css";
+
+// Components
+@import "components/link-card";

--- a/resources/assets/sass/components/_link-card.scss
+++ b/resources/assets/sass/components/_link-card.scss
@@ -1,0 +1,21 @@
+.link-card {
+  .row > div:last-child {
+    max-height: 400px;
+    overflow: hidden;
+
+    // 省略を表す影を付けるやつ
+    &::before {
+      content: '';
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      left: 0;
+      top: 0;
+      background: linear-gradient(transparent 320px, white);
+    }
+  }
+
+  .card-text {
+    white-space: pre-line;
+  }
+}

--- a/resources/assets/sass/tissue.css
+++ b/resources/assets/sass/tissue.css
@@ -97,23 +97,3 @@
     border-top-right-radius: calc(.25rem - 1px);
     border-bottom-right-radius: calc(.25rem - 1px);
 }
-
-.link-card .row > div:last-child {
-    max-height: 400px;
-    overflow: hidden;
-}
-
-/* 省略を表す影を付けるやつ */
-.link-card .row > div:last-child::before {
-    content: '';
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    left: 0;
-    top: 0;
-    background: linear-gradient(transparent 320px, white);
-}
-
-.link-card .card-text {
-    white-space: pre-line;
-}

--- a/resources/assets/sass/tissue.css
+++ b/resources/assets/sass/tissue.css
@@ -97,3 +97,23 @@
     border-top-right-radius: calc(.25rem - 1px);
     border-bottom-right-radius: calc(.25rem - 1px);
 }
+
+.link-card .row > div:last-child {
+    max-height: 400px;
+    overflow: hidden;
+}
+
+/* 省略を表す影を付けるやつ */
+.link-card .row > div:last-child::before {
+    content: '';
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    background: linear-gradient(transparent 320px, white);
+}
+
+.link-card .card-text {
+    white-space: pre-line;
+}


### PR DESCRIPTION
https://github.com/shikorism/tissue/issues/87#issuecomment-470697153 にて提案された `white-space: pre-line` を用いて、metadata.description の改行が表示上に反映されるようにしました。

テキストが長すぎる場合は、適当な所で省略します。

> ![image](https://user-images.githubusercontent.com/1352154/54042608-df4ec400-420d-11e9-8bb5-a0b94872d538.png)
> リンク先: https://ertona.net/@shibafu528/101716004483801313

close #87 
