### PR TITLE
robots.txt取得時、text/plain以外の応答は失敗扱いにする

### DIFF
--- a/app/Services/MetadataResolveService.php
+++ b/app/Services/MetadataResolveService.php
@@ -162,6 +162,11 @@ class MetadataResolveService
         $client = app(Client::class);
         try {
             $res = $client->get($robotsUrl);
+            if (stripos($res->getHeaderLine('Content-Type'), 'text/plain') !== 0) {
+                Log::error('robots.txtの取得に失敗: 不適切なContent-Type (' . $res->getHeaderLine('Content-Type') . ')');
+
+                return null;
+            }
 
             return (string) $res->getBody();
         } catch (\Exception $e) {


### PR DESCRIPTION
`http://shibafu528.info` とかを取得しようとするとHTMLが返ってきてrobots.txtパーサーが暴走してタイムアウトすることがあった。  
明らかな異常パターンを弾くための措置として、Content-Typeチェックを行うようにする。