### PR TITLE
MastodonのプロフィールURLをいい感じに表示する

### DIFF
--- a/app/MetadataResolver/ActivityPubResolver.php
+++ b/app/MetadataResolver/ActivityPubResolver.php
@@ -37,6 +37,10 @@ class ActivityPubResolver implements Resolver, Parser
         $activityOrObject = json_decode($json, true);
         $object = $activityOrObject['object'] ?? $activityOrObject;
 
+        if ($object['type'] !== 'Note') {
+            throw new UnsupportedContentException('Unsupported object type: ' . $object['type']);
+        }
+
         $metadata = new Metadata();
 
         $metadata->title = isset($object['attributedTo']) ? $this->getTitleFromActor($object['attributedTo']) : '';

--- a/app/MetadataResolver/UnsupportedContentException.php
+++ b/app/MetadataResolver/UnsupportedContentException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\MetadataResolver;
+
+use Exception;
+
+/**
+ * このResolverやParserが対応していないサイトであったことを表わします。
+ */
+class UnsupportedContentException extends Exception
+{
+}


### PR DESCRIPTION
fixes https://github.com/shikorism/tissue/issues/157

ActivityPubのActorは自分で頑張らんでもOGPResolverでいい感じに見れるでしょ、ということでそのようにしました。

なおMastodonの場合、アバターのURLはアップロードする度に変化するので、アバター変更されると画像のリンクは切れます。

<details>
<summary>sample</summary>

before:
![image](https://user-images.githubusercontent.com/705555/69494720-40383c80-0f02-11ea-830a-cfac14f18073.png)

after:
![image](https://user-images.githubusercontent.com/705555/69494700-1121cb00-0f02-11ea-8791-0afd5bcfb1c9.png)

</details>