### PR TITLE
メールアドレスを変更可能にする

### DIFF
--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
 
 class SettingController extends Controller
 {
@@ -18,10 +19,18 @@ class SettingController extends Controller
         $inputs = $request->all();
         $validator = Validator::make($inputs, [
             'display_name' => 'required|string|max:20',
+            'email' => [
+                'required',
+                'string',
+                'email',
+                'max:255',
+                Rule::unique('users')->ignore(Auth::user()->email, 'email')
+            ],
             'bio' => 'nullable|string|max:160',
             'url' => 'nullable|url|max:2000'
         ], [], [
             'display_name' => '名前',
+            'email' => 'メールアドレス',
             'bio' => '自己紹介',
             'url' => 'URL'
         ]);
@@ -32,6 +41,7 @@ class SettingController extends Controller
 
         $user = Auth::user();
         $user->display_name = $inputs['display_name'];
+        $user->email = $inputs['email'];
         $user->bio = $inputs['bio'] ?? '';
         $user->url = $inputs['url'] ?? '';
         $user->save();

--- a/resources/views/setting/profile.blade.php
+++ b/resources/views/setting/profile.blade.php
@@ -32,9 +32,12 @@
             <small class="form-text text-muted">現在は変更できません。</small>
         </div>
         <div class="from-group mt-3">
-            <label for="name">メールアドレス</label>
-            <input id="name" name="name" type="text" class="form-control" value="{{ Auth::user()->email }}" disabled>
-            <small class="form-text text-muted">現在は変更できません。</small>
+            <label for="email">メールアドレス</label>
+            <input id="email" name="email" type="email" class="form-control {{ $errors->has('email') ? ' is-invalid' : '' }}" value="{{ old('email') ?? Auth::user()->email }}">
+
+            @if ($errors->has('email'))
+                <div class="invalid-feedback">{{ $errors->first('email') }}</div>
+            @endif
         </div>
         <div class="form-group mt-3">
             <label for="bio">自己紹介</label>


### PR DESCRIPTION
プロフィール設定上のメールアドレス欄を入力可能にします。

バリデーションルールは RegisterController からパクってきた。

fix #262 