### PR TITLE
thanks prestissimo, goodbye!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update \
     && pecl install xdebug \
     && curl -sS https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer \
-    && composer global require hirak/prestissimo \
     && sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
     && sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf \
     && a2enmod rewrite


### PR DESCRIPTION
`https://getcomposer.org/installer` で得られるcomposerのバージョンが2.0系になったので、prestissimoをインストールしないようにする。  
今まで本当にありがとう……