### PR TITLE
トップページのお惣菜表示量をお惣菜コーナー1ページ分にする

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -70,7 +70,7 @@ SQL
                 ->select('ejaculations.*')
                 ->with('user', 'tags')
                 ->withLikes()
-                ->take(10)
+                ->take(21)
                 ->get();
 
             return view('home')->with(compact('informations', 'categories', 'globalEjaculationCounts', 'publicLinkedEjaculations'));

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -60,7 +60,7 @@
                         </li>
                     @endforeach
                     <li class="list-group-item no-side-border text-right">
-                        <a href="{{ route('timeline.public') }}" class="stretched-link">もっと見る &raquo;</a>
+                        <a href="{{ route('timeline.public', ['page' => 2]) }}" class="stretched-link">もっと見る &raquo;</a>
                     </li>
                 </ul>
             @endif


### PR DESCRIPTION
表題に加えて「もっと見る」リンクの遷移先を2ページ目に変更しています。

fix #325 