### PR TITLE
チェックインビュー上のdisplay_nameをbdiタグでマークアップ

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -58,7 +58,7 @@
                             <!-- span -->
                             <div class="d-flex justify-content-between">
                                 <h5>
-                                    <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> {{ $ejaculation->user->display_name }}</a>
+                                    <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> <bdi>{{ $ejaculation->user->display_name }}</bdi></a>
                                     <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
                                 </h5>
                                 <div>

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -10,7 +10,7 @@
                 <!-- span -->
                 <div class="d-flex justify-content-between">
                     <h5>
-                        <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> {{ $ejaculation->user->display_name }}</a>
+                        <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> <bdi>{{ $ejaculation->user->display_name }}</bdi></a>
                         <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
                     </h5>
                     <div>

--- a/resources/views/timeline/public.blade.php
+++ b/resources/views/timeline/public.blade.php
@@ -14,7 +14,7 @@
                     <!-- span -->
                     <div class="d-flex justify-content-between">
                         <h5>
-                            <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> {{ $ejaculation->user->display_name }}</a>
+                            <a href="{{ route('user.profile', ['id' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> <bdi>{{ $ejaculation->user->display_name }}</bdi></a>
                             <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
                         </h5>
                         <div>


### PR DESCRIPTION
名前欄の書字方向を独立させるためのマークアップとして `<bdi>` タグを使用してみた。 (https://github.com/shikorism/tissue/issues/128#issuecomment-474901827)

refs #128 

## Screenshot
<img width="587" alt="Screenshot_20190326_223525" src="https://user-images.githubusercontent.com/1352154/55001232-7d68c980-5017-11e9-9302-913a58ad0afb.png">
