### PR TITLE
古いなろう作品のIDにマッチングするように

### DIFF
--- a/app/MetadataResolver/MetadataResolver.php
+++ b/app/MetadataResolver/MetadataResolver.php
@@ -26,7 +26,7 @@ class MetadataResolver implements Resolver
         '~dmm\.co\.jp/~' => FanzaResolver::class,
         '~www\.patreon\.com/~' => PatreonResolver::class,
         '~www\.deviantart\.com/.*/art/.*~' => DeviantArtResolver::class,
-        '~\.syosetu\.com/n\d+[a-z]{2,}~' => NarouResolver::class,
+        '~\.syosetu\.com/n\d+[a-z]+~' => NarouResolver::class,
         '~ci-en\.(jp|net|dlsite\.com)/creator/\d+/article/\d+~' => CienResolver::class,
         '~www\.plurk\.com\/p\/.*~' => PlurkResolver::class,
         '~(adult\.)?contents\.fc2\.com\/article_search\.php\?id=\d+~' => FC2ContentsResolver::class,


### PR DESCRIPTION
なろう作品のURLのうち、2013年以前の作品などにおいて作品IDの末尾にアルファベットが1文字しか含まれない場合があるが、それにマッチングしていなかった。最初期については調べられていないので不明。

ex) 薬屋 https://ncode.syosetu.com/n9636x/