### PR TITLE
DLsiteResolver 新しいアフィリエイトURL構造に対応

### DIFF
--- a/app/MetadataResolver/DLsiteResolver.php
+++ b/app/MetadataResolver/DLsiteResolver.php
@@ -54,7 +54,7 @@ class DLsiteResolver implements Resolver
     {
         //アフィリエイトの場合は普通のURLに変換
         // ID型
-        if (strpos($url, '/dlaf/=/link/') !== false || preg_match('~/dlaf/=(/.+/.+)?/link/~', $url)) {
+        if (preg_match('~/dlaf/=(/.+/.+)?/link/~', $url)) {
             preg_match('~www\.dlsite\.com/(?P<genre>.+)/dlaf/=(/.+/.+)?/link/work/aid/(?P<AffiliateId>.+)/id/(?P<titleId>..\d+)(\.html)?~', $url, $matches);
             $url = "https://www.dlsite.com/{$matches['genre']}/work/=/product_id/{$matches['titleId']}.html";
         }

--- a/app/MetadataResolver/DLsiteResolver.php
+++ b/app/MetadataResolver/DLsiteResolver.php
@@ -53,17 +53,19 @@ class DLsiteResolver implements Resolver
     public function resolve(string $url): Metadata
     {
         //アフィリエイトの場合は普通のURLに変換
-        if (strpos($url, '/dlaf/=/link/') !== false) {
-            preg_match('~www\.dlsite\.com/(?P<genre>.+)/dlaf/=/link/work/aid/.+/id/(?P<titleId>..\d+)(\.html)?~', $url, $matches);
+        // ID型
+        if (strpos($url, '/dlaf/=/link/') !== false || preg_match('~/dlaf/=(/.+/.+)?/link/~', $url)) {
+            preg_match('~www\.dlsite\.com/(?P<genre>.+)/dlaf/=(/.+/.+)?/link/work/aid/(?P<AffiliateId>.+)/id/(?P<titleId>..\d+)(\.html)?~', $url, $matches);
             $url = "https://www.dlsite.com/{$matches['genre']}/work/=/product_id/{$matches['titleId']}.html";
         }
+        // URL型
         if (strpos($url, '/dlaf/=/aid/') !== false) {
             preg_match('~www\.dlsite\.com/.+/dlaf/=/aid/.+/url/(?P<url>.+)~', $url, $matches);
-            $affiliate_url = urldecode($matches['url']);
-            if (preg_match('~www\.dlsite\.com/.+/(work|announce)/=/product_id/..\d+(\.html)?~', $affiliate_url, $matches)) {
-                $url = $affiliate_url;
+            $affiliateUrl = urldecode($matches['url']);
+            if (preg_match('~www\.dlsite\.com/.+/(work|announce)/=/product_id/..\d+(\.html)?~', $affiliateUrl, $matches)) {
+                $url = $affiliateUrl;
             } else {
-                throw new \RuntimeException("アフィリエイト先のリンクがDLsiteのタイトルではありません: $affiliate_url");
+                throw new \RuntimeException("アフィリエイト先のリンクがDLsiteのタイトルではありません: $affiliateUrl");
             }
         }
 

--- a/app/MetadataResolver/MetadataResolver.php
+++ b/app/MetadataResolver/MetadataResolver.php
@@ -16,7 +16,7 @@ class MetadataResolver implements Resolver
         '~ec\.toranoana\.(jp|shop)/(tora|joshi)(_[rd]+)?/(ec|digi)/item/~' => ToranoanaResolver::class,
         '~iwara\.tv/(videos|images)/.*~' => IwaraResolver::class,
         '~www\.dlsite\.com/.*/(work|announce)/=/product_id/..\d+(\.html)?~' => DLsiteResolver::class,
-        '~www\.dlsite\.com/.*/dlaf/=/link/(work|announce)/aid/.+/..\d+(\.html)?~' => DLsiteResolver::class,
+        '~www\.dlsite\.com/.*/dlaf/=(/.+/.+)?/link/work/aid/.+(/id)?/..\d+(\.html)?~' => DLsiteResolver::class,
         '~www\.dlsite\.com/.*/dlaf/=/aid/.+/url/.+~' => DLsiteResolver::class,
         '~dlsite\.jp/...tw/..\d+~' => DLsiteResolver::class,
         '~www\.pixiv\.net/member_illust\.php\?illust_id=\d+~' => PixivResolver::class,

--- a/tests/Unit/MetadataResolver/DLsiteResolverTest.php
+++ b/tests/Unit/MetadataResolver/DLsiteResolverTest.php
@@ -227,13 +227,45 @@ class DLsiteResolverTest extends TestCase
         }
     }
 
-    public function testAffiliateLink()
+    public function testOldAffiliateLink()
     {
         $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testHome.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
         $metadata = $this->resolver->resolve('https://www.dlsite.com/home/dlaf/=/link/work/aid/eai04191/id/RJ221761.html');
+        $this->assertEquals('ひつじ、数えてあげるっ', $metadata->title);
+        $this->assertEquals('サークル名: Butterfly Dream' . PHP_EOL . '眠れないあなたに彼女が羊を数えてくれる音声です。', $metadata->description);
+        $this->assertEquals('https://img.dlsite.jp/modpub/images2/work/doujin/RJ222000/RJ221761_img_main.jpg', $metadata->image);
+        $this->assertEquals(['癒し', 'バイノーラル/ダミヘ', '日常/生活', 'ほのぼの', '恋人同士'], $metadata->tags);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://www.dlsite.com/home/work/=/product_id/RJ221761.html', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
+
+    public function testSnsAffiliateLink()
+    {
+        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testHome.html');
+
+        $this->createResolver(DLsiteResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://www.dlsite.com/home/dlaf/=/t/s/link/work/aid/eai04191/id/RJ221761.html');
+        $this->assertEquals('ひつじ、数えてあげるっ', $metadata->title);
+        $this->assertEquals('サークル名: Butterfly Dream' . PHP_EOL . '眠れないあなたに彼女が羊を数えてくれる音声です。', $metadata->description);
+        $this->assertEquals('https://img.dlsite.jp/modpub/images2/work/doujin/RJ222000/RJ221761_img_main.jpg', $metadata->image);
+        $this->assertEquals(['癒し', 'バイノーラル/ダミヘ', '日常/生活', 'ほのぼの', '恋人同士'], $metadata->tags);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://www.dlsite.com/home/work/=/product_id/RJ221761.html', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
+
+    public function testAffiliateLink()
+    {
+        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testHome.html');
+
+        $this->createResolver(DLsiteResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://www.dlsite.com/home/dlaf/=/t/t/link/work/aid/eai04191/id/RJ221761.html');
         $this->assertEquals('ひつじ、数えてあげるっ', $metadata->title);
         $this->assertEquals('サークル名: Butterfly Dream' . PHP_EOL . '眠れないあなたに彼女が羊を数えてくれる音声です。', $metadata->description);
         $this->assertEquals('https://img.dlsite.jp/modpub/images2/work/doujin/RJ222000/RJ221761_img_main.jpg', $metadata->image);


### PR DESCRIPTION
https://shikorism.net/checkin/5877 のように新しいアフィリエイトURLに対応していなかったので対応しました。
現状`/dlaf/=`の後に

- `/t/s`
- `/t/t`

が追加されただけのようですが、他の文字でもたぶん動きます。