### PR TITLE
「前回チェックインからの経過時間を記録しない」チェックインオプションの追加

### DIFF
--- a/app/Ejaculation.php
+++ b/app/Ejaculation.php
@@ -19,7 +19,7 @@ class Ejaculation extends Model
     protected $fillable = [
         'user_id', 'ejaculated_date',
         'note', 'geo_latitude', 'geo_longitude', 'link', 'source',
-        'is_private', 'is_too_sensitive',
+        'is_private', 'is_too_sensitive', 'discard_elapsed_time',
         'checkin_webhook_id'
     ];
 

--- a/app/Ejaculation.php
+++ b/app/Ejaculation.php
@@ -105,4 +105,33 @@ class Ejaculation extends Model
             'is_too_sensitive' => $this->is_too_sensitive,
         ]);
     }
+
+    public function ejaculatedSpan(): string
+    {
+        if (array_key_exists('ejaculated_span', $this->attributes)) {
+            if ($this->ejaculated_span === null) {
+                return '精通';
+            }
+            if ($this->discard_elapsed_time) {
+                return '0日 0時間 0分'; // TODO: 気の効いたフレーズにする
+            }
+
+            return $this->ejaculated_span;
+        } else {
+            $previous = Ejaculation::select('ejaculated_date')
+                ->where('user_id', $this->user_id)
+                ->where('ejaculated_date', '<', $this->ejaculated_date)
+                ->orderByDesc('ejaculated_date')
+                ->first();
+
+            if ($previous === null) {
+                return '精通';
+            }
+            if ($this->discard_elapsed_time) {
+                return '0日 0時間 0分';
+            }
+
+            return $this->ejaculated_date->diff($previous->ejaculated_date)->format('%a日 %h時間 %i分');
+        }
+    }
 }

--- a/app/Http/Controllers/Api/WebhookController.php
+++ b/app/Http/Controllers/Api/WebhookController.php
@@ -35,6 +35,7 @@ class WebhookController extends Controller
             'tags.*' => ['string', 'not_regex:/[\s\r\n]/u', 'max:255'],
             'is_private' => 'nullable|boolean',
             'is_too_sensitive' => 'nullable|boolean',
+            'discard_elapsed_time' => 'nullable|boolean',
         ], [
             'tags.*.not_regex' => 'The :attribute cannot contain spaces, tabs and newlines.'
         ]);
@@ -71,6 +72,7 @@ class WebhookController extends Controller
                 'source' => Ejaculation::SOURCE_WEBHOOK,
                 'is_private' => (bool)($inputs['is_private'] ?? false),
                 'is_too_sensitive' => (bool)($inputs['is_too_sensitive'] ?? false),
+                'discard_elapsed_time' => (bool)($inputs['discard_elapsed_time'] ?? false),
                 'checkin_webhook_id' => $webhook->id
             ]);
 

--- a/app/Http/Controllers/EjaculationController.php
+++ b/app/Http/Controllers/EjaculationController.php
@@ -32,7 +32,8 @@ class EjaculationController extends Controller
                 'note' => old('note') ?? $request->input('note', ''),
                 'is_private' => old('is_private') ?? $request->input('is_private', 0) == 1,
                 'is_too_sensitive' => old('is_too_sensitive') ?? $request->input('is_too_sensitive', 0) == 1,
-                'is_realtime' => old('is_realtime', true)
+                'is_realtime' => old('is_realtime', true),
+                'discard_elapsed_time' => old('discard_elapsed_time') ?? $request->input('discard_elapsed_time') == 1,
             ],
             'errors' => isset($errors) ? $errors->getMessages() : null
         ];
@@ -85,7 +86,8 @@ class EjaculationController extends Controller
                 'link' => $inputs['link'] ?? '',
                 'source' => Ejaculation::SOURCE_WEB,
                 'is_private' => $request->has('is_private') ?? false,
-                'is_too_sensitive' => $request->has('is_too_sensitive') ?? false
+                'is_too_sensitive' => $request->has('is_too_sensitive') ?? false,
+                'discard_elapsed_time' => $request->has('discard_elapsed_time') ?? false,
             ]);
 
             $tagIds = [];
@@ -161,7 +163,8 @@ class EjaculationController extends Controller
                 'tags' => $tags,
                 'note' => old('note') ?? $ejaculation->note,
                 'is_private' => is_bool(old('is_private')) ? old('is_private') : $ejaculation->is_private,
-                'is_too_sensitive' => is_bool(old('is_too_sensitive')) ? old('is_too_sensitive') : $ejaculation->is_too_sensitive
+                'is_too_sensitive' => is_bool(old('is_too_sensitive')) ? old('is_too_sensitive') : $ejaculation->is_too_sensitive,
+                'discard_elapsed_time' => is_bool(old('discard_elapsed_time')) ? old('discard_elapsed_time') : $ejaculation->discard_elapsed_time,
             ],
             'errors' => isset($errors) ? $errors->getMessages() : null
         ];
@@ -203,7 +206,8 @@ class EjaculationController extends Controller
                 'note' => $inputs['note'] ?? '',
                 'link' => $inputs['link'] ?? '',
                 'is_private' => $request->has('is_private') ?? false,
-                'is_too_sensitive' => $request->has('is_too_sensitive') ?? false
+                'is_too_sensitive' => $request->has('is_too_sensitive') ?? false,
+                'discard_elapsed_time' => $request->has('discard_elapsed_time') ?? false,
             ])->save();
 
             $tagIds = [];

--- a/app/Http/Controllers/EjaculationController.php
+++ b/app/Http/Controllers/EjaculationController.php
@@ -121,21 +121,7 @@ class EjaculationController extends Controller
             ->firstOrFail();
         $user = User::findOrFail($ejaculation->user_id);
 
-        // 1つ前のチェックインからの経過時間を求める
-        $previousEjaculation = Ejaculation::select('ejaculated_date')
-            ->where('user_id', $ejaculation->user_id)
-            ->where('ejaculated_date', '<', $ejaculation->ejaculated_date)
-            ->orderByDesc('ejaculated_date')
-            ->first();
-        if (!empty($previousEjaculation)) {
-            $ejaculatedSpan = $ejaculation->ejaculated_date
-                ->diff($previousEjaculation->ejaculated_date)
-                ->format('%a日 %h時間 %i分');
-        } else {
-            $ejaculatedSpan = null;
-        }
-
-        return view('ejaculation.show')->with(compact('user', 'ejaculation', 'ejaculatedSpan'));
+        return view('ejaculation.show')->with(compact('user', 'ejaculation'));
     }
 
     public function edit(Request $request, $id)

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -35,6 +35,7 @@ is_private,
 is_too_sensitive,
 link,
 source,
+discard_elapsed_time,
 to_char(before_dates.before_date, 'YYYY/MM/DD HH24:MI') AS before_date,
 to_char(ejaculated_date - before_dates.before_date, 'FMDDD日 FMHH24時間 FMMI分') AS ejaculated_span
 SQL
@@ -169,6 +170,7 @@ is_private,
 is_too_sensitive,
 link,
 source,
+discard_elapsed_time,
 to_char(before_dates.before_date, 'YYYY/MM/DD HH24:MI') AS before_date,
 to_char(ejaculated_date - before_dates.before_date, 'FMDDD日 FMHH24時間 FMMI分') AS ejaculated_span
 SQL

--- a/database/migrations/2020_11_08_005107_add_discard_elapsed_time_to_ejaculations.php
+++ b/database/migrations/2020_11_08_005107_add_discard_elapsed_time_to_ejaculations.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDiscardElapsedTimeToEjaculations extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('ejaculations', function (Blueprint $table) {
+            $table->boolean('discard_elapsed_time')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('ejaculations', function (Blueprint $table) {
+            $table->dropColumn('discard_elapsed_time');
+        });
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: |
     夜のライフログサービス Tissue の公開API仕様です。
     全てのAPIのURLは `https://shikorism.net/api` から始まります。
-  version: 0.1.0
+  version: 0.1.1
 servers:
   - url: 'https://shikorism.net/api'
 paths:
@@ -51,6 +51,10 @@ paths:
                   type: boolean
                   default: false
                   description: チェックイン対象のオカズをより過激なオカズとして設定
+                discard_elapsed_time:
+                  type: boolean
+                  default: false
+                  description: 前回チェックインからの経過時間を記録しない
             examples:
               simple:
                 description: 何も指定しなければ、現在時刻で公開チェックインをおこないます。

--- a/resources/assets/js/components/CheckinForm.tsx
+++ b/resources/assets/js/components/CheckinForm.tsx
@@ -21,6 +21,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
     const [isRealtime, setRealtime] = useState<boolean>(mode === 'create' && initialState.fields.is_realtime);
     const [isPrivate, setPrivate] = useState<boolean>(!!initialState.fields.is_private);
     const [isTooSensitive, setTooSensitive] = useState<boolean>(!!initialState.fields.is_too_sensitive);
+    const [discardElapsedTime, setDiscardElapsedTime] = useState<boolean>(!!initialState.fields.discard_elapsed_time);
     useEffect(() => {
         if (mode === 'create' && isRealtime) {
             const id = setInterval(() => {
@@ -163,6 +164,23 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
                         onChange={(v) => setTooSensitive(v)}
                     >
                         <span className="oi oi-warning" /> チェックイン対象のオカズをより過激なオカズとして設定する
+                    </CheckBox>
+                    <CheckBox
+                        id="discardElapsedTime"
+                        name="discard_elapsed_time"
+                        className="mb-3"
+                        checked={discardElapsedTime}
+                        onChange={(v) => setDiscardElapsedTime(v)}
+                    >
+                        <span className="oi oi-timer" /> 前回チェックインからの経過時間を記録しない
+                        <br />
+                        <small className="form-text text-muted">
+                            長期間お使いにならなかった場合など、経過時間に意味が無い時のリセット用オプションです。
+                            <ul className="pl-3">
+                                <li>最長・最短記録の計算から除外されます。</li>
+                                <li>平均記録の起点がこのチェックインになります。</li>
+                            </ul>
+                        </small>
                     </CheckBox>
                 </div>
             </div>

--- a/resources/views/components/profile-stats.blade.php
+++ b/resources/views/components/profile-stats.blade.php
@@ -8,8 +8,8 @@
 @endif
 
 <h6 class="font-weight-bold"><span class="oi oi-graph"></span> 概況</h6>
-<p class="card-text mb-0">平均記録: {{ Formatter::formatInterval($average[0]->average) }}</p>
+<p class="card-text mb-0">平均記録: {{ Formatter::formatInterval($average) }}</p>
 <p class="card-text mb-0">最長記録: {{ Formatter::formatInterval($summary[0]->longest) }}</p>
 <p class="card-text mb-0">最短記録: {{ Formatter::formatInterval($summary[0]->shortest) }}</p>
 <p class="card-text mb-0">合計時間: {{ Formatter::formatInterval($summary[0]->total_times) }}</p>
-<p class="card-text">通算回数: {{ number_format($summary[0]->total_checkins) }}回</p>
+<p class="card-text">通算回数: {{ number_format($total) }}回</p>

--- a/resources/views/ejaculation/show.blade.php
+++ b/resources/views/ejaculation/show.blade.php
@@ -31,7 +31,7 @@
                     <div class="card-body">
                         <!-- span -->
                         <div>
-                            <h5>{{ $ejaculatedSpan ?? '精通' }} <small class="text-muted">{{ $ejaculation->before_date }}{{ !empty($ejaculation->before_date) ? ' ～ ' : '' }}{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></h5>
+                            <h5>{{ $ejaculation->ejaculatedSpan() }} <small class="text-muted">{{ !empty($ejaculation->before_date) && !$ejaculation->discard_elapsed_time ? $ejaculation->before_date . ' ～ ' : '' }}{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></h5>
                         </div>
                         <!-- tags -->
                         @if ($ejaculation->is_private || $ejaculation->source !== 'web' || $ejaculation->tags->isNotEmpty())

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -58,7 +58,7 @@
             <li class="list-group-item border-bottom-only pt-3 pb-3 text-break">
                 <!-- span -->
                 <div>
-                    <h5>{{ $ejaculation->ejaculated_span ?? '精通' }} <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ $ejaculation->before_date }}{{ !empty($ejaculation->before_date) ? ' ～ ' : '' }}{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a></h5>
+                    <h5>{{ $ejaculation->ejaculatedSpan() }} <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ !empty($ejaculation->before_date) && !$ejaculation->discard_elapsed_time ? $ejaculation->before_date . ' ～ ' : '' }}{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a></h5>
                 </div>
                 <!-- tags -->
                 @if ($ejaculation->is_private || $ejaculation->source !== 'web' || $ejaculation->tags->isNotEmpty())


### PR DESCRIPTION
fix #332 

チェックインオプションとして「前回チェックインからの経過時間を記録しない」を追加します。

このオプションを有効にした場合、次のような効果があります。

* チェックインに経過時間が表示されなくなる。
* 概況欄の平均の計算対象が、このオプションを有効にしたチェックインから最新のチェックインまでになる。(直近30チェックイン内に存在する場合)
* 概況欄の最長・最短・合計の計算から除外される。

仕様検討にあたっては、Tissueへのチェックイン記録を再開する時にしか統計をリセットする実質的な意味は無いと捉え、そのようにオプションを配置することとしました。  
また、記録として使えなくなっているのは、利用を中断してから再開するまでの2点間のみであると考えたため、この区間のみを各種計算から除外するような形にしました。
