### PR TITLE
PixivResolver 英語版に対応する

### DIFF
--- a/app/MetadataResolver/MetadataResolver.php
+++ b/app/MetadataResolver/MetadataResolver.php
@@ -20,7 +20,7 @@ class MetadataResolver implements Resolver
         '~www\.dlsite\.com/.*/dlaf/=/aid/.+/url/.+~' => DLsiteResolver::class,
         '~dlsite\.jp/...tw/..\d+~' => DLsiteResolver::class,
         '~www\.pixiv\.net/member_illust\.php\?illust_id=\d+~' => PixivResolver::class,
-        '~www\.pixiv\.net/artworks/\d+~' => PixivResolver::class,
+        '~www\.pixiv\.net/(en/)?artworks/\d+~' => PixivResolver::class,
         '~www\.pixiv\.net/user/\d+/series/\d+~' => PixivResolver::class,
         '~fantia\.jp/posts/\d+~' => FantiaResolver::class,
         '~dmm\.co\.jp/~' => FanzaResolver::class,

--- a/app/MetadataResolver/PixivResolver.php
+++ b/app/MetadataResolver/PixivResolver.php
@@ -45,8 +45,8 @@ class PixivResolver implements Resolver
         }
 
         $page = 0;
-        if (preg_match('~www\.pixiv\.net/artworks/(\d+)~', $url, $matches)) {
-            $illustId = $matches[1];
+        if (preg_match('~www\.pixiv\.net/(en/)?artworks/(?P<illustId>\d+)~', $url, $matches)) {
+            $illustId = $matches['illustId'];
         } else {
             parse_str(parse_url($url, PHP_URL_QUERY), $params);
             $illustId = $params['illust_id'];

--- a/tests/Unit/MetadataResolver/PixivResolverTest.php
+++ b/tests/Unit/MetadataResolver/PixivResolverTest.php
@@ -81,4 +81,20 @@ class PixivResolverTest extends TestCase
             $this->assertSame('https://www.pixiv.net/ajax/illust/68188073', (string) $this->handler->getLastRequest()->getUri());
         }
     }
+
+    public function testArtworkUrlEn()
+    {
+        $responseText = file_get_contents(__DIR__ . '/../../fixture/Pixiv/illust.json');
+
+        $this->createResolver(PixivResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://www.pixiv.net/en/artworks/68188073');
+        $this->assertEquals('coffee break', $metadata->title);
+        $this->assertEquals('投稿者: 裕' . PHP_EOL, $metadata->description);
+        $this->assertEquals('https://i.pixiv.cat/img-master/img/2018/04/12/00/01/28/68188073_p0_master1200.jpg', $metadata->image);
+        $this->assertEquals(['オリジナル', 'カフェ', '眼鏡', 'イヤホン', 'ぱっつん', '艶ぼくろ', '眼鏡っ娘', 'オリジナル5000users入り'], $metadata->tags);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://www.pixiv.net/ajax/illust/68188073', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
 }


### PR DESCRIPTION
`https://www.pixiv.net/en/artworks/~`のような形式に対応します。
今の所韓国語と中国語ではURLは変わらないようです。