### PR TITLE
カード画像の角丸の位置をメディアクエリで可変にした

### DIFF
--- a/resources/assets/sass/_bootstrap-custom.scss
+++ b/resources/assets/sass/_bootstrap-custom.scss
@@ -7,3 +7,13 @@
     width: 100%;
     @include border-right-radius($card-inner-border-radius);
 }
+
+.card-img-top-to-left {
+    width: 100%;
+    @include media-breakpoint-down(md) {
+        @include border-top-radius($card-inner-border-radius);
+    }
+    @include media-breakpoint-up(lg) {
+        @include border-left-radius($card-inner-border-radius);
+    }
+}

--- a/resources/views/components/link-card.blade.php
+++ b/resources/views/components/link-card.blade.php
@@ -2,7 +2,7 @@
     <a class="text-dark card-link" href="{{ $link }}" target="_blank" rel="noopener">
         <div class="row no-gutters">
             <div class="col-12 col-md-6">
-                <img src="" alt="Thumbnail" class="card-img-left bg-secondary">
+                <img src="" alt="Thumbnail" class="card-img-top-to-left bg-secondary">
             </div>
             <div class="col-12 col-md-6">
                 <div class="card-body">


### PR DESCRIPTION
https://github.com/shikorism/tissue/issues/140#issuecomment-471278788 で書いた案をそのままPRにしました。

レイアウトに応じてCSSを付け変えるのも面倒なので、メディアクエリに任せてしまえばいいという魂胆です。

fix #140 