### PR TITLE
Linux+Dockerな開発環境でxdebugが使えるようにコールバック先IPアドレスの設定を調整

### DIFF
--- a/dist/bin/tissue-entrypoint.sh
+++ b/dist/bin/tissue-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 if [[ "$APP_DEBUG" == "true" ]]; then
   export PHP_INI_SCAN_DIR=":/usr/local/etc/php/php.d"
 
-  php -r "if (gethostbyname('host.docker.internal') === 'host.docker.internal') exit(1);" &> /dev/null
+  php -r "if (gethostbyname('host.docker.internal') === 'host.docker.internal') exit(1);" &> /dev/null && :
   if [[ $? -eq 0 ]]; then
     # Docker for Windows/Mac
     export PHP_XDEBUG_REMOTE_HOST='host.docker.internal'

--- a/dist/bin/tissue-entrypoint.sh
+++ b/dist/bin/tissue-entrypoint.sh
@@ -3,7 +3,15 @@ set -e
 
 if [[ "$APP_DEBUG" == "true" ]]; then
   export PHP_INI_SCAN_DIR=":/usr/local/etc/php/php.d"
-  export PHP_XDEBUG_REMOTE_HOST=$(cat /etc/hosts | awk 'END{print $1}' | sed -r -e 's/[0-9]+$/1/g')
+
+  php -r "if (gethostbyname('host.docker.internal') === 'host.docker.internal') exit(1);" &> /dev/null
+  if [[ $? -eq 0 ]]; then
+    # Docker for Windows/Mac
+    export PHP_XDEBUG_REMOTE_HOST='host.docker.internal'
+  else
+    # Docker for Linux
+    export PHP_XDEBUG_REMOTE_HOST=$(cat /etc/hosts | awk 'END{print $1}' | sed -r -e 's/[0-9]+$/1/g')
+  fi
 fi
 
 exec docker-php-entrypoint "$@"

--- a/dist/bin/tissue-entrypoint.sh
+++ b/dist/bin/tissue-entrypoint.sh
@@ -3,6 +3,7 @@ set -e
 
 if [[ "$APP_DEBUG" == "true" ]]; then
   export PHP_INI_SCAN_DIR=":/usr/local/etc/php/php.d"
+  export PHP_XDEBUG_REMOTE_HOST=$(cat /etc/hosts | awk 'END{print $1}' | sed -r -e 's/[0-9]+$/1/g')
 fi
 
 exec docker-php-entrypoint "$@"

--- a/dist/php.d/99-xdebug.ini
+++ b/dist/php.d/99-xdebug.ini
@@ -1,4 +1,4 @@
 ; Dockerでのデバッグ用設定
 zend_extension=xdebug.so
 xdebug.remote_enable=true
-xdebug.remote_host=host.docker.internal
+xdebug.remote_host=${PHP_XDEBUG_REMOTE_HOST}


### PR DESCRIPTION
コンテナ用のxdebug設定ではコールバック先を `host.docker.internal` に決め打ちしていましたが、これはDocker for Windows/Macで暗黙に定義されるホスト名であるため、Linux環境では使えません。

そのため、試しに `host.docker.internal` が名前解決できるかテストしてみて、解決できればそのまま使用し、だめなら自身のIPv4アドレスの第4オクテットを 1 にしたものがホストのアドレスであると仮定するように変更しました。

……ソースはQiitaなんですけど、これ本当に良いんですかね？