### PR TITLE
ES5 User error class workaround

### DIFF
--- a/resources/assets/js/fetch.ts
+++ b/resources/assets/js/fetch.ts
@@ -67,5 +67,6 @@ export class ResponseError extends Error {
 
         this.name = 'ResponseError';
         this.response = response;
+        Object.setPrototypeOf(this, new.target.prototype);
     }
 }


### PR DESCRIPTION
TypeScriptで出力をES5にしている場合、ビルトインクラスの継承にはワークアラウンドが必要。

https://stackoverflow.com/q/41102060
https://future-architect.github.io/typescript-guide/exception.html#id4

この変更によって `instanceof ResponseError` と書いている場所が動作してなかったのが直る。