### PR TITLE
名前入りチェックインビューのタイムスタンプに書字方向の属性を付与

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -59,7 +59,7 @@
                             <div class="d-flex justify-content-between">
                                 <h5>
                                     <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> {{ $ejaculation->user->display_name }}</a>
-                                    <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
+                                    <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted" dir="ltr"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
                                 </h5>
                                 <div>
                                     <a class="text-secondary timeline-action-item" href="{{ route('checkin', ['link' => $ejaculation->link, 'tags' => $ejaculation->textTags()]) }}"><span class="oi oi-reload" data-toggle="tooltip" data-placement="bottom" title="同じオカズでチェックイン"></span></a>

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -11,7 +11,7 @@
                 <div class="d-flex justify-content-between">
                     <h5>
                         <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> {{ $ejaculation->user->display_name }}</a>
-                        <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
+                        <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted" dir="ltr"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
                     </h5>
                     <div>
                         <a class="text-secondary timeline-action-item" href="{{ route('checkin', ['link' => $ejaculation->link, 'tags' => $ejaculation->textTags()]) }}"><span class="oi oi-reload" data-toggle="tooltip" data-placement="bottom" title="同じオカズでチェックイン"></span></a>

--- a/resources/views/timeline/public.blade.php
+++ b/resources/views/timeline/public.blade.php
@@ -15,7 +15,7 @@
                     <div class="d-flex justify-content-between">
                         <h5>
                             <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> {{ $ejaculation->user->display_name }}</a>
-                            <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
+                            <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted" dir="ltr"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
                         </h5>
                         <div>
                             <a class="text-secondary timeline-action-item" href="{{ route('checkin', ['link' => $ejaculation->link, 'tags' => $ejaculation->textTags()]) }}"><span class="oi oi-reload" data-toggle="tooltip" data-placement="bottom" title="同じオカズでチェックイン"></span></a>


### PR DESCRIPTION
一般的なRTL文字が名前に入るケースについて https://github.com/shikorism/tissue/issues/128#issuecomment-470662999 の手法で対策してみた。

refs #128 

## Screenshot
<img width="563" alt="Screenshot_20190319_232910" src="https://user-images.githubusercontent.com/1352154/54613903-daf09980-4a9e-11e9-8dd3-0f8b8806647c.png">
