### PR TITLE
タグ入力欄からフォーカスが外れた時、入力があるならタグとして確定させる

### DIFF
--- a/resources/assets/js/components/TagInput.tsx
+++ b/resources/assets/js/components/TagInput.tsx
@@ -23,8 +23,7 @@ export const TagInput: React.FC<TagInputProps> = ({ id, name, values, isInvalid,
                 case 'Enter':
                 case ' ':
                     if ((event as any).isComposing !== true) {
-                        onChange && onChange(values.concat(buffer.trim().replace(/\s+/g, '_')));
-                        setBuffer('');
+                        commitBuffer();
                     }
                     event.preventDefault();
                     break;
@@ -32,8 +31,7 @@ export const TagInput: React.FC<TagInputProps> = ({ id, name, values, isInvalid,
                     // 実際にテキストボックスに入力されている文字を見に行く (フォールバック処理)
                     const nativeEvent = event.nativeEvent;
                     if (nativeEvent.srcElement && (nativeEvent.srcElement as HTMLInputElement).value.slice(-1) == ' ') {
-                        onChange && onChange(values.concat(buffer.trim().replace(/\s+/g, '_')));
-                        setBuffer('');
+                        commitBuffer();
                         event.preventDefault();
                     }
                     break;
@@ -43,6 +41,13 @@ export const TagInput: React.FC<TagInputProps> = ({ id, name, values, isInvalid,
             // 誤爆防止
             event.preventDefault();
         }
+    };
+
+    const commitBuffer = () => {
+        const newTag = buffer.trim().replace(/\s+/g, '_');
+        if (newTag.length === 0) return;
+        onChange && onChange(values.concat(newTag));
+        setBuffer('');
     };
 
     return (
@@ -66,6 +71,7 @@ export const TagInput: React.FC<TagInputProps> = ({ id, name, values, isInvalid,
                         className="tis-tag-input-field"
                         value={buffer}
                         onChange={(e) => setBuffer(e.target.value)}
+                        onBlur={commitBuffer}
                         onKeyDown={onKeyDown}
                     />
                 </li>


### PR DESCRIPTION
![2020-12-12_19-42-56](https://user-images.githubusercontent.com/3516343/101981729-4b4b3f80-3cb2-11eb-92cd-0431750cb936.gif)

スマホから使っているとタグの入力を確定させずにチェックインボタンを押すことが多発したためです

## before
![before](https://user-images.githubusercontent.com/3516343/101981786-a67d3200-3cb2-11eb-9a35-056fed31f51f.gif)

## after
![after](https://user-images.githubusercontent.com/3516343/101981785-a54c0500-3cb2-11eb-913f-a0cb9b2a95f0.gif)
