### PR TITLE
Fixture updater

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ LOG_CHANNEL=stack
 # テストにモックを使用するか falseの場合は実際のHTML等を取得してテストする
 TEST_USE_HTTP_MOCK=true
 
+# テスト用のスナップショットを更新する場合はtrueにする (TEST_USE_HTTP_MOCKと重複させないよう注意)
+TEST_UPDATE_SNAPSHOT=false
+
 DB_CONNECTION=pgsql
 DB_HOST=db
 DB_PORT=5432

--- a/tests/Unit/MetadataResolver/CienResolverTest.php
+++ b/tests/Unit/MetadataResolver/CienResolverTest.php
@@ -20,7 +20,7 @@ class CienResolverTest extends TestCase
 
     public function test()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Cien/test.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Cien/test.html');
 
         $this->createResolver(CienResolver::class, $responseText);
 
@@ -37,7 +37,7 @@ class CienResolverTest extends TestCase
 
     public function testWithNoTimestamp()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Cien/testWithNoTimestamp.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Cien/testWithNoTimestamp.html');
         $this->createResolver(CienResolver::class, $responseText);
 
         $this->expectException(\RuntimeException::class);

--- a/tests/Unit/MetadataResolver/CreateMockedResolver.php
+++ b/tests/Unit/MetadataResolver/CreateMockedResolver.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit\MetadataResolver;
 
 use App\MetadataResolver\Resolver;
-use function Clue\StreamFilter\fun;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;

--- a/tests/Unit/MetadataResolver/CreateMockedResolver.php
+++ b/tests/Unit/MetadataResolver/CreateMockedResolver.php
@@ -3,11 +3,14 @@
 namespace Tests\Unit\MetadataResolver;
 
 use App\MetadataResolver\Resolver;
+use function Clue\StreamFilter\fun;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\AbstractHandler;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 trait CreateMockedResolver
 {
@@ -22,6 +25,18 @@ trait CreateMockedResolver
     protected $handler;
 
     /**
+     * @var string
+     */
+    protected $snapshotFilename;
+
+    protected function fetchSnapshot(string $filename): string
+    {
+        $this->snapshotFilename = $filename;
+
+        return file_get_contents($filename);
+    }
+
+    /**
      * @param string $resolverClass
      * @param string $responseText
      * @param array $headers
@@ -30,19 +45,27 @@ trait CreateMockedResolver
      */
     protected function createResolver(string $resolverClass, string $responseText, array $headers = [], int $status = 200)
     {
-        if (!$this->shouldUseMock()) {
+        if (!$this->shouldUseMock() && !$this->shouldUpdateSnapshot()) {
             $this->resolver = app()->make($resolverClass);
 
             return $this->resolver;
         }
 
-        $headers += [
-            'content-type' => 'text/html',
-        ];
+        if ($this->shouldUseMock()) {
+            $headers += [
+                'content-type' => 'text/html',
+            ];
 
-        $mockResponse = new Response($status, $headers, $responseText);
-        $this->handler = new MockHandler([$mockResponse]);
-        $client = new Client(['handler' => HandlerStack::create($this->handler)]);
+            $mockResponse = new Response($status, $headers, $responseText);
+            $this->handler = new MockHandler([$mockResponse]);
+        }
+
+        $stack = HandlerStack::create($this->handler);
+        $client = new Client(['handler' => $stack]);
+        if ($this->shouldUpdateSnapshot()) {
+            $stack->push($this->makeUpdateSnapshotMiddleware());
+        }
+
         $this->resolver = app()->make($resolverClass, ['client' => $client]);
 
         return $this->resolver;
@@ -51,5 +74,28 @@ trait CreateMockedResolver
     protected function shouldUseMock(): bool
     {
         return (bool) env('TEST_USE_HTTP_MOCK', true);
+    }
+
+    protected function shouldUpdateSnapshot(): bool
+    {
+        return (bool) env('TEST_UPDATE_SNAPSHOT', false);
+    }
+
+    protected function makeUpdateSnapshotMiddleware(): callable
+    {
+        return function (callable $next) {
+            return function (RequestInterface $request, array $options) use ($next) {
+                return $next($request, $options)->then(function (ResponseInterface $response) {
+                    if (empty($this->snapshotFilename)) {
+                        throw new \RuntimeException('スナップショットのファイル名が分かりません。file_get_contents()を使っている場合、fetchSnapshot()に置き換えてください。');
+                    }
+
+                    file_put_contents($this->snapshotFilename, (string) $response->getBody());
+                    fwrite(STDERR, "Snapshot Updated: {$this->snapshotFilename}\n");
+
+                    return $response;
+                });
+            };
+        };
     }
 }

--- a/tests/Unit/MetadataResolver/DLsiteResolverTest.php
+++ b/tests/Unit/MetadataResolver/DLsiteResolverTest.php
@@ -20,7 +20,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testHome()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testHome.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testHome.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -36,7 +36,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testSoft()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testSoft.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testSoft.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -52,7 +52,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testComic()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testComic.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testComic.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -68,7 +68,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testManiax()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testManiax.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testManiax.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -84,7 +84,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testPro()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testPro.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testPro.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -100,7 +100,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testBooks()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testBooks.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testBooks.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -116,7 +116,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testGirls()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testGirls.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testGirls.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -132,7 +132,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testGirlsPro()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testGirlsPro.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testGirlsPro.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -148,7 +148,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testBL()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testBL.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testBL.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -164,7 +164,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testEng()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testEng.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testEng.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -180,7 +180,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testEcchiEng()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testEcchiEng.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testEcchiEng.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -196,7 +196,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testSPLink()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testHome.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testHome.html');
         // SP版（touch）のURLのテストだがリゾルバ側でURLから-touchを削除してPC版を取得するので、PC版の内容を使用する
 
         $this->createResolver(DLsiteResolver::class, $responseText);
@@ -213,7 +213,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testShortLink()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testHome.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testHome.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -229,7 +229,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testOldAffiliateLink()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testHome.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testHome.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -245,7 +245,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testSnsAffiliateLink()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testHome.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testHome.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -261,7 +261,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testAffiliateLink()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testHome.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testHome.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -277,7 +277,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testAffiliateUrl()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testHome.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testHome.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 
@@ -303,7 +303,7 @@ class DLsiteResolverTest extends TestCase
 
     public function testHTMLdescription()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DLsite/testHTMLdescription.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testHTMLdescription.html');
 
         $this->createResolver(DLsiteResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/DeviantArtResolverTest.php
+++ b/tests/Unit/MetadataResolver/DeviantArtResolverTest.php
@@ -20,7 +20,7 @@ class DeviantArtResolverTest extends TestCase
 
     public function testMature()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/DeviantArt/mature.json');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DeviantArt/mature.json');
 
         $this->createResolver(DeviantArtResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/FC2ContentsResolverTest.php
+++ b/tests/Unit/MetadataResolver/FC2ContentsResolverTest.php
@@ -20,7 +20,7 @@ class FC2ContentsResolverTest extends TestCase
 
     public function testAdult()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/FC2Contents/adult.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/FC2Contents/adult.html');
 
         $this->createResolver(FC2ContentsResolver::class, $responseText);
 
@@ -35,7 +35,7 @@ class FC2ContentsResolverTest extends TestCase
 
     public function testGeneral()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/FC2Contents/general.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/FC2Contents/general.html');
 
         $this->createResolver(FC2ContentsResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/FantiaResolverTest.php
+++ b/tests/Unit/MetadataResolver/FantiaResolverTest.php
@@ -20,7 +20,7 @@ class FantiaResolverTest extends TestCase
 
     public function test()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Fantia/test.json');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Fantia/test.json');
 
         $this->createResolver(FantiaResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/FanzaResolverTest.php
+++ b/tests/Unit/MetadataResolver/FanzaResolverTest.php
@@ -23,7 +23,7 @@ class FanzaResolverTest extends TestCase
      */
     public function test($filename, $url, $title, $description, $image, $tags)
     {
-        $responseText = file_get_contents(__DIR__ . "/../../fixture/Fanza/{$filename}");
+        $responseText = $this->fetchSnapshot(__DIR__ . "/../../fixture/Fanza/{$filename}");
 
         $this->createResolver(FanzaResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/HentaiFoundryResolverTest.php
+++ b/tests/Unit/MetadataResolver/HentaiFoundryResolverTest.php
@@ -20,7 +20,7 @@ class HentaiFoundryResolverTest extends TestCase
 
     public function test()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/HentaiFoundry/illust.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/HentaiFoundry/illust.html');
 
         $this->createResolver(HentaiFoundryResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/IwaraResolverTest.php
+++ b/tests/Unit/MetadataResolver/IwaraResolverTest.php
@@ -20,7 +20,7 @@ class IwaraResolverTest extends TestCase
 
     public function testVideo()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Iwara/video.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Iwara/video.html');
 
         $this->createResolver(IwaraResolver::class, $responseText);
 
@@ -37,7 +37,7 @@ class IwaraResolverTest extends TestCase
 
     public function testYouTube()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Iwara/youtube.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Iwara/youtube.html');
 
         $this->createResolver(IwaraResolver::class, $responseText);
 
@@ -54,7 +54,7 @@ class IwaraResolverTest extends TestCase
 
     public function testImages()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Iwara/images.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Iwara/images.html');
 
         $this->createResolver(IwaraResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/Kb10uyShortStoryServerResolverTest.php
+++ b/tests/Unit/MetadataResolver/Kb10uyShortStoryServerResolverTest.php
@@ -20,7 +20,7 @@ class Kb10uyShortStoryServerResolverTest extends TestCase
 
     public function testNormalPost()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Kb10uyShortStoryServer/tomone.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Kb10uyShortStoryServer/tomone.html');
 
         $this->createResolver(Kb10uyShortStoryServerResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/KomifloResolverTest.php
+++ b/tests/Unit/MetadataResolver/KomifloResolverTest.php
@@ -20,7 +20,7 @@ class KomifloResolverTest extends TestCase
 
     public function testComic()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Komiflo/comic.json');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Komiflo/comic.json');
 
         $this->createResolver(KomifloResolver::class, $responseText);
 
@@ -36,7 +36,7 @@ class KomifloResolverTest extends TestCase
 
     public function testComicWithNoParents()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Komiflo/comicWithNoParents.json');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Komiflo/comicWithNoParents.json');
 
         $this->createResolver(KomifloResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/NicoSeigaResolverTest.php
+++ b/tests/Unit/MetadataResolver/NicoSeigaResolverTest.php
@@ -21,7 +21,7 @@ class NicoSeigaResolverTest extends TestCase
 
     public function testSeiga()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/NicoSeiga/seiga.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/NicoSeiga/seiga.html');
 
         $this->createResolver(NicoSeigaResolver::class, $responseText);
 
@@ -37,7 +37,7 @@ class NicoSeigaResolverTest extends TestCase
 
     public function testShunga()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/NicoSeiga/shunga.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/NicoSeiga/shunga.html');
 
         $this->createResolver(NicoSeigaResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/NijieResolverTest.php
+++ b/tests/Unit/MetadataResolver/NijieResolverTest.php
@@ -20,7 +20,7 @@ class NijieResolverTest extends TestCase
 
     public function testStandardPicture()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Nijie/testStandardPictureResponse.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Nijie/testStandardPictureResponse.html');
 
         $this->createResolver(NijieResolver::class, $responseText);
 
@@ -36,7 +36,7 @@ class NijieResolverTest extends TestCase
 
     public function testMultiplePicture()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Nijie/testMultiplePictureResponse.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Nijie/testMultiplePictureResponse.html');
 
         $this->createResolver(NijieResolver::class, $responseText);
 
@@ -52,7 +52,7 @@ class NijieResolverTest extends TestCase
 
     public function testAnimationGif()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Nijie/testAnimationGifResponse.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Nijie/testAnimationGifResponse.html');
 
         $this->createResolver(NijieResolver::class, $responseText);
 
@@ -68,7 +68,7 @@ class NijieResolverTest extends TestCase
 
     public function testMp4Movie()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Nijie/testMp4MovieResponse.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Nijie/testMp4MovieResponse.html');
 
         $this->createResolver(NijieResolver::class, $responseText);
 
@@ -84,7 +84,7 @@ class NijieResolverTest extends TestCase
 
     public function testViewPopup()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Nijie/testStandardPictureResponse.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Nijie/testStandardPictureResponse.html');
 
         $this->createResolver(NijieResolver::class, $responseText);
 
@@ -100,7 +100,7 @@ class NijieResolverTest extends TestCase
 
     public function testSp()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Nijie/testStandardPictureResponse.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Nijie/testStandardPictureResponse.html');
 
         $this->createResolver(NijieResolver::class, $responseText);
 
@@ -116,7 +116,7 @@ class NijieResolverTest extends TestCase
 
     public function testSpViewPopup()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Nijie/testStandardPictureResponse.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Nijie/testStandardPictureResponse.html');
 
         $this->createResolver(NijieResolver::class, $responseText);
 
@@ -132,7 +132,7 @@ class NijieResolverTest extends TestCase
 
     public function testHasHtmlInAuthorProfile()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Nijie/testHasHtmlInAuthorProfileResponse.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Nijie/testHasHtmlInAuthorProfileResponse.html');
 
         $this->createResolver(NijieResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/PixivResolverTest.php
+++ b/tests/Unit/MetadataResolver/PixivResolverTest.php
@@ -20,7 +20,7 @@ class PixivResolverTest extends TestCase
 
     public function testIllust()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Pixiv/illust.json');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Pixiv/illust.json');
 
         $this->createResolver(PixivResolver::class, $responseText);
 
@@ -36,7 +36,7 @@ class PixivResolverTest extends TestCase
 
     public function testIllustMultiPages()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Pixiv/illustMultiPages.json');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Pixiv/illustMultiPages.json');
 
         $this->createResolver(PixivResolver::class, $responseText);
 
@@ -52,7 +52,7 @@ class PixivResolverTest extends TestCase
 
     public function testManga()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Pixiv/manga.json');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Pixiv/manga.json');
 
         $this->createResolver(PixivResolver::class, $responseText);
 
@@ -68,7 +68,7 @@ class PixivResolverTest extends TestCase
 
     public function testArtworkUrl()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Pixiv/illust.json');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Pixiv/illust.json');
 
         $this->createResolver(PixivResolver::class, $responseText);
 
@@ -84,7 +84,7 @@ class PixivResolverTest extends TestCase
 
     public function testArtworkUrlEn()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Pixiv/illust.json');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Pixiv/illust.json');
 
         $this->createResolver(PixivResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/PlurkResolverTest.php
+++ b/tests/Unit/MetadataResolver/PlurkResolverTest.php
@@ -20,7 +20,7 @@ class PlurkResolverTest extends TestCase
 
     public function test()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Plurk/test.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Plurk/test.html');
 
         $this->createResolver(PlurkResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/SteamResolverTest.php
+++ b/tests/Unit/MetadataResolver/SteamResolverTest.php
@@ -20,7 +20,7 @@ class SteamResolverTest extends TestCase
 
     public function test()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Steam/test.json');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Steam/test.json');
 
         $this->createResolver(SteamResolver::class, $responseText);
 
@@ -32,7 +32,7 @@ class SteamResolverTest extends TestCase
 
     public function testR18()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Steam/testR18.json');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Steam/testR18.json');
 
         $this->createResolver(SteamResolver::class, $responseText);
 
@@ -46,7 +46,7 @@ class SteamResolverTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Steam/testNotFound.json');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Steam/testNotFound.json');
 
         $this->createResolver(SteamResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/ToranoanaResolverTest.php
+++ b/tests/Unit/MetadataResolver/ToranoanaResolverTest.php
@@ -20,7 +20,7 @@ class ToranoanaResolverTest extends TestCase
 
     public function testTora()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Toranoana/testTora.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Toranoana/testTora.html');
 
         $this->createResolver(ToranoanaResolver::class, $responseText);
 
@@ -35,7 +35,7 @@ class ToranoanaResolverTest extends TestCase
 
     public function testToraR()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Toranoana/testToraR.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Toranoana/testToraR.html');
 
         $this->createResolver(ToranoanaResolver::class, $responseText);
 
@@ -50,7 +50,7 @@ class ToranoanaResolverTest extends TestCase
 
     public function testToraD()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Toranoana/testToraD.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Toranoana/testToraD.html');
 
         $this->createResolver(ToranoanaResolver::class, $responseText);
 
@@ -65,7 +65,7 @@ class ToranoanaResolverTest extends TestCase
 
     public function testToraRD()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Toranoana/testToraRD.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Toranoana/testToraRD.html');
 
         $this->createResolver(ToranoanaResolver::class, $responseText);
 
@@ -80,7 +80,7 @@ class ToranoanaResolverTest extends TestCase
 
     public function testJoshi()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Toranoana/testJoshi.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Toranoana/testJoshi.html');
 
         $this->createResolver(ToranoanaResolver::class, $responseText);
 
@@ -95,7 +95,7 @@ class ToranoanaResolverTest extends TestCase
 
     public function testJoshiR()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Toranoana/testJoshiR.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Toranoana/testJoshiR.html');
 
         $this->createResolver(ToranoanaResolver::class, $responseText);
 
@@ -110,7 +110,7 @@ class ToranoanaResolverTest extends TestCase
 
     public function testJoshiD()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Toranoana/testJoshiD.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Toranoana/testJoshiD.html');
 
         $this->createResolver(ToranoanaResolver::class, $responseText);
 
@@ -125,7 +125,7 @@ class ToranoanaResolverTest extends TestCase
 
     public function testJoshiRD()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Toranoana/testJoshiRD.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Toranoana/testJoshiRD.html');
 
         $this->createResolver(ToranoanaResolver::class, $responseText);
 

--- a/tests/Unit/MetadataResolver/XtubeResolverTest.php
+++ b/tests/Unit/MetadataResolver/XtubeResolverTest.php
@@ -20,7 +20,7 @@ class XtubeResolverTest extends TestCase
 
     public function test()
     {
-        $responseText = file_get_contents(__DIR__ . '/../../fixture/Xtube/video.html');
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Xtube/video.html');
 
         $this->createResolver(XtubeResolver::class, $responseText);
 


### PR DESCRIPTION
fix #463

環境変数 `TEST_UPDATE_SNAPSHOT` を設定することで、実リクエストテストをする際にレスポンスをfixtureとして保存する処理を差し込むようにしました。

~ちょっとHTMLの浄化とかしたほうが良いかもしれないので、まだドラフトということでご意見募集中。~  
→ あんまり考えなくてもいいかなぁになってます。