### PR TITLE
ユーザーページでstatus alertを出した時に余白が無くて不恰好なのを修正

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -22,3 +22,8 @@ $primary: #e53fb1;
 
 // Underline tabs
 @import "underline-tabs";
+
+// Status containerの後続要素との余白調整
+.tis-status-container + .mt-n1 {
+    margin-top: 0 !important;
+}

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -162,7 +162,7 @@
     </div>
 </nav>
 @if (session('status'))
-<div class="container">
+<div class="container tis-status-container">
     <div id="status" class="alert alert-success alert-dismissible fade show" role="alert">
         {{ session('status') }}
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">


### PR DESCRIPTION
何もしないよりはマシ

## Before
![Screenshot_20201118_231155](https://user-images.githubusercontent.com/1352154/99540880-7617e000-29f3-11eb-93a3-e7993e662e7e.png)

## After
![Screenshot_20201118_231114](https://user-images.githubusercontent.com/1352154/99540812-5e405c00-29f3-11eb-9e1a-36d4c5103c60.png)
