### PR TITLE
グラフ画面で表示するデータ範囲を当月末までに制限

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -67,6 +67,8 @@ SQL
             abort(404);
         }
 
+        $dateUntil = now()->addMonth()->startOfMonth();
+
         $groupByDay = Ejaculation::select(DB::raw(
             <<<'SQL'
 to_char(ejaculated_date, 'YYYY/MM/DD') AS "date",
@@ -74,6 +76,7 @@ count(*) AS "count"
 SQL
         ))
             ->where('user_id', $user->id)
+            ->where('ejaculated_date', '<', $dateUntil)
             ->groupBy(DB::raw("to_char(ejaculated_date, 'YYYY/MM/DD')"))
             ->orderBy(DB::raw("to_char(ejaculated_date, 'YYYY/MM/DD')"))
             ->get();
@@ -85,6 +88,7 @@ count(*) AS "count"
 SQL
         ))
             ->where('user_id', $user->id)
+            ->where('ejaculated_date', '<', $dateUntil)
             ->groupBy(DB::raw("to_char(ejaculated_date, 'HH24')"))
             ->orderBy(DB::raw('1'))
             ->get();


### PR DESCRIPTION
グラフの表示範囲は当月までしか想定していなかったが、取得範囲を制限していないために未来のチェックインで障害を起こしていた。

当日まで・当月末までどちらにするかちょっと悩んだが、表示しているグラフがだいたい月単位で描画されているので当月末までとした。

fix #165 
