### PR TITLE
空文字列のタグは保存せず捨てる

### DIFF
--- a/app/Http/Controllers/EjaculationController.php
+++ b/app/Http/Controllers/EjaculationController.php
@@ -65,6 +65,10 @@ class EjaculationController extends Controller
         if (!empty($inputs['tags'])) {
             $tags = explode(' ', $inputs['tags']);
             foreach ($tags as $tag) {
+                if ($tag === '') {
+                    continue;
+                }
+
                 $tag = Tag::firstOrCreate(['name' => $tag]);
                 $tagIds[] = $tag->id;
             }
@@ -151,6 +155,10 @@ class EjaculationController extends Controller
         if (!empty($inputs['tags'])) {
             $tags = explode(' ', $inputs['tags']);
             foreach ($tags as $tag) {
+                if ($tag === '') {
+                    continue;
+                }
+
                 $tag = Tag::firstOrCreate(['name' => $tag]);
                 $tagIds[] = $tag->id;
             }


### PR DESCRIPTION
新規作成・更新時に、空文字列のタグは捨てるように修正。

refs #295 

## メモ: 空タグの削除

```
$ docker-compose run --rm web php artisan tinker
# or
$ php artisan tinker

# ↓

$t = Tag::where("name", "=", "")->first()
DB::table("ejaculation_tag")->where("tag_id", $t->id")->delete()
$t->delete()

# TODO: 正しい消し方が分からない。FK張ればTagのModelをdeleteするだけで消える？
```
