### PR TITLE
メタデータ取得エラーの記録とリトライ制限の適用

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -20,6 +20,7 @@ class Handler extends ExceptionHandler
         \Illuminate\Database\Eloquent\ModelNotFoundException::class,
         \Illuminate\Session\TokenMismatchException::class,
         \Illuminate\Validation\ValidationException::class,
+        \App\MetadataResolver\ResolverCircuitBreakException::class,
     ];
 
     /**

--- a/app/Metadata.php
+++ b/app/Metadata.php
@@ -13,7 +13,7 @@ class Metadata extends Model
     protected $fillable = ['url', 'title', 'description', 'image', 'expires_at'];
     protected $visible = ['url', 'title', 'description', 'image', 'expires_at', 'tags'];
 
-    protected $dates = ['created_at', 'updated_at', 'expires_at'];
+    protected $dates = ['created_at', 'updated_at', 'expires_at', 'error_at'];
 
     public function tags()
     {

--- a/app/Metadata.php
+++ b/app/Metadata.php
@@ -2,6 +2,8 @@
 
 namespace App;
 
+use Carbon\CarbonInterface;
+use GuzzleHttp\Exception\RequestException;
 use Illuminate\Database\Eloquent\Model;
 
 class Metadata extends Model
@@ -18,5 +20,61 @@ class Metadata extends Model
     public function tags()
     {
         return $this->belongsToMany(Tag::class)->withTimestamps();
+    }
+
+    public function needRefresh(): bool
+    {
+        return $this->isExpired() || $this->error_at !== null;
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expires_at !== null && $this->expires_at < now();
+    }
+
+    public function storeException(CarbonInterface $error_at, \Exception $exception): self
+    {
+        $this->prepareFieldsOnError();
+        $this->error_at = $error_at;
+        $this->error_exception_class = get_class($exception);
+        $this->error_body = $exception->getMessage();
+        if ($exception instanceof RequestException) {
+            $this->error_http_code = $exception->getCode();
+        } else {
+            $this->error_http_code = null;
+        }
+        $this->error_count++;
+
+        return $this;
+    }
+
+    public function storeError(CarbonInterface $error_at, string $body, ?int $httpCode = null): self
+    {
+        $this->prepareFieldsOnError();
+        $this->error_at = $error_at;
+        $this->error_exception_class = null;
+        $this->error_body = $body;
+        $this->error_http_code = $httpCode;
+        $this->error_count++;
+
+        return $this;
+    }
+
+    public function clearError(): self
+    {
+        $this->error_at = null;
+        $this->error_exception_class = null;
+        $this->error_body = null;
+        $this->error_http_code = null;
+        $this->error_count = 0;
+
+        return $this;
+    }
+
+    private function prepareFieldsOnError()
+    {
+        $this->title = $this->title ?? '';
+        $this->description = $this->description ?? '';
+        $this->image = $this->image ?? '';
     }
 }

--- a/app/MetadataResolver/ResolverCircuitBreakException.php
+++ b/app/MetadataResolver/ResolverCircuitBreakException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\MetadataResolver;
+
+use Throwable;
+
+/**
+ * 規定回数以上の解決失敗により、メタデータの取得が不能となっている場合にスローされます。
+ */
+class ResolverCircuitBreakException extends \RuntimeException
+{
+    public function __construct(int $errorCount, string $url, Throwable $previous = null)
+    {
+        parent::__construct("{$errorCount}回失敗しているためメタデータの取得を中断しました: {$url}", 0, $previous);
+    }
+}

--- a/app/MetadataResolver/UncaughtResolverException.php
+++ b/app/MetadataResolver/UncaughtResolverException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\MetadataResolver;
+
+/**
+ * MetadataResolver内で未キャッチの例外が発生した場合にスローされます。
+ */
+class UncaughtResolverException extends \RuntimeException
+{
+}

--- a/app/Services/MetadataResolveService.php
+++ b/app/Services/MetadataResolveService.php
@@ -10,7 +10,6 @@ use App\MetadataResolver\UncaughtResolverException;
 use App\Tag;
 use App\Utilities\Formatter;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 
 class MetadataResolveService
 {
@@ -63,9 +62,6 @@ class MetadataResolveService
                 try {
                     $resolved = $this->resolver->resolve($url);
                 } catch (\Exception $e) {
-                    Log::error(self::class . ': メタデータの取得に失敗 URL=' . $url);
-
-                    // TODO: 何か制御用の例外を下位で使ってないか確認したほうが良い？その場合、雑catchできない
                     $metadata->storeException(now(), $e);
                     $metadata->save();
                     throw new UncaughtResolverException(implode(': ', [

--- a/database/migrations/2020_08_10_114944_add_error_data_to_metadata.php
+++ b/database/migrations/2020_08_10_114944_add_error_data_to_metadata.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddErrorDataToMetadata extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('metadata', function (Blueprint $table) {
+            $table->timestamp('error_at')->nullable();
+            $table->string('error_exception_class')->nullable();
+            $table->integer('error_http_code')->nullable();
+            $table->text('error_body')->nullable();
+            $table->integer('error_count')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('metadata', function (Blueprint $table) {
+            $table->dropColumn(['error_at', 'error_exception_class', 'error_http_code', 'error_body', 'error_count']);
+        });
+    }
+}


### PR DESCRIPTION
メタデータURLごとに最後の取得エラーの結果と、連続エラー回数を残すようにします。  
これによって、どうやっても解決できないURLにアクセスし続けるのを抑止できるようになります。

将来的には、ホストごとに閾値の調整などしたいところ。

## 確認事項
- これ排他ロック取ってないからカウンターぶっこわれそう