### PR TITLE
Twitterのサブドメイン対応用Resolverを追加

### DIFF
--- a/app/MetadataResolver/MetadataResolver.php
+++ b/app/MetadataResolver/MetadataResolver.php
@@ -34,6 +34,7 @@ class MetadataResolver implements Resolver
         '~www\.xtube\.com/video-watch/.*-\d+$~'=> XtubeResolver::class,
         '~ss\.kb10uy\.org/posts/\d+$~' => Kb10uyShortStoryServerResolver::class,
         '~www\.hentai-foundry\.com/pictures/user/.+/\d+/.+~'=> HentaiFoundryResolver::class,
+        '~(www\.)?((mobile|m)\.)?twitter\.com/(#!/)?[0-9a-zA-Z_]{1,15}/status(es)?/([0-9]+)/?(\\?.+)?$~' => TwitterResolver::class,
     ];
 
     public $mimeTypes = [

--- a/app/MetadataResolver/TwitterResolver.php
+++ b/app/MetadataResolver/TwitterResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\MetadataResolver;
+
+use GuzzleHttp\Client;
+
+class TwitterResolver implements Resolver
+{
+    /**
+     * @var Client
+     */
+    private $client;
+    /**
+     * @var OGPResolver
+     */
+    private $ogpResolver;
+
+    public function __construct(Client $client, OGPResolver $ogpResolver)
+    {
+        $this->client = $client;
+        $this->ogpResolver = $ogpResolver;
+    }
+
+    public function resolve(string $url): Metadata
+    {
+        $url = preg_replace('/(www\.)?(mobile|m)\.twitter\.com/u', 'twitter.com', $url);
+
+        $res = $this->client->get($url);
+        $html = (string) $res->getBody();
+
+        return $this->ogpResolver->parse($html);
+    }
+}


### PR DESCRIPTION
fix #466 

Twitterの思いつく限りのサブドメインを正規化してOGPResolverに横流しするResolverを追加。 