### PR TITLE
タグ入力確定時のフォールバック処理を追加

### DIFF
--- a/resources/assets/js/components/TagInput.vue
+++ b/resources/assets/js/components/TagInput.vue
@@ -46,6 +46,14 @@
                         }
                         event.preventDefault();
                         break;
+                    case 'Unidentified':
+                        // 実際にテキストボックスに入力されている文字を見に行く (フォールバック処理)
+                        if (event.srcElement && (event.srcElement as HTMLInputElement).value.slice(-1) == ' ') {
+                            this.tags.push(this.buffer);
+                            this.buffer = "";
+                            event.preventDefault();
+                        }
+                        break;
                 }
             } else if (event.key === "Enter") {
                 // 誤爆防止


### PR DESCRIPTION
fix #231 

本PRにおける現状の制約事項
・Androidだとスペース文字入力後にさらに文字を入力するかスペース文字を2回入力しないとタグ入力が確定されない。(キー入力確定時のキーイベントが拾えてないっぽい？)