### PR TITLE
Stateful APIのMiddleware順序を調整

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -48,6 +48,8 @@ class Kernel extends HttpKernel
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
+            'throttle:60,1',
+            'auth',
         ]
     ];
 
@@ -79,6 +81,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middlewarePriority = [
+        \App\Http\Middleware\EncryptCookies::class,
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \App\Http\Middleware\Authenticate::class,

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,7 +18,7 @@
 Route::get('/checkin/card', 'Api\\CardController@show')
     ->middleware('throttle:180,1,card');
 
-Route::middleware(['throttle:60,1', 'stateful', 'auth'])->group(function () {
+Route::middleware('stateful')->group(function () {
     Route::post('/likes', 'Api\\LikeController@store');
     Route::delete('/likes/{id}', 'Api\\LikeController@destroy');
 });


### PR DESCRIPTION
Middleware Group内にいろいろ移したのはあまり関係がなくて、なぜかEncryptCookiesの前にStartSessionが走っていた。なんでだよ。