### PR TITLE
MetadataResolverからタグ情報を保存できるようにする

### DIFF
--- a/app/Http/Controllers/Api/CardController.php
+++ b/app/Http/Controllers/Api/CardController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Metadata;
 use App\MetadataResolver\MetadataResolver;
+use App\Tag;
 use App\Utilities\Formatter;
 use Illuminate\Http\Request;
 
@@ -41,6 +42,13 @@ class CardController
                 'image' => $resolved->image,
                 'expires_at' => $resolved->expires_at
             ]);
+
+            $tagIds = [];
+            foreach ($resolved->tags as $tagName) {
+                $tag = Tag::firstOrCreate(['name' => $tagName]);
+                $tagIds[] = $tag->id;
+            }
+            $metadata->tags()->sync($tagIds);
         }
 
         $response = response($metadata);

--- a/app/Metadata.php
+++ b/app/Metadata.php
@@ -14,4 +14,9 @@ class Metadata extends Model
     protected $visible = ['url', 'title', 'description', 'image', 'expires_at'];
 
     protected $dates = ['created_at', 'updated_at', 'expires_at'];
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class)->withTimestamps();
+    }
 }

--- a/app/MetadataResolver/KomifloResolver.php
+++ b/app/MetadataResolver/KomifloResolver.php
@@ -34,6 +34,20 @@ class KomifloResolver implements Resolver
                 ($json['content']['parents'][0]['data']['title'] ?? '?');
             $metadata->image = 'https://t.komiflo.com/564_mobile_large_3x/' . $json['content']['named_imgs']['cover']['filename'];
 
+            // 作者情報
+            if (!empty($json['content']['attributes']['artists']['children'])) {
+                foreach ($json['content']['attributes']['artists']['children'] as $artist) {
+                    $metadata->tags[] = preg_replace('/\s/', '_', $artist['data']['name']);
+                }
+            }
+
+            // タグ
+            if (!empty($json['content']['attributes']['tags']['children'])) {
+                foreach ($json['content']['attributes']['tags']['children'] as $tag) {
+                    $metadata->tags[] = preg_replace('/\s/', '_', $tag['data']['name']);
+                }
+            }
+
             return $metadata;
         } else {
             throw new \RuntimeException("{$res->getStatusCode()}: $url");

--- a/app/MetadataResolver/Metadata.php
+++ b/app/MetadataResolver/Metadata.php
@@ -6,9 +6,21 @@ use Carbon\Carbon;
 
 class Metadata
 {
+    /** @var string タイトル */
     public $title = '';
+
+    /** @var string 概要 */
     public $description = '';
+
+    /** @var string サムネイルのURL */
     public $image = '';
-    /** @var Carbon|null */
+
+    /** @var Carbon|null メタデータの有効期限 */
     public $expires_at = null;
+
+    /**
+     * @var string[] タグ
+     * チェックインタグと同様に保存されるため、スペースや改行文字を含めてはいけません。
+     */
+    public $tags = [];
 }

--- a/database/migrations/2019_04_29_111019_create_metadata_tag_table.php
+++ b/database/migrations/2019_04_29_111019_create_metadata_tag_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMetadataTagTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('metadata_tag', function (Blueprint $table) {
+            $table->increments('id');
+            $table->text('metadata_url')->index();
+            $table->integer('tag_id')->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('metadata_tag');
+    }
+}


### PR DESCRIPTION
#105 を何かしらの形で実現するための下準備です。

metadata テーブルと tags テーブルにリレーションを設定し、タグ情報の保存をサポートします。

また、Resolver側実装サンプルとして、KomifloResolverとPixivResolverで実際にタグを保存するようにしました。

ref #40 