### PR TITLE
phpunit.xml内の環境変数を強制適用する

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -27,9 +27,9 @@
         </whitelist>
     </filter>
     <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="QUEUE_DRIVER" value="sync"/>
+        <env name="APP_ENV" value="testing" force="true"/>
+        <env name="CACHE_DRIVER" value="array" force="true"/>
+        <env name="SESSION_DRIVER" value="array" force="true"/>
+        <env name="QUEUE_DRIVER" value="sync" force="true"/>
     </php>
 </phpunit>

--- a/tests/Feature/SettingTest.php
+++ b/tests/Feature/SettingTest.php
@@ -30,13 +30,9 @@ class SettingTest extends TestCase
             'ejaculation_id' => $ejaculation->id,
         ]);
 
-        $token = $this->getCsrfToken($user, '/setting/deactivate');
         $response = $this->actingAs($user)
             ->followingRedirects()
-            ->post('/setting/deactivate', [
-                '_token' => $token,
-                'password' => 'secret',
-            ]);
+            ->post('/setting/deactivate', ['password' => 'secret']);
 
         $response->assertStatus(200)
             ->assertViewIs('setting.deactivated');
@@ -46,19 +42,5 @@ class SettingTest extends TestCase
         $this->assertDatabaseMissing('likes', ['id' => $like->id]);
         $this->assertDatabaseMissing('likes', ['id' => $anotherLike->id]);
         $this->assertDatabaseHas('deactivated_users', ['name' => $user->name]);
-    }
-
-    /**
-     * テスト対象を呼び出す前にGETリクエストを行い、CSRFトークンを得る
-     * @param Authenticatable $user 認証情報
-     * @param string $uri リクエスト先
-     * @return string CSRFトークン
-     */
-    private function getCsrfToken(Authenticatable $user, string $uri): string
-    {
-        $response = $this->actingAs($user)->get($uri);
-        $crawler = new Crawler($response->getContent());
-
-        return $crawler->filter('input[name=_token]')->attr('value');
     }
 }


### PR DESCRIPTION
https://github.com/shikorism/tissue/pull/299#discussion_r357143108 への対応。

テスト時にはphpunit.xml内に記載されている環境変数が設定されていることが期待されるが、docker-composeで環境変数を設定していると上書きされてしまう。  
この挙動は思わぬ状態でテストが実行される原因になるので、phpunit.xml内でforce属性を付けて上書きされないようにする。