### PR TITLE
/user/{name}/okazu にもいいねしたユーザーのアイコンを表示する

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -165,6 +165,7 @@ SQL
         }
         $ejaculations = $query->orderBy('ejaculated_date', 'desc')
             ->with('tags')
+            ->withLikes()
             ->paginate(20);
 
         return view('user.profile')->with(compact('user', 'ejaculations'));


### PR DESCRIPTION
fix #334 

もしかしたら、オカズを一覧するためのページだから余計なものを消していたのかもしれませんが、意図の記録が出てこなかったので変えます。  
タイムラインとほぼ同じ出し方をしている間は、なるべく同様の表示になるようにしておきましょう。