### PR TITLE
PixivResolverのタグ抽出がおそらく「R-18」を無視できていないのを修正

### DIFF
--- a/app/MetadataResolver/PixivResolver.php
+++ b/app/MetadataResolver/PixivResolver.php
@@ -76,7 +76,7 @@ class PixivResolver implements Resolver
             }
 
             // 一部の固定キーワードは無視
-            if (array_search($keyword, ['R-18', 'イラスト', 'pixiv', 'ピクシブ'], true)) {
+            if (array_search($keyword, ['R-18', 'イラスト', 'pixiv', 'ピクシブ'], true) !== false) {
                 continue;
             }
 


### PR DESCRIPTION
`array_search()`  の戻り値は、見つからなければ `FALSE`、見つかれば 0 以上のインデックス。

たぶんこの修正前の式だと「R-18」(index 0)を素通ししてしまう。