### PR TITLE
.env.exampleにTEST_USE_HTTP_MOCKを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost
 
+# テストにモックを使用するか falseの場合は実際のHTML等を取得してテストする
+TEST_USE_HTTP_MOCK=true
+
 DB_CONNECTION=pgsql
 DB_HOST=db
 DB_PORT=5432


### PR DESCRIPTION
READMEのテストの項目にも追記するべきかもしれない（乱用されると困るかも）