### PR TITLE
iOS対策 カード省略グラデーションの透明色指定をtransparentからrgba()に変更

### DIFF
--- a/resources/assets/sass/components/_link-card.scss
+++ b/resources/assets/sass/components/_link-card.scss
@@ -21,7 +21,7 @@
       width: 100%;
       height: 100%;
       content: '';
-      background: linear-gradient(transparent 320px, white);
+      background: linear-gradient(rgba(255, 255, 255, 0) 320px, white);
     }
   }
 


### PR DESCRIPTION
たぶん参考資料の通りの現象だと思うので、雰囲気で修正した。

iOSデバイスを持ってないので確かめられない(絶望) おのれAppleめ……

## 参考
* https://glatchdesign.com/blog/web/css/1254
* https://qiita.com/takanorip/items/4e8d4c92bcbc34a954bb

fix #200