### PR TITLE
NijieResolver: JSONデコード後にHTMLエンティティのデコードを行う

### DIFF
--- a/app/MetadataResolver/NijieResolver.php
+++ b/app/MetadataResolver/NijieResolver.php
@@ -36,11 +36,15 @@ class NijieResolver implements Resolver
         $metadata = $this->ogpResolver->parse($html);
         $crawler = new Crawler($html);
 
-        // DomCrawler内でjson内の日本語がHTMLエンティティに変換されるのでhtml_entity_decode
-        $json = html_entity_decode($crawler->filter('script[type="application/ld+json"]')->first()->text());
+        $json = $crawler->filter('script[type="application/ld+json"]')->first()->text();
 
         // 改行がそのまま入っていることがあるのでデコード前にエスケープが必要
         $data = json_decode(preg_replace('/\r?\n/', '\n', $json), true);
+
+        // DomCrawler内でjson内の日本語がHTMLエンティティに変換されるので、全要素に対してhtml_entity_decode
+        array_walk_recursive($data, function (&$v) {
+            $v = html_entity_decode($v);
+        });
 
         $metadata->title = $data['name'];
         $metadata->description = '投稿者: ' . $data['author']['name'] . PHP_EOL . $data['description'];

--- a/tests/Unit/MetadataResolver/NijieResolverTest.php
+++ b/tests/Unit/MetadataResolver/NijieResolverTest.php
@@ -129,4 +129,23 @@ class NijieResolverTest extends TestCase
             $this->assertSame('https://nijie.info/view.php?id=66384', (string) $this->handler->getLastRequest()->getUri());
         }
     }
+
+    public function testHasHtmlInAuthorProfile()
+    {
+        $responseText = file_get_contents(__DIR__ . '/../../fixture/Nijie/testHasHtmlInAuthorProfileResponse.html');
+
+        $this->createResolver(NijieResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://nijie.info/view.php?id=285698');
+        $this->assertSame('ＪＫ文化祭コスプレ喫茶', $metadata->title);
+        $this->assertSame('投稿者: ままままま' . PHP_EOL .
+            'https://www.pixiv.net/fanbox/creator/32045169' . PHP_EOL .
+            'ピクシブのファンボックスでこっちに上げてた一次創作のノリでえっちなやつ描いてます' . PHP_EOL .
+            '二次創作のえっちなやつは相変わらずこっち' . PHP_EOL . '健全目なのはついったー', $metadata->description);
+        $this->assertSame('https://pic.nijie.net/02/nijie_picture/540086_20181028112046_0.png', $metadata->image);
+        $this->assertSame(['バニーガール'], $metadata->tags);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://nijie.info/view.php?id=285698', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
 }

--- a/tests/fixture/Nijie/testHasHtmlInAuthorProfileResponse.html
+++ b/tests/fixture/Nijie/testHasHtmlInAuthorProfileResponse.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml" lang="ja" xml:lang="ja"><head><link rel="alternate" media="handheld" href="http://mb.nijie.info/view.php?id=285698" /><link rel="alternate" media="only screen and (max-width: 640px)" href="https://sp.nijie.info/view.php?id=285698" /><link rel="canonical"  href="https://nijie.info/view.php?id=285698" /><meta http-equiv="X-UA-Compatible" content="IE=edge" /><meta name="viewport" content="width=970" /><meta name="format-detection" content="telephone=no" /><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><meta http-equiv="Content-Style-Type" content="text/css; charset=utf-8" /><meta http-equiv="Content-Script-Type" content="text/javascript" /><meta http-equiv="Content-Language" content="ja" /><meta name="description" content="ニジエに投稿された、まままままのイラスト「ＪＫ文化祭コスプレ喫茶」です。この画像はＪＫ文化祭コスプレ喫茶,ままままま,バニーガール,に関連があります。「https://www.pixiv.net/fanbox/creator/32045169
+ピクシブのファンボックスでこっちに上げてた一次創作のノリでえっちなやつ描いてます
+二次創作のえっちなやつは相変わらずこっち
+健全目なのはついったー」" /><meta name="keywords" content="ＪＫ文化祭コスプレ喫茶,ままままま,バニーガール," /><meta property="og:title" content="ＪＫ文化祭コスプレ喫茶 | ままままま" /><meta property="og:type" content="article" /><meta property="og:description" content="https://www.pixiv.net/fanbox/creator/32045169
+ピクシブのファンボックスでこっちに上げてた一次創作のノリでえっちなやつ描いてます
+二次創作のえっちなやつは相変わらずこっち
+健全目なのはついったー" /><meta property="og:url" content="https://nijie.info/view.php?id=285698" /><meta property="og:image" content="https://nijie.info/pic/logo/nijie_logo_og.png?201909291446" /><meta property="og:site_name" content="ＪＫ文化祭コスプレ喫茶 | ままままま | ニジエ" /><meta property="og:email" content="info@nijie.co.jp" /><link rel="alternate" href="https://nijie.info/view.php?id=285698" hreflang="x-default" /><link rel="shortcut icon" href="https://nijie.info/icon/favicon.ico?201909291446" /><link rel="shortcut icon" type="image/vnd.microsoft.icon" href="https://nijie.info/pic/icon/nijie.png?201909291446" /><link rel="stylesheet" type="text/css" href="https://nijie.info/css/pc-css.css?201909291446" /><link rel="stylesheet" type="text/css" href="https://nijie.info/css/common.css?201909291446" /><link rel="stylesheet" type="text/css" href="https://nijie.info/css/css.php?css=jquery.lightbox-0.5&201909291446" media="screen" /><link rel="stylesheet" type="text/css" href="https://nijie.info/css/select2.css?201909291446"/><link rel="stylesheet" type="text/css" href="https://nijie.info/css/font_awesome/all.css?201909291446"/><link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/earlyaccess/mplus1p.css" /><link rel="stylesheet" type="text/css" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/ui-lightness/jquery-ui.css"><link rel="stylesheet" type="text/css" href="https://nijie.info/css/view.css?201909291446" /><link rel="stylesheet" type="text/css" href="https://nijie.info/css/login.css?201909291446" /><link rel="stylesheet" type="text/css" href="https://nijie.info/css/view_login.css?201909291446" /><link rel="stylesheet" type="text/css" href="https://nijie.info/css/view_comment.css?201909291446" /><link rel="stylesheet" type="text/css" href="https://nijie.info/css/view_button.css?201909291446" /><script type="text/javascript" src="https://nijie.info/js/jquery.min.js?201909291446"></script><script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script><!--[if lt IE 9]><script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]--><script type="text/javascript" src="https://nijie.info/js/login.js?201909291446"></script><title>ＪＫ文化祭コスプレ喫茶 | ままままま | ニジエ</title></head><body >
+<div id="h_container"><h1>ＪＫ文化祭コスプレ喫茶 | ままままま</h1></div><div id="header-login-container"><div id="header"><div id="head-width"><div id="header-left-in"><div id="logo_centering"><div class="float-left"><p><em>描け、抜け、学べ</em></p><p><a href="/login.php?url=0fba6bedc9af1247b376f5d1b7667a7def173c99:iXUwVQwxMG1lcCFoGGw1fX18WFwxUR0hADhMND1RbV14CAAEA"><img src="//nijie.info/pic/logo/nijie_logo_small.png?201310" width="114" alt="ニジエ" /></a></p></div></div></div><div id="header_banner_wrapper"><div id="banner"><a href="/avtsm.php?id=3443" target="_blank" ad_id="3443" class="_ad"><img src="//pic.nijie.net/01/banner/61c1b8c56e206f670ffd8e7a2f56adf40441e269.gif" /></a>
+</div></div>
+<div id="header-right"><p style="font-size:13px;font-weight: bold;">イラストを投稿・閲覧できるSNSです！</p><div id="login_slide"><p class="register"><a href="https://nijie.info/touroku.php" style="width:225px;">会員登録しよう！(無料)</a></p></div><div class="sub_login_button"><a href="https://nijie.info/login.php?url=0fba6bedc9af1247b376f5d1b7667a7def173c99:iXUwVQwxMG1lcCFoGGw1fX18WFwxUR0hADhMND1RbV14CAAEA">登録済みの方はコチラからログイン！&nbsp;&raquo;</a></div></div></div></div></div>
+<script type="application/ld+json">{"@context": "http://schema.org","@type": "ImageObject","name": "ＪＫ文化祭コスプレ喫茶","description": "https://www.pixiv.net/fanbox/creator/32045169
+ピクシブのファンボックスでこっちに上げてた一次創作のノリでえっちなやつ描いてます
+二次創作のえっちなやつは相変わらずこっち
+健全目なのはついったー","text": "https://www.pixiv.net/fanbox/creator/32045169
+ピクシブのファンボックスでこっちに上げてた一次創作のノリでえっちなやつ描いてます
+二次創作のえっちなやつは相変わらずこっち
+健全目なのはついったー","interactionCount": "5253 UserPlays, 1 UserComments","datePublished": "Sun Oct 28 11:20:47 2018","uploadDate": "Sun Oct 28 11:20:47 2018","dateModified": "Sat Aug 31 17:15:22 2019","copyrightYear": "2019","genre":"Image","contentLocation":"Japan","width":160,"height":90,"thumbnailUrl": "https://pic.nijie.net/02/__rs_l160x160/nijie_picture/540086_20181028112046_0.png","author": {"@type": "Person","name": "ままままま","description": "&lt;font color=&quot;#ff2b3a&quot;&gt;&lt;strong&gt;Ｈ&lt;/strong&gt;&lt;/font&gt;
+な
+絵
+の
+練習するよ！","sameAs": "https://nijie.info/members.php?id=540086","image": "https://pic.nijie.net/02/__rs_cs150x150/members_picture/540086_1508801752.png"},"creator": {"@type": "Person","name": "ままままま","description": "&lt;font color=&quot;#ff2b3a&quot;&gt;&lt;strong&gt;Ｈ&lt;/strong&gt;&lt;/font&gt;
+な
+絵
+の
+練習するよ！","sameAs": "https://nijie.info/members.php?id=540086","image": "https://pic.nijie.net/02/__rs_cs150x150/members_picture/540086_1508801752.png"},"editor": {"@type": "Person","name": "ままままま","description": "&lt;font color=&quot;#ff2b3a&quot;&gt;&lt;strong&gt;Ｈ&lt;/strong&gt;&lt;/font&gt;
+な
+絵
+の
+練習するよ！","sameAs": "https://nijie.info/members.php?id=540086","image": "https://pic.nijie.net/02/__rs_cs150x150/members_picture/540086_1508801752.png"},"copyrightHolder": {"@type": "Person","name": "ままままま","description": "&lt;font color=&quot;#ff2b3a&quot;&gt;&lt;strong&gt;Ｈ&lt;/strong&gt;&lt;/font&gt;
+な
+絵
+の
+練習するよ！","sameAs": "https://nijie.info/members.php?id=540086","image": "https://pic.nijie.net/02/__rs_cs150x150/members_picture/540086_1508801752.png"}}</script>
+<div id="main"><div class="login"><div class="login_view_container"><div id="login_illust"><div id="login_members_picture"><img src="//pic.nijie.net/02/__rs_cs150x150/members_picture/540086_1508801752.png" width="50" height="50" alt="ままままま" /></div><div id="login_illust_detail"><h2 class="title">ＪＫ文化祭コスプレ喫茶</h2><h3 class="user_name">by&nbsp;<a href="/members.php?id=540086">ままままま</a></h3></div></div><div class="r-18_image"><div class="warning_illust">まずは無料登録！ニジエに登録して、お絵かきをもっと楽しもう！！</div><div class="nijie_regist"><a href="https://nijie.info/touroku.php">無料登録してこの絵を見る</a></div><div class="twitter_regist"><a href="https://nijie.info/login_twitter.php?url=0fba6bedc9af1247b376f5d1b7667a7def173c99:iXUwVQwxMG1lcCFoGGw1fX18WFwxUR0hADhMND1RbV14CAAEA" class="twit-button">Twitterで簡単アカウント登録</a></div><div class="login_regist"><div class="image"><img class="mozamoza ngtag" illust_id="285698" user_id="540086" itemprop="image" src="//pic.nijie.net/02/__rs_cns30x30/nijie_picture/540086_20181028112046_0.png" alt="ＪＫ文化祭コスプレ喫茶" style="display:none;"  /></div></div></div><p class="illust_description"><a href="/jump.php?url=ff9bcae16eb24f0702e89addb175a23ce2ff1f3b:iXUwVQ0VZGxhCFURNRQ1JUEYXDwBFHwBRCAFdHh8FFwNWQldKHQcAVQENUAUP" target="_blank">https://www.pixiv.net/fanbox/creator/32045169</a><br />
+ピクシブのファンボックスでこっちに上げてた一次創作のノリでえっちなやつ描いてます<br />
+二次創作のえっちなやつは相変わらずこっち<br />
+健全目なのはついったー</p><div id="view-tag"><ul><li class="tag" tag_id="140"><span class="tag_name"><a href="/dic/seiten/d/%E3%83%90%E3%83%8B%E3%83%BC%E3%82%AC%E3%83%BC%E3%83%AB">バニーガール</a></span></li><script>
+    $(function(){
+        $('#view-tag .tag').each(function(index){
+            var tag = $(this);
+
+            var url = location.href;
+            p = url.split('?');
+            paramms   = p[1].split('&');
+            p2 = paramms[0].split('=');
+            illust_id = p2[1] ;
+            $.getJSON('/php/ajax/view/tag_list.php',
+            {'tag_id':$(this).attr('tag_id'),
+             'illust_id': illust_id },
+            function(data){
+                if (data.error != '' && data.error != undefined) {
+                    alert(data.error);
+                } else {
+                    var obj_dic = $('<a style="margin-left:5px; float: left; position: relative; " target="_blank">');
+                    obj_dic.attr('href','/dic/seiten/d/'+encodeURIComponent(data.result.name));
+					obj_dic.attr('title', '"'+(data.result.name)+'"'+'に関する大性典記事');
+					obj_dic.attr('class', 'dic');
+
+                    var is_post_tag = "";
+                    if (data.result.is_status == "1") {
+                        is_post_tag = '<span class="tag_bold">*</span>';
+                    }
+                    $(tag).prepend(is_post_tag);
+
+                    if (data.result.dic_flg == "1") {
+                        dic_img = $('<img src="//nijie.info/pic/icon/dic.png" alt="バニーガール" style="height:12px;" />');
+                    } else {
+                        dic_img = $('<img src="//nijie.info/pic/icon/no_dic.png" alt="バニーガール" style="width:12px;height:12px;" />');
+                    }
+                    $(obj_dic).append(dic_img);
+                    $(tag).find('.tag_name').append(obj_dic);
+                }
+            });
+        });
+    });
+</script></ul></div><!-- このイラストにつけられたタグ等 --><div class="search_block"><div class="left"><p class="index">このイラストにつけられたタグ一覧</p><ul><li class="tag"><span class="tag_name"><a href="/search.php?word=%E3%83%90%E3%83%8B%E3%83%BC%E3%82%AC%E3%83%BC%E3%83%AB"><span class="size16">バニーガール</span>&nbsp;タグがついたイラストを見る</a></span></li></ul></div><div class="right"><p class="index">気になるタグがある？公開設定のイラストを検索してみよう！</p><div class="form" itemscope itemtype='https://schema.org/WebSite'><meta content='https://nijie.info/' itemprop='url'><form id="form" method="get" action="/search_all.php" itemprop="potentialAction" itemscope="itemscope" itemtype="https://schema.org/SearchAction"><meta content='/search_all.php?word={word}' itemprop='target'><input itemprop="query-input" placeholder="気になるタグがある？公開設定のイラストを検索してみよう！" name="word" class="word" type="text" value="" /><input type="image" src="/pic/seach.png" alt="検索" class="button" onClick="void(this.form.submit());return false" /></form></div><p class="sub_text">（例：おっぱい&nbsp;アナル&nbsp;ちっぱい）</p></div></div><!-- ここから絵に付けられたレコメンド等 --><div id="nuitahito_index"><p><strong>あなたにオススメのイラスト</strong></p></div><div id="nuitahito"><div id="carouselWrap-view"><p id="carouselPrev-view"><i class="fa fa-arrow-circle-left"></i></p><p id="carouselNext-view"><i class="fa fa-arrow-circle-right"></i></p><div id="carousel-view"><div id="carouselInner-view"><ul class="column"><li><a href="/view.php?id=299774"><img class="mozamoza ngtag" illust_id="299774" user_id="1016791" itemprop="image" src="//pic.nijie.net/04/__rs_l30x30/nijie_picture/1016791_20190204135432_0.jpg" alt="オナホと張り合う後輩さん" style="display:none;" style="height:120px;" /><br /></a></li><li><a href="/view.php?id=294211"><img class="mozamoza ngtag" illust_id="294211" user_id="80505" itemprop="image" src="//pic.nijie.net/01/__rs_l30x30/nijie_picture/80505_20181229010920_0.png" alt="アシュレイちゃん（アナザーコード）" style="display:none;" style="height:120px;" /><br /></a></li><li><a href="/view.php?id=263400"><img class="mozamoza ngtag" illust_id="263400" user_id="1000143" itemprop="image" src="//pic.nijie.net/04/__rs_l30x30/nijie_picture/1000143_20180520182811_0.jpg" alt="桐須真冬先生 足コキ！" style="display:none;" style="height:120px;" /><br /></a></li><li><a href="/view.php?id=165605"><img class="mozamoza ngtag" illust_id="165605" user_id="10543" itemprop="image" src="//pic.nijie.net/01/__rs_l30x30/nijie_picture/10543_20160411033626_0.jpg" alt="エルフとクリ" style="display:none;" style="height:120px;" /><br /></a></li></ul><ul class="column"><li><a href="/view.php?id=239382"><img class="mozamoza ngtag" illust_id="239382" user_id="647698" itemprop="image" src="//pic.nijie.net/04/__rs_l30x30/nijie_picture/647698_20171130014444_0.jpg" alt="前回のやつに" style="display:none;" style="height:120px;" /><br /></a></li><li><a href="/view.php?id=246146"><img class="mozamoza ngtag" illust_id="246146" user_id="2538" itemprop="image" src="//pic.nijie.net/02/__rs_l30x30/nijie_picture/2538_20180118233125_0.png" alt="よそのこガールズ　ﾅｵﾁｬﾝセレクション" style="display:none;" style="height:120px;" /><br /></a></li><li><a href="/view.php?id=242384"><img class="mozamoza ngtag" illust_id="242384" user_id="730314" itemprop="image" src="//pic.nijie.net/05/__rs_l30x30/nijie_picture/730314_20171224152214_0.jpg" alt="悪い子へのプレゼント" style="display:none;" style="height:120px;" /><br /></a></li><li><a href="/view.php?id=221569"><img class="mozamoza ngtag" illust_id="221569" user_id="80297" itemprop="image" src="//pic.nijie.net/01/__rs_l30x30/nijie_picture/80297_20170712223511_0.jpg" alt="眼鏡ＪＫフェラ" style="display:none;" style="height:120px;" /><br /></a></li></ul><ul class="column"><li><a href="/view.php?id=207227"><img class="mozamoza ngtag" illust_id="207227" user_id="158868" itemprop="image" src="//pic.nijie.net/02/__rs_l30x30/nijie_picture/158868_20170318180506_0.jpg" alt="大人の味" style="display:none;" style="height:120px;" /><br /></a></li><li><a href="/view.php?id=212875"><img class="mozamoza ngtag" illust_id="212875" user_id="4248" itemprop="image" src="//pic.nijie.net/02/__rs_l30x30/nijie_picture/4248_20170504001828_0.jpg" alt="すぐ犯されちゃうお姉さん" style="display:none;" style="height:120px;" /><br /></a></li><li><a href="/view.php?id=294934"><img class="mozamoza ngtag" illust_id="294934" user_id="42583" itemprop="image" src="//pic.nijie.net/02/__rs_l30x30/nijie_picture/42583_20190102171338_0.png" alt="あけまして" style="display:none;" style="height:120px;" /><br /></a></li><li><a href="/view.php?id=246255"><img class="mozamoza ngtag" illust_id="246255" user_id="752918" itemprop="image" src="//pic.nijie.net/05/__rs_l30x30/nijie_picture/752918_20180119221432_0.png" alt="yosonoko" style="display:none;" style="height:120px;" /><br /></a></li></ul></div></div></div></div><!-- コメント部分はじまり --><div id="comment_list_js"><script type="application/ld+json">{"@context": "http://schema.org","@type": "Review","reviewBody": "いいよね！","author": {"@type": "Person","name": "ままままま","description": "&lt;font color=&quot;#ff2b3a&quot;&gt;&lt;strong&gt;Ｈ&lt;/strong&gt;&lt;/font&gt;
+な
+絵
+の
+練習するよ！","sameAs": "https://nijie.info/members.php?id=540086","image": "http://pic.nijie.net/02/__rs_cs150x150/members_picture/540086_1508801752.png"},"datePublished": "Sun Oct 28 12:26:07 2018","contentLocation": "Japan","itemReviewed": {"@type" : "ImageObject","name" : "ＪＫ文化祭コスプレ喫茶","sameAs": "https://nijie.info/view.php?id=285698"}}</script><div class="members_comment_block"><div class="members_icon"><p><img src="//nijie.info/members_picture/nijie_noimage.jpg" alt="" width="50" /></p></div><div class="members_comment"><p class="text"><span><img src="//pic.nijie.net/02/stamp/stamp/55d343874bc6c71b698dc03aeb30416a20f58053_1452305630.png" alt="いいよね！" width="120" /></span></p><p class="members"><meta content="一丁のい" /><span>名無しのチンポップ</span></p><p class="comment_time">2018-10-28</p><!-- コメントに対してのリプライフォームとか --><div class="comment_reply_form_wapper comment-sub" style="display:none;"><div class="comment-sub-img"><p><img src="///__rs_cs150x150" width="40" height="40" alt="" /></p></div><div class="comment-sub-text"><form name="add_comment_reply" action="" method="post" class="comment_reply_form" id="add_comment_reply"><input type="text" name="reply" class="comment-reply-text" /><input type="hidden" name="comment_id" value="418173" /><input type="hidden" name="user_id" value="" /><input type="button" value="返信" class="comment-reply-submit" /></form><p><em>コメントEnterでこの書き込みに返信します</em></p></div></div><!-- コメントに対してのリプライ表示 --><div id="comment_last_418173"></div></div></div></div>
+</div><nav class="nijie_nav"><div class="nijie_nav_wrapper"><span>&nbsp;&gt;&nbsp;</span><span><a href="/search.php?word=%E7%9D%80%E8%A1%A3"><span>着衣</span></a></span><span>&nbsp;&gt;&nbsp;</span><span><a href="/search.php?word=%E5%88%B6%E6%9C%8D"><span>制服</span></a></span><span>&nbsp;&gt;&nbsp;</span><span><a href="/search.php?word=%E3%83%90%E3%83%8B%E3%83%BC%E3%82%AC%E3%83%BC%E3%83%AB"><span>バニーガール</span></a></span></div></nav></div></div>
+<script type="text/javascript">
+    $(function(){
+       $('#slide_login_button').on('click', function(){
+           $('#login_box').toggle();
+       });
+    });
+</script>
+<script type="text/javascript" src="https://platform.twitter.com/widgets.js"></script><script type="text/javascript" src="/js/view_filter.js?201909291446"></script><script type="text/javascript" src="/js/view_count.js?201909291446"></script><style type="text/css"><!--#nuitahito li {height:150px;}#nuitahito img {height:100%;}h3.login_name::before {content: "by";margin-right: 3px;}// --></style><div id="footer-banner"><p><a href="/avtsm.php?id=3309" target="_blank" ad_id="3309" class="_ad"><img src="//pic.nijie.net/02/banner/0890e34e0c5c430984f368bf98471230f862e892.png" /></a>
+</p></div>
+<div id="bottom"><div id="footer-centering"><div class="footer-block"><div class="footer-section"><ul><li><strong>おしらせとか</strong></li><li><a href="https://nijie.info/headline.php">お知らせ</a></li><li><a href="https://twitter.com/nijie_tan" target="_blank">運営Twitter</a></li><li><a href="https://twitter.com/nijieinfra" target="_blank">インフラTwitter</a></li></ul></div><div class="footer-section"><ul><li><strong>ニジエの利用について</strong></li><li><a href="https://nijie.info/manual.php">ニジエについて</a></li><li><a href="https://nijie.info/guide.php">利用規約</a></li><li><a href="https://nijie.info/inquiry_form.php">お問い合わせ</a></li><li><a href="https://nijie.info/statutes.php">特商法に基づく表記</a></li><li><a href="https://nijie.info/idea_search.php?sort=2">機能要望</a></li></ul></div><div class="footer-section"><ul><li><strong>サブコンテンツ</strong></li><li><a href="https://nijie.info/illust_view_ug.php">ニジエ裏</a></li><li><a href="https://nijie.info/lp.php?page=201701_nijie_stg">ニジエSTG</a></li><li><a href="https://nijie.info/dic/seiten/">ニジエ大性典</a></li><li><a href="https://nijie.info/kuyo.php">精子供養</a></li><li><a href="https://nijie.info/lp.php?page=nijie_shrine">ニジエ大明神</a></li></ul></div><div class="footer-section"><ul><li><strong>運用さーびす</strong></li><li><a href="https://nijie.info/">ニジエ</a></li><li><a href="http://horne.red/" target="_blank">ホルネ</a></li><li><a href="http://hi-na.info/" target="_blank">ひな</a></li><li><a href="http://emogin.net/" target="_blank">えもじん</a></li><li><a href="http://omata-pic.com/" target="_blank">omata-pic</a></li></ul></div><div class="footer-scroll"><p><a href="#header" class="scroll">ページ上部へ</a></p></div></div><div id="footer-address"><address>copyright&copy;&nbsp;2012-2019&nbsp;<a href="http://nijie.co.jp">株式会社ニジエ</a>&nbsp;All&nbsp;Rights&nbsp;Reserved.</address></div></div></div>
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-29617551-1', 'nijie.info');
+  ga('require', 'displayfeatures');
+  ga('send', 'pageview');
+  var dimensionValue = 0;
+  ga('set', 'dimension1', dimensionValue);
+  
+  var url = document.location.href.split("?");
+  
+  if(url.length != 1 && url.indexOf("inflow")){
+	  var custom = url[url.length - 1].split("=")[1];
+	  var dimensionValue = custom;
+	  ga('set', 'dimension3', dimensionValue);
+  }
+
+</script>
+<!-- 汎用script をfooter に移動 --><script type="text/javascript" src="https://nijie.info/js/common.js?201909291446"></script><script type="text/javascript" src="https://nijie.info/js/select2.js?201909291446"></script><script type="text/javascript" src="https://nijie.info/js/twitter.js?201909291446"></script><script type="text/javascript" src="https://nijie.info/js/nijie.js?201909291446"></script><script type="text/javascript" src="https://nijie.info/js/ad.js?201909291446"></script><script type="text/javascript" src="https://nijie.info/js/popup_balloon.js?201909291446"></script><script type="text/javascript" src="https://nijie.info/js/jquery.lightbox-0.5.js?201909291446"></script><script type="text/javascript" src="https://nijie.info/js/view_dojin.js?201909291446"></script><script type="text/javascript" src="https://nijie.info/js/ng_illust.js?201909291446"></script><div id="balloon_wrapper"></div><div id="balloon_wappar"></div><script type="application/ld+json">{"@context": "http://schema.org","@type": "BreadcrumbList","itemListElement":[{"@type": "ListItem","position": 1,"item":{"@id": "https://nijie.info/members.php?id=540086","name": "ままままま"}},{"@type": "ListItem","position": 2,"item":{"@id": "https://nijie.info/members_illust.php?id=540086","name": "まままままさんのイラスト一覧"}},{"@type": "ListItem","position": 3,"item":{"@id": "https://nijie.info/view.php?id=285698","name": "ＪＫ文化祭コスプレ喫茶"}}]}</script></body></html>
+


### PR DESCRIPTION
ニジエの作者プロフィールにはHTMLが含まれていることがあります。それが抽出対象のJSON内にエンティティ変換を施した状態で含まれていて、html_entity_decode()によって `&quot;` も巻き込んで解除してしまうことで、JSONを破壊してしまっていました。

html_entity_decode() のオプションで除外しても良いのですが、改行以外は一応JSONとして正当なはずですから、安全に倒してJSONとしてのデコードを済ませてから処理するように変更しました。