### PR TITLE
改行コードを正規化する処理をミドルウェア化

### DIFF
--- a/app/Http/Controllers/EjaculationController.php
+++ b/app/Http/Controllers/EjaculationController.php
@@ -30,9 +30,6 @@ class EjaculationController extends Controller
     public function store(Request $request)
     {
         $inputs = $request->all();
-        if ($request->has('note')) {
-            $inputs['note'] = str_replace(["\r\n", "\r"], "\n", $inputs['note']);
-        }
 
         $validator = Validator::make($inputs, [
             'date' => 'required|date_format:Y/m/d',
@@ -113,9 +110,6 @@ class EjaculationController extends Controller
         $ejaculation = Ejaculation::findOrFail($id);
 
         $inputs = $request->all();
-        if ($request->has('note')) {
-            $inputs['note'] = str_replace(["\r\n", "\r"], "\n", $inputs['note']);
-        }
 
         $validator = Validator::make($inputs, [
             'date' => 'required|date_format:Y/m/d',

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -35,6 +35,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\NormalizeLineEnding::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/NormalizeLineEnding.php
+++ b/app/Http/Middleware/NormalizeLineEnding.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+/**
+ * リクエスト内の改行コードを正規化する。
+ * @package App\Http\Middleware
+ */
+class NormalizeLineEnding
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $newInput = [];
+        foreach ($request->input() as $key => $value) {
+            $newInput[$key] = str_replace(["\r\n", "\r"], "\n", $value);
+        }
+        $request->replace($newInput);
+
+        return $next($request);
+    }
+}

--- a/tests/Unit/Http/Middleware/NormalizeLineEndingTest.php
+++ b/tests/Unit/Http/Middleware/NormalizeLineEndingTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit\Http\Middleware;
+
+use App\Http\Middleware\NormalizeLineEnding;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class NormalizeLineEndingTest extends TestCase
+{
+    public function testCRLFtoLF()
+    {
+        $request = Request::create('/');
+        $request->replace([
+            'test' => "foo\r\nbar"
+        ]);
+
+        $middleware = new NormalizeLineEnding();
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals("foo\nbar", $request->input('test'));
+        });
+    }
+
+    public function testCRtoLF()
+    {
+        $request = Request::create('/');
+        $request->replace([
+            'test' => "foo\rbar"
+        ]);
+
+        $middleware = new NormalizeLineEnding();
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals("foo\nbar", $request->input('test'));
+        });
+    }
+
+    public function testLFtoLF()
+    {
+        $request = Request::create('/');
+        $request->replace([
+            'test' => "foo\nbar"
+        ]);
+
+        $middleware = new NormalizeLineEnding();
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals("foo\nbar", $request->input('test'));
+        });
+    }
+
+    public function testArrayRequest()
+    {
+        $request = Request::create('/');
+        $request->replace([
+            'test' => "foo\r\nbar",
+            'hash' => [
+                'yuzuki' => "yuzuki\r\nyukari",
+                'miku' => "hatsune\r\nmiku",
+            ],
+            'array' => [
+                "kagamine\r\nrin",
+                "kagamine\r\nlen"
+            ]
+        ]);
+
+        $middleware = new NormalizeLineEnding();
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals("foo\nbar", $request->input('test'));
+            $this->assertEquals("yuzuki\nyukari", $request->input('hash.yuzuki'));
+            $this->assertEquals("hatsune\nmiku", $request->input('hash.miku'));
+            $this->assertEquals("kagamine\nrin", $request->input('array.0'));
+            $this->assertEquals("kagamine\nlen", $request->input('array.1'));
+        });
+    }
+}


### PR DESCRIPTION
#1 の対応を行った際に改行コードを正規化する処理を実装したが、これは個別に処理するものではなくて全体で統一されるべき振る舞いなのでは？と思い直した。

ということで、その処理をミドルウェア化してWebグループに設定した。

APIグループには設定していないが、そっちでも統一しておいたほうが良いだろうか……。  
(そうであれば、いっそグローバルに仕掛けるのが良いのかな)