### PR TITLE
特定条件下においてタグ入力が正常に行えない問題の修正

### DIFF
--- a/resources/assets/js/checkin.js
+++ b/resources/assets/js/checkin.js
@@ -28,9 +28,11 @@ $('#tagInput').on('keydown', function (ev) {
             case 'Tab':
             case 'Enter':
             case ' ':
-                insertTag($this.val().trim());
-                $this.val('');
-                updateTags();
+                if (ev.originalEvent.isComposing !== true) {
+                    insertTag($this.val().trim());
+                    $this.val('');
+                    updateTags();
+                }
                 ev.preventDefault();
                 break;
         }


### PR DESCRIPTION
特定の環境(※今回事象が確認されたのはmacOS)において、全角文字を含むタグの入力が正常に行えない問題に対応する修正です。
Keyboard​Event​.isComposingが生えてない環境では従来通りの挙動となります。