### PR TITLE
カード情報の取得に失敗した時にちゃんと処理を中断させる

### DIFF
--- a/resources/assets/js/tissue.ts
+++ b/resources/assets/js/tissue.ts
@@ -1,4 +1,4 @@
-import { fetchGet } from './fetch';
+import { fetchGet, ResponseError } from './fetch';
 
 export function suicide<T>(e: T) {
     return function (): never {
@@ -15,7 +15,12 @@ export function linkCard(el: Element) {
     }
 
     fetchGet('/api/checkin/card', { url })
-        .then((response) => response.json())
+        .then((response) => {
+            if (response.ok) {
+                return response.json();
+            }
+            throw new ResponseError(response);
+        })
         .then((data) => {
             const metaColumn = el.querySelector('.col-12:last-of-type') || die();
             const imageColumn = el.querySelector<HTMLElement>('.col-12:first-of-type') || die();


### PR DESCRIPTION
fix #491 

単にエラー処理してなかった