### PR TITLE
メタデータのタグ重複対策

### DIFF
--- a/app/Console/Commands/DedupTags.php
+++ b/app/Console/Commands/DedupTags.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Tag;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class DedupTags extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'tissue:tag:dedup {--dry-run}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Deduplicate tags';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        if ($this->option('dry-run')) {
+            $this->warn('dry-runモードで実行します。');
+        } else {
+            if (!$this->confirm('dry-runオプションが付いてないけど、本当に実行しますか？')) {
+                return;
+            }
+        }
+
+        DB::transaction(function () {
+            $duplicatedTags = DB::table('tags')
+                ->select('name', DB::raw('count(*)'))
+                ->groupBy('name')
+                ->having(DB::raw('count(*)'), '>=', 2)
+                ->get();
+
+            $this->info($duplicatedTags->count() . ' duplicated tags found.');
+
+            foreach ($duplicatedTags as $tag) {
+                $this->line('Tag name: ' . $tag->name);
+
+                $tagIds = Tag::where('name', $tag->name)->orderBy('id')->pluck('id');
+                $newId = $tagIds->first();
+                $dropIds = $tagIds->slice(1);
+
+                $this->line('  New ID: ' . $newId);
+                $this->line('  Drop IDs: ' . $dropIds->implode(', '));
+
+                if ($this->option('dry-run')) {
+                    continue;
+                }
+
+                // 同じタグ名でIDが違うものについて、全て統一する
+                foreach (['ejaculation_tag', 'metadata_tag'] as $table) {
+                    DB::table($table)
+                        ->whereIn('tag_id', $dropIds)
+                        ->update(['tag_id' => $newId]);
+                }
+                DB::table('tags')->whereIn('id', $dropIds)->delete();
+
+                // 統一した上で、重複しているレコードを削除する
+                DB::delete(
+                    <<<SQL
+DELETE FROM ejaculation_tag
+WHERE id IN (
+    SELECT id
+    FROM (
+        SELECT id, row_number() OVER (PARTITION BY ejaculation_id, tag_id ORDER BY id) AS ord
+        FROM ejaculation_tag
+    ) t
+    WHERE ord > 1
+)
+SQL
+                );
+                DB::delete(
+                    <<<SQL
+DELETE FROM metadata_tag
+WHERE id IN (
+    SELECT id
+    FROM (
+        SELECT id, row_number() OVER (PARTITION BY metadata_url, tag_id ORDER BY id) AS ord
+        FROM metadata_tag
+    ) t
+    WHERE ord > 1
+)
+SQL
+                );
+            }
+        });
+
+        $this->info('Done!');
+    }
+}

--- a/app/Http/Controllers/Api/CardController.php
+++ b/app/Http/Controllers/Api/CardController.php
@@ -44,7 +44,7 @@ class CardController
             ]);
 
             $tagIds = [];
-            foreach ($resolved->tags as $tagName) {
+            foreach ($resolved->normalizedTags() as $tagName) {
                 $tag = Tag::firstOrCreate(['name' => $tagName]);
                 $tagIds[] = $tag->id;
             }

--- a/app/Listeners/LinkCollector.php
+++ b/app/Listeners/LinkCollector.php
@@ -56,7 +56,7 @@ class LinkCollector
                 ]);
 
                 $tagIds = [];
-                foreach ($resolved->tags as $tagName) {
+                foreach ($resolved->normalizedTags() as $tagName) {
                     $tag = Tag::firstOrCreate(['name' => $tagName]);
                     $tagIds[] = $tag->id;
                 }

--- a/app/MetadataResolver/Metadata.php
+++ b/app/MetadataResolver/Metadata.php
@@ -23,4 +23,30 @@ class Metadata
      * チェックインタグと同様に保存されるため、スペースや改行文字を含めてはいけません。
      */
     public $tags = [];
+
+    /**
+     * 重複を排除し、正規化を行ったタグの集合を返します。
+     * @return string[]
+     */
+    public function normalizedTags(): array
+    {
+        $tags = [];
+        foreach ($this->tags as $tag) {
+            $tag = $this->sanitize($tag);
+            $tag = $this->trim($tag);
+            $tags[$tag] = true;
+        }
+
+        return array_keys($tags);
+    }
+
+    private function sanitize(string $value): string
+    {
+        return preg_replace('/\r?\n/u', ' ', $value);
+    }
+
+    private function trim(string $value): string
+    {
+        return trim($value);
+    }
 }

--- a/database/migrations/2020_02_22_164304_add_unique_constraint_to_tag_relations.php
+++ b/database/migrations/2020_02_22_164304_add_unique_constraint_to_tag_relations.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUniqueConstraintToTagRelations extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('ejaculation_tag', function (Blueprint $table) {
+            $table->unique(['ejaculation_id', 'tag_id']);
+        });
+        Schema::table('metadata_tag', function (Blueprint $table) {
+            $table->unique(['metadata_url', 'tag_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('ejaculation_tag', function (Blueprint $table) {
+            $table->dropUnique(['ejaculation_id', 'tag_id']);
+        });
+        Schema::table('metadata_tag', function (Blueprint $table) {
+            $table->dropUnique(['metadata_url', 'tag_id']);
+        });
+    }
+}

--- a/tests/Unit/MetadataResolver/MetadataTest.php
+++ b/tests/Unit/MetadataResolver/MetadataTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit\MetadataResolver;
+
+use App\MetadataResolver\Metadata;
+use Tests\TestCase;
+
+class MetadataTest extends TestCase
+{
+    public function testNormalizedTagsCanTrim()
+    {
+        $metadata = new Metadata();
+        $metadata->tags = ['foo ', ' bar', ' foo bar '];
+
+        $this->assertEquals(['foo', 'bar', 'foo bar'], $metadata->normalizedTags());
+    }
+
+    public function testNormalizedTagsCanSanitize()
+    {
+        $metadata = new Metadata();
+        $metadata->tags = ["foo \n", " \nbar", " foo\n bar "];
+
+        $this->assertEquals(['foo', 'bar', 'foo  bar'], $metadata->normalizedTags());
+    }
+
+    public function testNormalizedTagsCanDeduplication()
+    {
+        $metadata = new Metadata();
+        $metadata->tags = ['foo ', ' foo', ' bar'];
+
+        $this->assertEquals(['foo', 'bar'], $metadata->normalizedTags());
+    }
+}


### PR DESCRIPTION
1. DBに登録する前に重複を除去する
2. 既にDB上に存在する重複タグを名寄せして削除する
3. DBの多対多テーブルにunique制約をかける

#330 