### PR TITLE
ニコニコ静画のタグを取得する & テストの追加

### DIFF
--- a/app/MetadataResolver/NicoSeigaResolver.php
+++ b/app/MetadataResolver/NicoSeigaResolver.php
@@ -25,22 +25,18 @@ class NicoSeigaResolver implements Resolver
     public function resolve(string $url): Metadata
     {
         $res = $this->client->get($url);
-        if ($res->getStatusCode() === 200) {
-            $html = (string)$res->getBody();
-            $metadata = $this->ogpResolver->parse($html);
-            $crawler = new Crawler($html);
+        $html = (string)$res->getBody();
+        $metadata = $this->ogpResolver->parse($html);
+        $crawler = new Crawler($html);
 
-            // タグ
-            $excludeTags = ['R-15'];
-            $metadata->tags = array_values(array_diff($crawler->filter('.tag')->extract(['_text']), $excludeTags));
+        // タグ
+        $excludeTags = ['R-15'];
+        $metadata->tags = array_values(array_diff($crawler->filter('.tag')->extract(['_text']), $excludeTags));
 
-            // ページURLからサムネイルURLに変換
-            preg_match('~https?://(?:(?:sp\\.)?seiga\\.nicovideo\\.jp/seiga(?:/#!)?|nico\\.ms)/im(\\d+)~', $url, $matches);
-            $metadata->image = "https://lohas.nicoseiga.jp/thumb/${matches[1]}l?";
+        // ページURLからサムネイルURLに変換
+        preg_match('~https?://(?:(?:sp\\.)?seiga\\.nicovideo\\.jp/seiga(?:/#!)?|nico\\.ms)/im(\\d+)~', $url, $matches);
+        $metadata->image = "https://lohas.nicoseiga.jp/thumb/${matches[1]}l?";
 
-            return $metadata;
-        } else {
-            throw new \RuntimeException("{$res->getStatusCode()}: $url");
-        }
+        return $metadata;
     }
 }

--- a/app/MetadataResolver/NicoSeigaResolver.php
+++ b/app/MetadataResolver/NicoSeigaResolver.php
@@ -35,8 +35,8 @@ class NicoSeigaResolver implements Resolver
             $metadata->tags = array_values(array_diff($crawler->filter('.tag')->extract(['_text']), $excludeTags));
 
             // ページURLからサムネイルURLに変換
-            preg_match('~http://(?:(?:sp\\.)?seiga\\.nicovideo\\.jp/seiga(?:/#!)?|nico\\.ms)/im(\\d+)~', $url, $matches);
-            $metadata->image = "http://lohas.nicoseiga.jp/thumb/${matches[1]}l?";
+            preg_match('~https?://(?:(?:sp\\.)?seiga\\.nicovideo\\.jp/seiga(?:/#!)?|nico\\.ms)/im(\\d+)~', $url, $matches);
+            $metadata->image = "https://lohas.nicoseiga.jp/thumb/${matches[1]}l?";
 
             return $metadata;
         } else {

--- a/app/MetadataResolver/NicoSeigaResolver.php
+++ b/app/MetadataResolver/NicoSeigaResolver.php
@@ -3,6 +3,7 @@
 namespace App\MetadataResolver;
 
 use GuzzleHttp\Client;
+use Symfony\Component\DomCrawler\Crawler;
 
 class NicoSeigaResolver implements Resolver
 {
@@ -25,7 +26,13 @@ class NicoSeigaResolver implements Resolver
     {
         $res = $this->client->get($url);
         if ($res->getStatusCode() === 200) {
-            $metadata = $this->ogpResolver->parse($res->getBody());
+            $html = (string)$res->getBody();
+            $metadata = $this->ogpResolver->parse($html);
+            $crawler = new Crawler($html);
+
+            // タグ
+            $excludeTags = ['R-15'];
+            $metadata->tags = array_values(array_diff($crawler->filter('.tag')->extract(['_text']), $excludeTags));
 
             // ページURLからサムネイルURLに変換
             preg_match('~http://(?:(?:sp\\.)?seiga\\.nicovideo\\.jp/seiga(?:/#!)?|nico\\.ms)/im(\\d+)~', $url, $matches);

--- a/tests/Unit/MetadataResolver/NicoSeigaResolverTest.php
+++ b/tests/Unit/MetadataResolver/NicoSeigaResolverTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Unit\MetadataResolver;
+
+use App\MetadataResolver\NicoSeigaResolver;
+use Tests\TestCase;
+
+class NicoSeigaResolverTest extends TestCase
+{
+    use CreateMockedResolver;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (!$this->shouldUseMock()) {
+            sleep(1);
+        }
+    }
+
+    public function testSeiga()
+    {
+        $responseText = file_get_contents(__DIR__ . '/../../fixture/NicoSeiga/seiga.html');
+
+        $this->createResolver(NicoSeigaResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://seiga.nicovideo.jp/seiga/im9623750');
+        $this->assertSame('シャミ子 / まとけち さんのイラスト', $metadata->title);
+        $this->assertSame('シャミ子が悪いんだよ・・・', $metadata->description);
+        $this->assertSame('https://lohas.nicoseiga.jp/thumb/9623750l?', $metadata->image);
+        $this->assertSame(['アニメ', 'まちカドまぞく', 'シャミ子', 'シャドウミストレス優子', '吉田優子', '危機管理フォーム', 'シャミ子が悪いんだよ', '赤面', 'シャミ子は悪くないよ'], $metadata->tags);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://seiga.nicovideo.jp/seiga/im9623750', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
+
+    public function testShunga()
+    {
+        $responseText = file_get_contents(__DIR__ . '/../../fixture/NicoSeiga/shunga.html');
+
+        $this->createResolver(NicoSeigaResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://seiga.nicovideo.jp/seiga/im9232798');
+        $this->assertSame('ベッドのゆかりさん / せゆーら/Se-U-Ra さんのイラスト', $metadata->title);
+        $this->assertSame('待つ側の方がつよいってスマブラが伝えてきたので', $metadata->description);
+        $this->assertSame('https://lohas.nicoseiga.jp/thumb/9232798l?', $metadata->image);
+        $this->assertSame(['結月ゆかり', 'VOICEROID', '裸パーカー', '謎の光'], $metadata->tags);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://seiga.nicovideo.jp/seiga/im9232798', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
+}

--- a/tests/fixture/NicoSeiga/seiga.html
+++ b/tests/fixture/NicoSeiga/seiga.html
@@ -1,0 +1,88 @@
+
+
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html lang="ja" xmlns:og="http://ogp.me/ns#" xmlns:mixi="http://mixi-platform.com/ns#">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta http-equiv="Content-Script-Type" content="text/javascript">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<meta name="description" content="シャミ子が悪いんだよ・・・">
+<meta name="copyright" content="&copy; DWANGO Co., Ltd.">
+<meta name="keywords" content="アニメ,まちカドまぞく,シャミ子,シャドウミストレス優子,吉田優子">
+<meta name="google-site-verification" content="X1ARxKsFZK8gXr39X1KnF8tzHbcCj5lVZ-jQB0VwS-I" />
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:description" content="シャミ子が悪いんだよ・・・">
+<meta property="og:type" content="article" />
+<meta property="og:title" content="シャミ子 / まとけち さんのイラスト" />
+<meta property="og:url" content="http://seiga.nicovideo.jp/seiga/im9623750" />
+<meta property="og:description" content="シャミ子が悪いんだよ・・・" />
+<meta property="og:site_name" content="ニコニコ静画 (イラスト)" />
+<meta property="og:image" content="https://lohas.nicoseiga.jp/thumb/9623750i?1567848744" />
+<title>シャミ子 / まとけち さんのイラスト - ニコニコ静画 (イラスト)</title>
+<link rel="canonical" href="http://seiga.nicovideo.jp/seiga/im9623750" />
+<link rel="shortcut icon" href="/favicon.ico">
+<link rel="stylesheet" type="text/css" href="/css/common/common_l.css?pzsf3v">
+<link rel="stylesheet" type="text/css" href="/css/illust/common.css?201401061430">
+<link href="/css/login.css?201106241500" rel="stylesheet" type="text/css">
+<link href="/css/illust.css?201104270015" rel="stylesheet" type="text/css">
+<link href="/css/illust_list.css?201104270015" rel="stylesheet" type="text/css">
+<link href="/css/ichiba_2.css?201511242239" rel="stylesheet" type="text/css">
+<!--[if IE 7]>
+<link rel="stylesheet" type="text/css" href="/css/manga/ie7.css">
+<![endif]-->
+<script src="/js/common.min.js?q0xrj7" type="text/javascript"></script>
+<script src="/js/illust/common.min.js?xjmqae" type="text/javascript"></script>
+
+<body class="mode_2">
+<!--↓メインコンテンツ-->
+
+
+<div id="login_im_container">
+<div id="login_im_left">
+
+<!-- ▼Illust -->
+ <div id="login_im">
+
+  <div id="login_exp_area">
+      <img src="/img/login/title.png" alt="ログインすることで、フルサイズの画像を閲覧・コメントの投稿ができます。">
+  </div>
+  <table border="0" cellpadding="0" cellspacing="0" id="illust_area">
+  <tr>
+  <td>
+        <a id="link_thumbnail_main" href="/login/redirect?next_url=%2Fseiga%2Fim9623750">
+     <img src="https://lohas.nicoseiga.jp/thumb/9623750i?1567848744" alt="シャミ子">
+    </a></td>
+  </tr>
+  <tr>
+  <td>
+  <div class="lg_ttl_illust"><h1>シャミ子</h1></div>
+    <div class="lg_txt_illust">投稿者：<strong>まとけち</strong>&nbsp;さん</div>
+    <div class="lg_txt_illust">シャミ子が悪いんだよ・・・</div>
+
+  <div class="lg_txt_date">2019年09月07日 18:17:19 投稿</div>
+  <div class="lg_txt_illust"><span class="bold">登録タグ</span></div>
+  <div class="lg_box_tag">
+
+          &nbsp;<a href="/tag/%E3%82%A2%E3%83%8B%E3%83%A1" class="tag" rel="tag">アニメ</a>&nbsp;
+          &nbsp;<a href="/tag/%E3%81%BE%E3%81%A1%E3%82%AB%E3%83%89%E3%81%BE%E3%81%9E%E3%81%8F" class="tag" rel="tag">まちカドまぞく</a>&nbsp;
+          &nbsp;<a href="/tag/%E3%82%B7%E3%83%A3%E3%83%9F%E5%AD%90" class="tag" rel="tag">シャミ子</a>&nbsp;
+          &nbsp;<a href="/tag/%E3%82%B7%E3%83%A3%E3%83%89%E3%82%A6%E3%83%9F%E3%82%B9%E3%83%88%E3%83%AC%E3%82%B9%E5%84%AA%E5%AD%90" class="tag" rel="tag">シャドウミストレス優子</a>&nbsp;
+          &nbsp;<a href="/tag/%E5%90%89%E7%94%B0%E5%84%AA%E5%AD%90" class="tag" rel="tag">吉田優子</a>&nbsp;
+          &nbsp;<a href="/tag/%E5%8D%B1%E6%A9%9F%E7%AE%A1%E7%90%86%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0" class="tag" rel="tag">危機管理フォーム</a>&nbsp;
+          &nbsp;<a href="/tag/%E3%82%B7%E3%83%A3%E3%83%9F%E5%AD%90%E3%81%8C%E6%82%AA%E3%81%84%E3%82%93%E3%81%A0%E3%82%88" class="tag" rel="tag">シャミ子が悪いんだよ</a>&nbsp;
+          &nbsp;<a href="/tag/%E8%B5%A4%E9%9D%A2" class="tag" rel="tag">赤面</a>&nbsp;
+          &nbsp;<a href="/tag/%E3%82%B7%E3%83%A3%E3%83%9F%E5%AD%90%E3%81%AF%E6%82%AA%E3%81%8F%E3%81%AA%E3%81%84%E3%82%88" class="tag" rel="tag">シャミ子は悪くないよ</a>&nbsp;
+      </div>
+    </td>
+  </tr>
+  </table>
+</div>
+<!-- ▲Illust -->
+
+</div>
+</div>
+<!--↑メインコンテンツ-->
+</body>
+</html>

--- a/tests/fixture/NicoSeiga/shunga.html
+++ b/tests/fixture/NicoSeiga/shunga.html
@@ -1,0 +1,89 @@
+
+
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html lang="ja" xmlns:og="http://ogp.me/ns#" xmlns:mixi="http://mixi-platform.com/ns#">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta http-equiv="Content-Script-Type" content="text/javascript">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<meta name="description" content="待つ側の方がつよいってスマブラが伝えてきたので">
+<meta name="copyright" content="&copy; DWANGO Co., Ltd.">
+<meta name="keywords" content="R-15,結月ゆかり,VOICEROID,裸パーカー,謎の光">
+<meta name="google-site-verification" content="X1ARxKsFZK8gXr39X1KnF8tzHbcCj5lVZ-jQB0VwS-I" />
+<meta property="mixi:content-rating" content="1" />
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:description" content="待つ側の方がつよいってスマブラが伝えてきたので">
+<meta property="og:type" content="article" />
+<meta property="og:title" content="ベッドのゆかりさん / せゆーら/Se-U-Ra さんのイラスト" />
+<meta property="og:url" content="http://seiga.nicovideo.jp/seiga/im9232798" />
+<meta property="og:description" content="待つ側の方がつよいってスマブラが伝えてきたので" />
+<meta property="og:site_name" content="ニコニコ静画 (イラスト)" />
+<meta property="og:image" content="http://seiga.nicovideo.jp/img/shunga/adult_warning.png" />
+<title>ベッドのゆかりさん / せゆーら/Se-U-Ra さんのイラスト - ニコニコ静画 (イラスト)</title>
+<link rel="canonical" href="http://seiga.nicovideo.jp/seiga/im9232798" />
+<link rel="shortcut icon" href="/favicon.ico">
+<link rel="stylesheet" type="text/css" href="/css/common/common_l.css?pzsf3v">
+<link rel="stylesheet" type="text/css" href="/css/illust/common.css?201401061430">
+<link href="/css/login.css?201106241500" rel="stylesheet" type="text/css">
+<link href="/css/illust.css?201104270015" rel="stylesheet" type="text/css">
+<link href="/css/illust_list.css?201104270015" rel="stylesheet" type="text/css">
+<link href="/css/ichiba_2.css?201511242239" rel="stylesheet" type="text/css">
+<!--[if IE 7]>
+<link rel="stylesheet" type="text/css" href="/css/manga/ie7.css">
+<![endif]-->
+<script src="/js/common.min.js?q0xrj7" type="text/javascript"></script>
+<script src="/js/illust/common.min.js?xjmqae" type="text/javascript"></script>
+
+<body class="mode_2">
+<!--↓メインコンテンツ-->
+
+
+<div id="login_im_container">
+<div id="login_im_left">
+
+<!-- ▼Illust -->
+ <div id="login_im">
+
+  <div id="login_exp_area">
+      <img src="/img/login/title.png" alt="ログインすることで、フルサイズの画像を閲覧・コメントの投稿ができます。">
+  </div>
+  <table border="0" cellpadding="0" cellspacing="0" id="illust_area">
+  <tr>
+  <td>
+        <div style="color:#900;padding-top:10px;font-weight:bold;">
+    15歳未満の方には不適切な表現が含まれる可能性があるため<br>サムネイルを非表示にしています
+    </div>
+        <a id="link_thumbnail_main" href="/login/redirect?next_url=%2Fseiga%2Fim9232798">
+     <img src="/img/shunga/adult_warning.png" alt="ベッドのゆかりさん">
+
+    </a></td>
+  </tr>
+  <tr>
+  <td>
+  <div class="lg_ttl_illust"><h1>ベッドのゆかりさん</h1></div>
+    <div class="lg_txt_illust">投稿者：<strong>せゆーら/Se-U-Ra</strong>&nbsp;さん</div>
+    <div class="lg_txt_illust">待つ側の方がつよいってスマブラが伝えてきたので</div>
+
+  <div class="lg_txt_date">2019年05月07日 12:59:32 投稿</div>
+  <div class="lg_txt_illust"><span class="bold">登録タグ</span></div>
+  <div class="lg_box_tag">
+
+          &nbsp;<a href="/tag/R-15" class="tag" rel="tag">R-15</a>&nbsp;
+          &nbsp;<a href="/tag/%E7%B5%90%E6%9C%88%E3%82%86%E3%81%8B%E3%82%8A" class="tag" rel="tag">結月ゆかり</a>&nbsp;
+          &nbsp;<a href="/tag/VOICEROID" class="tag" rel="tag">VOICEROID</a>&nbsp;
+          &nbsp;<a href="/tag/%E8%A3%B8%E3%83%91%E3%83%BC%E3%82%AB%E3%83%BC" class="tag" rel="tag">裸パーカー</a>&nbsp;
+          &nbsp;<a href="/tag/%E8%AC%8E%E3%81%AE%E5%85%89" class="tag" rel="tag">謎の光</a>&nbsp;
+      </div>
+    </td>
+  </tr>
+  </table>
+</div>
+<!-- ▲Illust -->
+
+</div>
+</div>
+<!--↑メインコンテンツ-->
+</body>
+</html>


### PR DESCRIPTION
ニコニコ静画の解決の際、タグ情報を取得するようにした。春画の場合、確定で「R-15」タグが入ってくるので、これは省くようにしている。

また、サムネイルURLはhttpsに変更した。

refs #42 