### PR TITLE
センシティブフラグのぼかしを画像にだけ適用するように変更

### DIFF
--- a/resources/assets/js/app.ts
+++ b/resources/assets/js/app.ts
@@ -91,9 +91,10 @@ $(() => {
         }
     });
 
-    $(document).on('click', '.card-spoiler-overlay', function (_event) {
+    $(document).on('click', '.card-spoiler-img-overlay', function (event) {
+        event.preventDefault();
         const $this = $(this);
-        $this.siblings('.card-link').removeClass('card-spoiler');
+        $this.closest('.card-link').removeClass('card-spoiler');
         $this.remove();
     });
 });

--- a/resources/assets/sass/components/_link-card.scss
+++ b/resources/assets/sass/components/_link-card.scss
@@ -31,7 +31,7 @@
     white-space: pre-line;
   }
 
-  .card-spoiler-overlay {
+  .card-spoiler-img-overlay {
     position: absolute;
     z-index: 1000;
     display: flex;
@@ -49,7 +49,7 @@
     }
   }
 
-  .card-spoiler {
+  .card-spoiler img {
     z-index: 1;
     filter: blur(15px) grayscale(100%);
   }

--- a/resources/views/components/link-card.blade.php
+++ b/resources/views/components/link-card.blade.php
@@ -1,12 +1,13 @@
 <div class="card link-card mb-2 px-0 col-12 d-none" style="font-size: small;">
-    @if ($is_too_sensitive)
-        <div class="card-spoiler-overlay">
-            <span class="warning-text">クリックまたはタップで表示</span>
-        </div>
-    @endif
+
     <a class="text-dark card-link {{ $is_too_sensitive ? 'card-spoiler' : '' }}" href="{{ $link }}" target="_blank" rel="noopener">
         <div class="row no-gutters">
             <div class="col-12 col-md-6 justify-content-center align-items-center">
+                @if ($is_too_sensitive)
+                    <div class="card-spoiler-img-overlay">
+                        <span class="warning-text">クリックまたはタップで表示</span>
+                    </div>
+                @endif
                 <img src="" alt="Thumbnail" class="w-100 bg-secondary">
             </div>
             <div class="col-12 col-md-6">


### PR DESCRIPTION
#270 で導入された過激なオカズを隠す機能ですが、実際に使われているのを見るとぼかしを解除するまでそれが何であるかが全く予想できないと感じたので、画像にだけ適用するように変更するPRです。

![2020-01-13_11-22-31_chrome](https://user-images.githubusercontent.com/3516343/72230245-7c7d4480-35f7-11ea-8a7a-9afcac725c01.png)

自分はこのほうが良いとおもうのですが、反対や他の意見があれば伺いたいです。
