### PR TITLE
manifest.jsonにテーマカラーを追加

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,6 +4,7 @@
     "description": "気持ちよくティッシュを使った、そのあとの感想戦。",
     "display": "minimal-ui",
     "start_url": "/",
+    "theme_color": "#e53fb1",
     "share_target": {
         "action": "/checkin",
         "method": "GET",


### PR DESCRIPTION
ホーム画面に追加したアイコンから起動すると、ブラウザ枠に色がつきます。

Chrome for Windows

![image](https://user-images.githubusercontent.com/705555/54763734-d9a7a400-4c39-11e9-9f8c-e57bcfa7a717.png)

Chrome for Android

![image](https://user-images.githubusercontent.com/705555/54765691-4cfee500-4c3d-11e9-8d94-ed2fcc24fadd.png)

