### PR TITLE
サムネイルを含むカードを高さ400pxに固定し、トリミング表示されるように変更

### DIFF
--- a/resources/assets/sass/components/_link-card.scss
+++ b/resources/assets/sass/components/_link-card.scss
@@ -1,8 +1,18 @@
 .link-card {
-  .row > div:last-child {
+  .row > div {
     max-height: 400px;
     overflow: hidden;
+  }
 
+  .row > div:first-child {
+    display: flex;
+
+    &:not([display=none]) {
+      height: 400px;
+    }
+  }
+
+  .row > div:last-child {
     // 省略を表す影を付けるやつ
     &::before {
       position: absolute;

--- a/resources/views/components/link-card.blade.php
+++ b/resources/views/components/link-card.blade.php
@@ -1,7 +1,7 @@
 <div class="card link-card mb-2 px-0 col-12 d-none" style="font-size: small;">
     <a class="text-dark card-link" href="{{ $link }}" target="_blank" rel="noopener">
         <div class="row no-gutters">
-            <div class="col-12 col-md-6">
+            <div class="col-12 col-md-6 justify-content-center align-items-center">
                 <img src="" alt="Thumbnail" class="card-img-top-to-left bg-secondary">
             </div>
             <div class="col-12 col-md-6">


### PR DESCRIPTION
大きな画像を表示した際に無制限に高さを取らないように、また今後プレースホルダを置きたくなった時の目安になるよう高さを固定します。

fix #137 