### PR TITLE
DockerfileおよびCI環境をPHP 7.3にアップデート

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   build:
     docker:
-      - image: circleci/php:7.1-node-browsers
+      - image: circleci/php:7.3-node-browsers
         environment:
           APP_DEBUG: true
           APP_ENV: testing

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10-jessie as node
 
-FROM php:7.1-apache
+FROM php:7.3-apache
 
 ENV APACHE_DOCUMENT_ROOT /var/www/html/public
 


### PR DESCRIPTION
まず開発環境をPHP 7.3にします。

本番環境の更新が完了するまでは、PHP 7.1までの機能を使用してPHP 7.3で動作確認とします。  
この期間はなるべく短く済むようにします。

refs #245 