### PR TITLE
Gravatarのデフォルトアイコンをretroにする

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -41,7 +41,7 @@ class User extends Authenticatable
     {
         $hash = md5(strtolower(trim($this->email)));
 
-        return '//www.gravatar.com/avatar/' . $hash . '?s=' . $size;
+        return '//www.gravatar.com/avatar/' . $hash . '?s=' . $size . '&d=retro';
     }
 
     /**


### PR DESCRIPTION
Gravatarのデフォルトのアイコンをretroにして別ユーザーで同じアイコンを使われないようにします。

![image](https://user-images.githubusercontent.com/3516343/60235045-6620cd00-98e1-11e9-9a56-2f877783571a.png)

現状デフォルトアイコンのユーザーが多くいいね一覧などでどれが誰だか分かりづらいのでこのPRを作りましたが、デフォルトアイコンがユニークなものだとユーザーは「アイコン変えなくてもいいか」と思ってしまう懸念もあります。