### PR TITLE
タグの確定時に空白文字を置換する

### DIFF
--- a/resources/assets/js/components/TagInput.vue
+++ b/resources/assets/js/components/TagInput.vue
@@ -41,7 +41,7 @@ export default class TagInput extends Vue {
                 case 'Enter':
                 case ' ':
                     if ((event as any).isComposing !== true) {
-                        this.tags.push(this.buffer.trim());
+                        this.tags.push(this.buffer.trim().replace(/\s+/g, '_'));
                         this.buffer = '';
                     }
                     event.preventDefault();
@@ -49,7 +49,7 @@ export default class TagInput extends Vue {
                 case 'Unidentified':
                     // 実際にテキストボックスに入力されている文字を見に行く (フォールバック処理)
                     if (event.srcElement && (event.srcElement as HTMLInputElement).value.slice(-1) == ' ') {
-                        this.tags.push(this.buffer.trim());
+                        this.tags.push(this.buffer.trim().replace(/\s+/g, '_'));
                         this.buffer = '';
                         event.preventDefault();
                     }


### PR DESCRIPTION
#414 の修正です。

ここでは<https://github.com/shikorism/tissue/issues/414#issuecomment-646325707>の1に倣って代替文字として`_`を採用しています。pixivでもタグの空白は`_`で代替されているので、この挙動が一番自然かと思います。

![preview](https://user-images.githubusercontent.com/68658332/88211679-0128d980-cc91-11ea-9da3-0634630ab4b4.gif)

Closes #414.