### PR TITLE
イラストURLの取得の仕方を変更

### DIFF
--- a/app/MetadataResolver/PixivResolver.php
+++ b/app/MetadataResolver/PixivResolver.php
@@ -96,7 +96,7 @@ class PixivResolver implements Resolver
      * @param int    $page 参照するページ
      * @return string i.pixiv.cat URL
      */
-    public function createProxyURL(int $illustId, string $illustExt = jpg, bool $isManga = false, int $page = 0): string
+    public function createProxyURL(int $illustId, string $illustExt = 'jpg', bool $isManga = false, int $page = 0): string
     {
         // 拡張子はjpg png gifの場合があるが、わざわざ判別するためにjson読むのもめんどくさいしjpgで問題ないのでjpgにしている
         $url = 'https://pixiv.cat/' . $illustId . '.' . $illustExt;


### PR DESCRIPTION
IDとページから作成するように

fix #195

テストは書いてませんが`mode=medium`の新旧、`mode=manga_big`は動くことを確認したのでマージしても問題ないはずです。

これがマージされたら #189 のテストを対応するように変更します。