### PR TITLE
削除モーダルの初期化が完了してから削除ボタンクリックイベントを仕掛ける

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -28,5 +28,9 @@ $(() => {
     }
 
     $('.link-card').linkCard();
-    $('#deleteCheckinModal').deleteCheckinModal();
+    const $deleteCheckinModal = $('#deleteCheckinModal').deleteCheckinModal();
+    $(document).on('click', '[data-target="#deleteCheckinModal"]', function (event) {
+        event.preventDefault();
+        $deleteCheckinModal.modal('show', this);
+    });
 });

--- a/resources/views/ejaculation/show.blade.php
+++ b/resources/views/ejaculation/show.blade.php
@@ -36,7 +36,7 @@
                                 <a class="text-secondary timeline-action-item" href="{{ route('checkin', ['link' => $ejaculation->link, 'tags' => $ejaculation->textTags()]) }}"><span class="oi oi-reload" data-toggle="tooltip" data-placement="bottom" title="同じオカズでチェックイン"></span></a>
                                 @if ($user->isMe())
                                     <a class="text-secondary timeline-action-item" href="{{ route('checkin.edit', ['id' => $ejaculation->id]) }}"><span class="oi oi-pencil" data-toggle="tooltip" data-placement="bottom" title="修正"></span></a>
-                                    <a class="text-secondary timeline-action-item" href="#" data-toggle="modal" data-target="#deleteCheckinModal" data-id="{{ $ejaculation->id }}" data-date="{{ $ejaculation->ejaculated_date }}"><span class="oi oi-trash" data-toggle="tooltip" data-placement="bottom" title="削除"></span></a>
+                                    <a class="text-secondary timeline-action-item" href="#" data-target="#deleteCheckinModal" data-id="{{ $ejaculation->id }}" data-date="{{ $ejaculation->ejaculated_date }}"><span class="oi oi-trash" data-toggle="tooltip" data-placement="bottom" title="削除"></span></a>
                                 @endif
                             </div>
                         </div>

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -42,7 +42,7 @@
                         <a class="text-secondary timeline-action-item" href="{{ route('checkin', ['link' => $ejaculation->link, 'tags' => $ejaculation->textTags()]) }}"><span class="oi oi-reload" data-toggle="tooltip" data-placement="bottom" title="同じオカズでチェックイン"></span></a>
                         @if ($user->isMe())
                             <a class="text-secondary timeline-action-item" href="{{ route('checkin.edit', ['id' => $ejaculation->id]) }}"><span class="oi oi-pencil" data-toggle="tooltip" data-placement="bottom" title="修正"></span></a>
-                            <a class="text-secondary timeline-action-item" href="#" data-toggle="modal" data-target="#deleteCheckinModal" data-id="{{ $ejaculation->id }}" data-date="{{ $ejaculation->ejaculated_date }}"><span class="oi oi-trash" data-toggle="tooltip" data-placement="bottom" title="削除"></span></a>
+                            <a class="text-secondary timeline-action-item" href="#" data-target="#deleteCheckinModal" data-id="{{ $ejaculation->id }}" data-date="{{ $ejaculation->ejaculated_date }}"><span class="oi oi-trash" data-toggle="tooltip" data-placement="bottom" title="削除"></span></a>
                         @endif
                     </div>
                 </div>


### PR DESCRIPTION
Bootstrapに任せると問答無用でModalを召喚しようとするので、自力で呼び出すようにしてみた。こっちにはこっちの都合というものがある。

まぁこれだと、DOMContentLoadedまでの間に触るとページの天井に頭をぶつけるけど、壊れたダイアログが出るよりは……。

fix #145 