### PR TITLE
よく使っているタグを統計情報として表示

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -16,6 +16,7 @@ $primary: #e53fb1;
 @import "components/tag-input";
 @import "components/metadata-preview";
 @import "components/profile-mini";
+@import "components/stat-table";
 
 // Tag
 @import "tag/index";
@@ -26,24 +27,4 @@ $primary: #e53fb1;
 // Status containerの後続要素との余白調整
 .tis-status-container + .mt-n1 {
     margin-top: 0 !important;
-}
-
-.tis-stat-table-category {
-    padding: 0.25em 0.8em;
-    font-size: 85%;
-    color: #ffffff;
-    text-align: center;
-    white-space: nowrap;
-    vertical-align: baseline;
-    border-radius: 10rem;
-
-    &-checkin {
-        @extend .tis-stat-table-category;
-        background-color: $primary;
-    }
-
-    &-metadata {
-        @extend .tis-stat-table-category;
-        background-color: $secondary;
-    }
 }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -27,3 +27,23 @@ $primary: #e53fb1;
 .tis-status-container + .mt-n1 {
     margin-top: 0 !important;
 }
+
+.tis-stat-table-category {
+    padding: 0.25em 0.8em;
+    font-size: 85%;
+    color: #ffffff;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: 10rem;
+
+    &-checkin {
+        @extend .tis-stat-table-category;
+        background-color: $primary;
+    }
+
+    &-metadata {
+        @extend .tis-stat-table-category;
+        background-color: $secondary;
+    }
+}

--- a/resources/assets/sass/components/_stat-table.scss
+++ b/resources/assets/sass/components/_stat-table.scss
@@ -1,0 +1,30 @@
+.tis-stat-table {
+    td {
+        padding: 0;
+
+        & > a {
+            display: block;
+            padding: 0.75rem;
+        }
+    }
+}
+
+.tis-stat-table-category {
+    padding: 0.25em 0.8em;
+    font-size: 85%;
+    color: #ffffff;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: 10rem;
+
+    &-checkin {
+        @extend .tis-stat-table-category;
+        background-color: $primary;
+    }
+
+    &-metadata {
+        @extend .tis-stat-table-category;
+        background-color: $secondary;
+    }
+}

--- a/resources/assets/sass/components/_stat-table.scss
+++ b/resources/assets/sass/components/_stat-table.scss
@@ -12,7 +12,7 @@
 .tis-stat-table-category {
     padding: 0.25em 0.8em;
     font-size: 85%;
-    color: #ffffff;
+    color: color("white");
     text-align: center;
     white-space: nowrap;
     vertical-align: baseline;

--- a/resources/views/user/stats/components/used-tags.blade.php
+++ b/resources/views/user/stats/components/used-tags.blade.php
@@ -1,35 +1,40 @@
-<h5 class="my-4">最も使用したタグ</h5>
-@if ($tags->isEmpty())
-    <div class="alert alert-secondary">
-        データがありません
+<div class="row">
+    <div class="col-md-6">
+        <h5 class="mb-4">最も使用したタグ</h5>
+        @if ($tags->isEmpty())
+            <div class="alert alert-secondary">
+                データがありません
+            </div>
+        @else
+            <table class="table table-striped border">
+                <tbody>
+                @foreach ($tags as $tag)
+                    <tr>
+                        <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
+                        <td class="text-right">{{ number_format($tag->count) }}</td>
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+        @endif
     </div>
-@else
-    <table class="table table-striped border">
-        <tbody>
-        @foreach ($tags as $tag)
-            <tr>
-                <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
-                <td class="text-right">{{ number_format($tag->count) }}</td>
-            </tr>
-        @endforeach
-        </tbody>
-    </table>
-@endif
-<hr class="my-4">
-<h5 class="my-4">最も使用したタグ (オカズのタグを含む)</h5>
-@if ($tagsIncludesMetadata->isEmpty())
-    <div class="alert alert-secondary">
-        データがありません
+    <div class="col-md-6">
+        <h5 class="mb-4">オカズを含む最も使用したタグ</h5>
+        @if ($tagsIncludesMetadata->isEmpty())
+            <div class="alert alert-secondary">
+                データがありません
+            </div>
+        @else
+            <table class="table table-striped border">
+                <tbody>
+                @foreach ($tagsIncludesMetadata as $tag)
+                    <tr>
+                        <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
+                        <td class="text-right">{{ number_format($tag->count) }}</td>
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+        @endif
     </div>
-@else
-    <table class="table table-striped border">
-        <tbody>
-        @foreach ($tagsIncludesMetadata as $tag)
-            <tr>
-                <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
-                <td class="text-right">{{ number_format($tag->count) }}</td>
-            </tr>
-        @endforeach
-        </tbody>
-    </table>
-@endif
+</div>

--- a/resources/views/user/stats/components/used-tags.blade.php
+++ b/resources/views/user/stats/components/used-tags.blade.php
@@ -2,7 +2,7 @@
 <div class="row">
     <div class="col-md-6">
         <h6 class="mb-2 text-center"><span class="tis-stat-table-category-checkin">チェックインタグ</span></h6>
-        <p class="mb-3 text-center"><small class="text-muted">直接入力されたタグのみ集計しています。</small></p>
+        <p class="mb-3 text-center"><small class="text-muted">チェックインに直接入力したタグの集計です。</small></p>
         @if ($tags->isEmpty())
             <div class="alert alert-secondary">
                 データがありません

--- a/resources/views/user/stats/components/used-tags.blade.php
+++ b/resources/views/user/stats/components/used-tags.blade.php
@@ -2,7 +2,7 @@
 <div class="row">
     <div class="col-md-6">
         <h6 class="mb-2 text-center"><span class="tis-stat-table-category-checkin">チェックインタグ</span></h6>
-        <p class="mb-3 text-center"><small class="text-muted">チェックインに直接入力したタグの集計です。</small></p>
+        <p class="mb-3 text-center"><small class="text-muted">チェックインに追加したタグの集計です。</small></p>
         @if ($tags->isEmpty())
             <div class="alert alert-secondary">
                 データがありません

--- a/resources/views/user/stats/components/used-tags.blade.php
+++ b/resources/views/user/stats/components/used-tags.blade.php
@@ -1,6 +1,8 @@
+<h5 class="mb-4">最も使用したタグ</h5>
 <div class="row">
     <div class="col-md-6">
-        <h5 class="mb-4">最も使用したタグ</h5>
+        <h6 class="mb-2 text-center"><span class="tis-stat-table-category-checkin">チェックインタグ</span></h6>
+        <p class="mb-3 text-center"><small class="text-muted">直接入力されたタグのみ集計しています。</small></p>
         @if ($tags->isEmpty())
             <div class="alert alert-secondary">
                 データがありません
@@ -19,7 +21,8 @@
         @endif
     </div>
     <div class="col-md-6">
-        <h5 class="mb-4">オカズを含む最も使用したタグ</h5>
+        <h6 class="mt-3 mt-md-0 mb-2 text-center"><span class="tis-stat-table-category-checkin">チェックインタグ</span> + <span class="tis-stat-table-category-metadata">オカズタグ</span></h6>
+        <p class="mb-3 text-center"><small class="text-muted">オカズ自体のタグも含めた集計です。</small></p>
         @if ($tagsIncludesMetadata->isEmpty())
             <div class="alert alert-secondary">
                 データがありません

--- a/resources/views/user/stats/components/used-tags.blade.php
+++ b/resources/views/user/stats/components/used-tags.blade.php
@@ -8,12 +8,16 @@
                 データがありません
             </div>
         @else
-            <table class="table table-striped border">
+            <table class="table table-striped border tis-stat-table">
                 <tbody>
                 @foreach ($tags as $tag)
                     <tr>
-                        <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
-                        <td class="text-right">{{ number_format($tag->count) }}</td>
+                        <td>
+                            <a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a>
+                        </td>
+                        <td class="text-right">
+                            <a class="text-reset text-decoration-none" href="{{ route('search', ['q' => $tag->name]) }}">{{ number_format($tag->count) }}</a>
+                        </td>
                     </tr>
                 @endforeach
                 </tbody>
@@ -28,12 +32,16 @@
                 データがありません
             </div>
         @else
-            <table class="table table-striped border">
+            <table class="table table-striped border tis-stat-table">
                 <tbody>
                 @foreach ($tagsIncludesMetadata as $tag)
                     <tr>
-                        <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
-                        <td class="text-right">{{ number_format($tag->count) }}</td>
+                        <td>
+                            <a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a>
+                        </td>
+                        <td class="text-right">
+                            <a class="text-reset text-decoration-none" href="{{ route('search', ['q' => $tag->name]) }}">{{ number_format($tag->count) }}</a>
+                        </td>
                     </tr>
                 @endforeach
                 </tbody>

--- a/resources/views/user/stats/components/used-tags.blade.php
+++ b/resources/views/user/stats/components/used-tags.blade.php
@@ -1,0 +1,35 @@
+<h5 class="my-4">最も使用したタグ</h5>
+@if ($tags->isEmpty())
+    <div class="alert alert-secondary">
+        データがありません
+    </div>
+@else
+    <table class="table table-striped border">
+        <tbody>
+        @foreach ($tags as $tag)
+            <tr>
+                <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
+                <td class="text-right">{{ number_format($tag->count) }}</td>
+            </tr>
+        @endforeach
+        </tbody>
+    </table>
+@endif
+<hr class="my-4">
+<h5 class="my-4">最も使用したタグ (オカズのタグを含む)</h5>
+@if ($tagsIncludesMetadata->isEmpty())
+    <div class="alert alert-secondary">
+        データがありません
+    </div>
+@else
+    <table class="table table-striped border">
+        <tbody>
+        @foreach ($tagsIncludesMetadata as $tag)
+            <tr>
+                <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
+                <td class="text-right">{{ number_format($tag->count) }}</td>
+            </tr>
+        @endforeach
+        </tbody>
+    </table>
+@endif

--- a/resources/views/user/stats/index.blade.php
+++ b/resources/views/user/stats/index.blade.php
@@ -11,6 +11,24 @@
     <hr class="my-4">
     <h5 class="my-4">曜日別チェックイン回数</h5>
     <canvas id="dow-graph" class="w-100"></canvas>
+    <hr class="my-4">
+    <h5 class="my-4">最も使用したタグ</h5>
+    @if ($tags->isEmpty())
+        <div class="alert alert-secondary">
+            データがありません
+        </div>
+    @else
+        <table class="table table-striped border">
+            <tbody>
+            @foreach ($tags as $tag)
+                <tr>
+                    <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
+                    <td class="text-right">{{ number_format($tag->count) }}</td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+    @endif
 @endsection
 
 @push('script')

--- a/resources/views/user/stats/index.blade.php
+++ b/resources/views/user/stats/index.blade.php
@@ -12,41 +12,7 @@
     <h5 class="my-4">曜日別チェックイン回数</h5>
     <canvas id="dow-graph" class="w-100"></canvas>
     <hr class="my-4">
-    <h5 class="my-4">最も使用したタグ</h5>
-    @if ($tags->isEmpty())
-        <div class="alert alert-secondary">
-            データがありません
-        </div>
-    @else
-        <table class="table table-striped border">
-            <tbody>
-            @foreach ($tags as $tag)
-                <tr>
-                    <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
-                    <td class="text-right">{{ number_format($tag->count) }}</td>
-                </tr>
-            @endforeach
-            </tbody>
-        </table>
-    @endif
-    <hr class="my-4">
-    <h5 class="my-4">最も使用したタグ (オカズのタグを含む)</h5>
-    @if ($tagsIncludesMetadata->isEmpty())
-        <div class="alert alert-secondary">
-            データがありません
-        </div>
-    @else
-        <table class="table table-striped border">
-            <tbody>
-            @foreach ($tagsIncludesMetadata as $tag)
-                <tr>
-                    <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
-                    <td class="text-right">{{ number_format($tag->count) }}</td>
-                </tr>
-            @endforeach
-            </tbody>
-        </table>
-    @endif
+    @include('user.stats.components.used-tags')
 @endsection
 
 @push('script')

--- a/resources/views/user/stats/index.blade.php
+++ b/resources/views/user/stats/index.blade.php
@@ -29,6 +29,24 @@
             </tbody>
         </table>
     @endif
+    <hr class="my-4">
+    <h5 class="my-4">最も使用したタグ (オカズのタグを含む)</h5>
+    @if ($tagsIncludesMetadata->isEmpty())
+        <div class="alert alert-secondary">
+            データがありません
+        </div>
+    @else
+        <table class="table table-striped border">
+            <tbody>
+            @foreach ($tagsIncludesMetadata as $tag)
+                <tr>
+                    <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
+                    <td class="text-right">{{ number_format($tag->count) }}</td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+    @endif
 @endsection
 
 @push('script')

--- a/resources/views/user/stats/monthly.blade.php
+++ b/resources/views/user/stats/monthly.blade.php
@@ -26,6 +26,24 @@
             </tbody>
         </table>
     @endif
+    <hr class="my-4">
+    <h5 class="my-4">最も使用したタグ (オカズのタグを含む)</h5>
+    @if ($tagsIncludesMetadata->isEmpty())
+        <div class="alert alert-secondary">
+            データがありません
+        </div>
+    @else
+        <table class="table table-striped border">
+            <tbody>
+            @foreach ($tagsIncludesMetadata as $tag)
+                <tr>
+                    <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
+                    <td class="text-right">{{ number_format($tag->count) }}</td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+    @endif
 @endsection
 
 @push('script')

--- a/resources/views/user/stats/monthly.blade.php
+++ b/resources/views/user/stats/monthly.blade.php
@@ -8,6 +8,24 @@
     <hr class="my-4">
     <h5 class="my-4">曜日別チェックイン回数</h5>
     <canvas id="dow-graph" class="w-100"></canvas>
+    <hr class="my-4">
+    <h5 class="my-4">最も使用したタグ</h5>
+    @if ($tags->isEmpty())
+        <div class="alert alert-secondary">
+            データがありません
+        </div>
+    @else
+        <table class="table table-striped border">
+            <tbody>
+            @foreach ($tags as $tag)
+                <tr>
+                    <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
+                    <td class="text-right">{{ number_format($tag->count) }}</td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+    @endif
 @endsection
 
 @push('script')

--- a/resources/views/user/stats/monthly.blade.php
+++ b/resources/views/user/stats/monthly.blade.php
@@ -9,41 +9,7 @@
     <h5 class="my-4">曜日別チェックイン回数</h5>
     <canvas id="dow-graph" class="w-100"></canvas>
     <hr class="my-4">
-    <h5 class="my-4">最も使用したタグ</h5>
-    @if ($tags->isEmpty())
-        <div class="alert alert-secondary">
-            データがありません
-        </div>
-    @else
-        <table class="table table-striped border">
-            <tbody>
-            @foreach ($tags as $tag)
-                <tr>
-                    <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
-                    <td class="text-right">{{ number_format($tag->count) }}</td>
-                </tr>
-            @endforeach
-            </tbody>
-        </table>
-    @endif
-    <hr class="my-4">
-    <h5 class="my-4">最も使用したタグ (オカズのタグを含む)</h5>
-    @if ($tagsIncludesMetadata->isEmpty())
-        <div class="alert alert-secondary">
-            データがありません
-        </div>
-    @else
-        <table class="table table-striped border">
-            <tbody>
-            @foreach ($tagsIncludesMetadata as $tag)
-                <tr>
-                    <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
-                    <td class="text-right">{{ number_format($tag->count) }}</td>
-                </tr>
-            @endforeach
-            </tbody>
-        </table>
-    @endif
+    @include('user.stats.components.used-tags')
 @endsection
 
 @push('script')

--- a/resources/views/user/stats/yearly.blade.php
+++ b/resources/views/user/stats/yearly.blade.php
@@ -36,6 +36,24 @@
             </tbody>
         </table>
     @endif
+    <hr class="my-4">
+    <h5 class="my-4">最も使用したタグ (オカズのタグを含む)</h5>
+    @if ($tagsIncludesMetadata->isEmpty())
+        <div class="alert alert-secondary">
+            データがありません
+        </div>
+    @else
+        <table class="table table-striped border">
+            <tbody>
+            @foreach ($tagsIncludesMetadata as $tag)
+                <tr>
+                    <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
+                    <td class="text-right">{{ number_format($tag->count) }}</td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+    @endif
 @endsection
 
 @push('script')

--- a/resources/views/user/stats/yearly.blade.php
+++ b/resources/views/user/stats/yearly.blade.php
@@ -19,41 +19,7 @@
     <h5 class="my-4">曜日別チェックイン回数</h5>
     <canvas id="dow-graph" class="w-100"></canvas>
     <hr class="my-4">
-    <h5 class="my-4">最も使用したタグ</h5>
-    @if ($tags->isEmpty())
-        <div class="alert alert-secondary">
-            データがありません
-        </div>
-    @else
-        <table class="table table-striped border">
-            <tbody>
-            @foreach ($tags as $tag)
-                <tr>
-                    <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
-                    <td class="text-right">{{ number_format($tag->count) }}</td>
-                </tr>
-            @endforeach
-            </tbody>
-        </table>
-    @endif
-    <hr class="my-4">
-    <h5 class="my-4">最も使用したタグ (オカズのタグを含む)</h5>
-    @if ($tagsIncludesMetadata->isEmpty())
-        <div class="alert alert-secondary">
-            データがありません
-        </div>
-    @else
-        <table class="table table-striped border">
-            <tbody>
-            @foreach ($tagsIncludesMetadata as $tag)
-                <tr>
-                    <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
-                    <td class="text-right">{{ number_format($tag->count) }}</td>
-                </tr>
-            @endforeach
-            </tbody>
-        </table>
-    @endif
+    @include('user.stats.components.used-tags')
 @endsection
 
 @push('script')

--- a/resources/views/user/stats/yearly.blade.php
+++ b/resources/views/user/stats/yearly.blade.php
@@ -18,6 +18,24 @@
     <hr class="my-4">
     <h5 class="my-4">曜日別チェックイン回数</h5>
     <canvas id="dow-graph" class="w-100"></canvas>
+    <hr class="my-4">
+    <h5 class="my-4">最も使用したタグ</h5>
+    @if ($tags->isEmpty())
+        <div class="alert alert-secondary">
+            データがありません
+        </div>
+    @else
+        <table class="table table-striped border">
+            <tbody>
+            @foreach ($tags as $tag)
+                <tr>
+                    <td><a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a></td>
+                    <td class="text-right">{{ number_format($tag->count) }}</td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+    @endif
 @endsection
 
 @push('script')


### PR DESCRIPTION
グラフページに、指定期間中に自分がよく使ったタグ、それに加えてオカズに付いていたタグも考慮した集計を追加します。  
目的としては、ある期間によく使ったオカズの傾向を知るための1資料として使えるかなと思ってのことです。

## Screenshot

![image](https://user-images.githubusercontent.com/1352154/101421048-d0db9200-3936-11eb-98ab-d3abbf9b8cd5.png)
