### PR TITLE
ゲストアクセス時のレートリミットを厳しめにする

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -48,8 +48,6 @@ class Kernel extends HttpKernel
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
-            'throttle:60,1',
-            'auth',
         ]
     ];
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,12 +15,14 @@
 //    return $request->user();
 //});
 
-Route::get('/checkin/card', 'Api\\CardController@show')
-    ->middleware('throttle:180,1,card');
-
 Route::middleware('stateful')->group(function () {
-    Route::post('/likes', 'Api\\LikeController@store');
-    Route::delete('/likes/{id}', 'Api\\LikeController@destroy');
+    Route::get('/checkin/card', 'Api\\CardController@show')
+        ->middleware('throttle:30|180,1,card');
+
+    Route::middleware(['throttle:60,1', 'auth'])->group(function () {
+        Route::post('/likes', 'Api\\LikeController@store');
+        Route::delete('/likes/{id}', 'Api\\LikeController@destroy');
+    });
 });
 
 Route::post('/webhooks/checkin/{webhook}', 'Api\\WebhookController@checkin')


### PR DESCRIPTION
throttle middlewareにはゲストアクセス時、ログイン時それぞれのレートリミットが書けると教えてもらったので、ゲスト時はcard APIへのアクセスを絞ることにした。

thanks hinaloe.