### PR TITLE
IDEからのデバッグ実行用ラッパーを追加

### DIFF
--- a/dist/bin/php-debug.sh
+++ b/dist/bin/php-debug.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+export APP_DEBUG=true
+exec tissue-entrypoint.sh php "$@"


### PR DESCRIPTION
PhpStormでデバッグ実行する時に使えるラッパーを追加します。

既存の状態ではなぜか上手く動いてくれなかったので、強制的にデバッグ有効でPHPのCLIを実行するようなものです。おま環かもしれないけど。

↓ここの "PHP executable" に指定して使っています  
<img width="591" alt="Screenshot_20200216_193904" src="https://user-images.githubusercontent.com/1352154/74603162-fec7bf80-50f3-11ea-9eeb-e722d94215f3.png">
