### PR TITLE
平均記録を直近30チェックインから算出するように変更

### DIFF
--- a/resources/views/components/profile-stats.blade.php
+++ b/resources/views/components/profile-stats.blade.php
@@ -8,7 +8,7 @@
 @endif
 
 <h6 class="font-weight-bold"><span class="oi oi-graph"></span> 概況</h6>
-<p class="card-text mb-0">平均記録: {{ Formatter::formatInterval($summary[0]->average) }}</p>
+<p class="card-text mb-0">平均記録: {{ Formatter::formatInterval($average[0]->average) }}</p>
 <p class="card-text mb-0">最長記録: {{ Formatter::formatInterval($summary[0]->longest) }}</p>
 <p class="card-text mb-0">最短記録: {{ Formatter::formatInterval($summary[0]->shortest) }}</p>
 <p class="card-text mb-0">合計時間: {{ Formatter::formatInterval($summary[0]->total_times) }}</p>


### PR DESCRIPTION
利用していなかった期間の長いユーザーの場合に実態とかけ離れてしまうのを軽減したいのと、現状に近い値が取れたほうが分かりやすいのではないかという意図があります。

でもこのSQLの投げかたは、なんかなあ……