### PR TITLE
statsのグラフでカーソルに近い位置のツールチップを表示する

### DIFF
--- a/resources/assets/js/user/stats.js
+++ b/resources/assets/js/user/stats.js
@@ -32,6 +32,10 @@ function createLineGraph(id, labels, data) {
                         beginAtZero: true
                     }
                 }]
+            },
+            tooltips: {
+                mode: 'index',
+                intersect: false,
             }
         }
     });
@@ -60,6 +64,10 @@ function createBarGraph(id, labels, data) {
                         beginAtZero: true
                     }
                 }]
+            },
+            tooltips: {
+                mode: 'index',
+                intersect: false,
             }
         }
     });


### PR DESCRIPTION
便利

## PC
![2020-02-03_01-02-05](https://user-images.githubusercontent.com/3516343/73611188-9b815c00-4622-11ea-826a-ef658afbed15.gif)

## スマホ
![2020-02-03_01-16-30](https://user-images.githubusercontent.com/3516343/73611206-d2577200-4622-11ea-8396-1f726efb6409.gif)