### PR TITLE
ユーザー入力テキストをLinkifyする時に target="_blank" rel="noopener" を付与する

### DIFF
--- a/app/Utilities/Formatter.php
+++ b/app/Utilities/Formatter.php
@@ -35,7 +35,7 @@ class Formatter
      */
     public function linkify($text)
     {
-        return $this->linkify->processUrls($text);
+        return $this->linkify->processUrls($text, ['attr' => ['target' => '_blank', 'rel' => 'noopener']]);
     }
 
     /**


### PR DESCRIPTION
fix #218 

`Formatter#linkify` でリンク化する際にオプションを設定して `target="_blank" rel="noopener"` が付くようにしました。

対象となるユーティリティメソッドは「チェックインのノート」「プロフィールの自己紹介」でしか使われていないので、全てに影響しても問題ないと判断しました。