### PR TITLE
プライマリカラーを変更

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,3 +1,6 @@
+// Bootstrap Variable Overlide
+$primary: #e53fb1;
+
 // Bootstrap
 @import "~bootstrap/scss/bootstrap";
 @import "bootstrap-custom";

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -89,7 +89,7 @@
                         </div>
                     </form>
                     <form class="form-inline mr-2">
-                        <a href="{{ route('checkin') }}" class="btn btn-outline-success">チェックイン</a>
+                        <a href="{{ route('checkin') }}" class="btn btn-outline-primary">チェックイン</a>
                     </form>
                     <ul class="navbar-nav">
                         <li class="nav-item dropdown">
@@ -114,18 +114,18 @@
                 <div class="d-lg-none">
                     <div class="row mt-2">
                         <div class="col">
-                            <a class="btn btn-outline-{{ stripos(Route::currentRouteName(), 'home') === 0 ? 'primary' : 'secondary'}}" href="{{ route('home') }}" role="button">ホーム</a>
+                            <a class="btn btn-{{ stripos(Route::currentRouteName(), 'home') === 0 ? 'primary' : 'outline-secondary'}}" href="{{ route('home') }}" role="button">ホーム</a>
                         </div>
                         <div class="col">
-                            <a class="btn btn-outline-{{ stripos(Route::currentRouteName(), 'user.profile') === 0 ? 'primary' : 'secondary'}}" href="{{ route('user.profile', ['name' => Auth::user()->name]) }}" role="button">タイムライン</a>
+                            <a class="btn btn-{{ stripos(Route::currentRouteName(), 'user.profile') === 0 ? 'primary' : 'outline-secondary'}}" href="{{ route('user.profile', ['name' => Auth::user()->name]) }}" role="button">タイムライン</a>
                         </div>
                     </div>
                     <div class="row mt-2">
                         <div class="col">
-                            <a class="btn btn-outline-{{ stripos(Route::currentRouteName(), 'user.stats') === 0 ? 'primary' : 'secondary'}}" href="{{ route('user.stats', ['name' => Auth::user()->name]) }}" role="button">グラフ</a>
+                            <a class="btn btn-{{ stripos(Route::currentRouteName(), 'user.stats') === 0 ? 'primary' : 'outline-secondary'}}" href="{{ route('user.stats', ['name' => Auth::user()->name]) }}" role="button">グラフ</a>
                         </div>
                         <div class="col">
-                            <a class="btn btn-outline-{{ stripos(Route::currentRouteName(), 'user.okazu') === 0 ? 'primary' : 'secondary'}}" href="{{ route('user.okazu', ['name' => Auth::user()->name]) }}" role="button">オカズ</a>
+                            <a class="btn btn-{{ stripos(Route::currentRouteName(), 'user.okazu') === 0 ? 'primary' : 'outline-secondary'}}" href="{{ route('user.okazu', ['name' => Auth::user()->name]) }}" role="button">オカズ</a>
                         </div>
                     </div>
                     {{-- <div class="row mt-2">
@@ -145,7 +145,7 @@
                     </div>
                     <div class="row mt-2">
                         <form class="form-inline col">
-                            <a class="btn btn-outline-success" href="{{ route('checkin') }}">チェックイン</a>
+                            <a class="btn btn-outline-primary" href="{{ route('checkin') }}">チェックイン</a>
                         </form>
                     </div>
                 </div>


### PR DESCRIPTION
このPRはBootstrapのプライマリカラーを `#e53fb1` に変更します。

faviconはピンクなのに、リンクなどのプライマリカラーがBootstrapデフォルトの青であることが気になったためです。それとブランディングのためにテーマカラーがあると便利なので。

## `#e53fb1` にした理由

faviconなどで使われている背景色は `#e040fb` ですがそのままプライマリカラーにするには眩しすぎたので、Bootstrapのpink `#e83e8c` とブレンドしたものです。

![image](https://user-images.githubusercontent.com/3516343/54124271-3f7b7b00-4445-11e9-8d5a-2f7bb1104224.png)

## 備考

色は個人の感性によるものが強いですので、気に入らなければcloseしてもらってまったく問題ありません。

## スクリーンショット

![localhost_4545_ (2)](https://user-images.githubusercontent.com/3516343/54124298-528e4b00-4445-11e9-841e-665f0cc1db0b.png)
![localhost_4545_ (1)](https://user-images.githubusercontent.com/3516343/54124300-54580e80-4445-11e9-8d53-be2a59dde485.png)
![localhost_4545_login](https://user-images.githubusercontent.com/3516343/54124305-5621d200-4445-11e9-8155-01416ff28c40.png)
![localhost_4545_ (3)](https://user-images.githubusercontent.com/3516343/54124308-5752ff00-4445-11e9-9246-9cd27ccfc2f6.png)
