### PR TITLE
Bump jquery from 3.5.0 to 3.5.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4221,9 +4221,9 @@ isobject@^3.0.0, isobject@^3.0.1:
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
 jquery@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 js-cookie@^2.2.0:
   version "2.2.1"


### PR DESCRIPTION
jQuery 3.5.0 + Bootstrap 4.4.1 の組み合わせで、メニューの展開などができない問題が起きています。これはjQuery側の問題で、3.5.1で修正されたのでアップデートします。

* https://yysk.icu/@kozue/104142876511327665
* https://mstdn.maud.io/@pikepikeid/104142887397009839
* https://social.mikutter.hachune.net/@shibafu528/104142918868080022