### PR TITLE
タグ一覧画面を追加

### DIFF
--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Tag;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class TagController extends Controller
+{
+    public function index()
+    {
+        $tags = Tag::select(DB::raw(
+            <<<'SQL'
+tags.name,
+count(*) AS "checkins_count"
+SQL
+            ))
+            ->join('ejaculation_tag', 'tags.id', '=', 'ejaculation_tag.tag_id')
+            ->join('ejaculations', 'ejaculations.id', '=', 'ejaculation_tag.ejaculation_id')
+            ->where('ejaculations.is_private', false)
+            ->groupBy('tags.name')
+            ->orderByDesc('checkins_count')
+            ->orderBy('tags.name')
+            ->paginate(100);
+
+        return view('tag.index', compact('tags'));
+    }
+}

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -13,3 +13,6 @@ $primary: #e53fb1;
 // Components
 @import "components/ejaculation";
 @import "components/link-card";
+
+// Tag
+@import "tag/index";

--- a/resources/assets/sass/tag/_index.scss
+++ b/resources/assets/sass/tag/_index.scss
@@ -1,0 +1,22 @@
+.tags {
+  & > .btn-tag {
+    width: 100%;
+
+    .tag-name {
+      display: inline-block;
+      max-width: 80%;
+      overflow: hidden;
+      line-height: 40px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      vertical-align: middle;
+    }
+
+    .checkins-count {
+      display: inline-block;
+      line-height: 40px;
+      white-space: nowrap;
+      vertical-align: middle;
+    }
+  }
+}

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -79,6 +79,9 @@
                         <li class="nav-item {{ stripos(Route::currentRouteName(), 'user.okazu') === 0 ? 'active' : ''}}">
                             <a class="nav-link" href="{{ route('user.okazu', ['name' => Auth::user()->name]) }}">オカズ</a>
                         </li>
+                        <li class="nav-item {{ stripos(Route::currentRouteName(), 'tag') === 0 ? 'active' : ''}}">
+                            <a class="nav-link" href="{{ route('tag') }}">タグ一覧</a>
+                        </li>
                         {{--<li class="nav-item">
                             <a class="nav-link" href="{{ route('ranking') }}">ランキング</a>
                         </li>--}}

--- a/resources/views/tag/index.blade.php
+++ b/resources/views/tag/index.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.base')
+
+@section('title', 'タグ一覧')
+
+@section('content')
+    <div class="container pb-1">
+        <h2 class="mb-3">タグ一覧</h2>
+        <p class="text-secondary">公開チェックインに付けられているタグを、チェックイン数の多い順で表示しています。</p>
+    </div>
+    <div class="container-fluid">
+        <div class="row mx-1">
+            @foreach($tags as $tag)
+                <div class="col-12 col-lg-6 col-xl-3 py-3 text-break tags">
+                    <a href="{{ route('search', ['q' => $tag->name]) }}" class="btn btn-outline-primary btn-tag" title="{{ $tag->name }}"><span class="tag-name">{{ $tag->name }}</span> <span class="checkins-count">({{ $tag->checkins_count }})</span></a>
+                </div>
+            @endforeach
+        </div>
+        {{ $tags->links(null, ['className' => 'mt-4 justify-content-center']) }}
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,8 @@ Route::redirect('/search', '/search/checkin', 301);
 Route::get('/search/checkin', 'SearchController@index')->name('search');
 Route::get('/search/related-tag', 'SearchController@relatedTag')->name('search.related-tag');
 
+Route::get('/tag', 'TagController@index')->name('tag');
+
 Route::middleware('can:admin')
     ->namespace('Admin')
     ->prefix('admin')


### PR DESCRIPTION
どのようなタグが使われているかを一覧化し、気になるタグからオカズへ到達しやすくするため、タグ一覧画面を作成しました。

### 仕様
- 公開チェックインに紐付いているタグを1ページあたり100件ずつ表示しています
- ソート順は1.チェックイン数の降順、2.タグ名の昇順の順番です
- 最大4列表示
- タグ名が長い場合、後半を一部省略して表示 (マウスオーバーで全量表示可)

### 課題
- ボタンの色どうしよう(今は検索の「関連するタグ」に色を合わせてピンクにしている)
- どこかで使いまわしたりするならタグボタンをcomponentsに切り出した方がいい？
- タグ画面はログイン必須にする？(お総菜コーナーはログイン必須だが検索は非ログイン状態でも可能であったため、いったん検索側の仕様に倒してます)