### PR TITLE
OGPResolver::parse() にタグ優先度を指定できるようにする

### DIFF
--- a/app/MetadataResolver/OGPParsePriority.php
+++ b/app/MetadataResolver/OGPParsePriority.php
@@ -45,19 +45,25 @@ class OGPParsePriority
     {
         switch ($priority) {
             case self::OGP:
-                $preferred = array_filter($expressions, function ($expr) {
-                    return stripos($expr, 'og:') !== false;
-                });
+                $needle = 'og:';
                 break;
             case self::TWITTER_CARDS:
-                $preferred = array_filter($expressions, function ($expr) {
-                    return stripos($expr, 'twitter:') !== false;
-                });
+                $needle = 'twitter:';
                 break;
             default:
                 throw new \InvalidArgumentException('$priority has an invalid value.');
         }
 
-        return array_values(array_unique(array_merge($preferred, $expressions)));
+        $preferred = [];
+        $rest = [];
+        foreach ($expressions as $expr) {
+            if (stripos($expr, $needle) !== false) {
+                $preferred[] = $expr;
+            } else {
+                $rest[] = $expr;
+            }
+        }
+
+        return array_merge($preferred, $rest);
     }
 }

--- a/app/MetadataResolver/OGPParsePriority.php
+++ b/app/MetadataResolver/OGPParsePriority.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\MetadataResolver;
+
+class OGPParsePriority
+{
+    const OGP = 0;
+    const TWITTER_CARDS = 1;
+
+    /** @var int */
+    private $title = self::OGP;
+    /** @var int */
+    private $description = self::OGP;
+    /** @var int */
+    private $image = self::OGP;
+
+    public static function preferTo(int $priority): OGPParsePriority
+    {
+        return new static($priority, $priority, $priority);
+    }
+
+    public function __construct(int $title = self::OGP, int $description = self::OGP, int $image = self::OGP)
+    {
+        $this->title = $title;
+        $this->description = $description;
+        $this->image = $image;
+    }
+
+    public function sortForTitle(string ...$expressions): array
+    {
+        return $this->sort($this->title, ...$expressions);
+    }
+
+    public function sortForDescription(string ...$expressions): array
+    {
+        return $this->sort($this->description, ...$expressions);
+    }
+
+    public function sortForImage(string ...$expressions): array
+    {
+        return $this->sort($this->image, ...$expressions);
+    }
+
+    private function sort(int $priority, string ...$expressions): array
+    {
+        switch ($priority) {
+            case self::OGP:
+                $preferred = array_filter($expressions, function ($expr) {
+                    return stripos($expr, 'og:') !== false;
+                });
+                break;
+            case self::TWITTER_CARDS:
+                $preferred = array_filter($expressions, function ($expr) {
+                    return stripos($expr, 'twitter:') !== false;
+                });
+                break;
+            default:
+                throw new \InvalidArgumentException('$priority has an invalid value.');
+        }
+
+        return array_values(array_unique(array_merge($preferred, $expressions)));
+    }
+}

--- a/app/MetadataResolver/OGPResolver.php
+++ b/app/MetadataResolver/OGPResolver.php
@@ -35,7 +35,7 @@ class OGPResolver implements Resolver, Parser
 
         $metadata = new Metadata();
 
-        $metadata->title = $this->findContent($xpath, $priority->sortForTitle('//meta[@*="og:title"]', '//meta[@*="twitter:title"]'));
+        $metadata->title = $this->findContent($xpath, ...$priority->sortForTitle('//meta[@*="og:title"]', '//meta[@*="twitter:title"]'));
         if (empty($metadata->title)) {
             $nodes = $xpath->query('//title');
             if ($nodes->length !== 0) {
@@ -44,9 +44,9 @@ class OGPResolver implements Resolver, Parser
         }
         $metadata->description = $this->findContent(
             $xpath,
-            $priority->sortForDescription('//meta[@*="og:description"]', '//meta[@*="twitter:description"]', '//meta[@name="description"]')
+            ...$priority->sortForDescription('//meta[@*="og:description"]', '//meta[@*="twitter:description"]', '//meta[@name="description"]')
         );
-        $metadata->image = $this->findContent($xpath, $priority->sortForImage('//meta[@*="og:image"]', '//meta[@*="twitter:image"]'));
+        $metadata->image = $this->findContent($xpath, ...$priority->sortForImage('//meta[@*="og:image"]', '//meta[@*="twitter:image"]'));
 
         return $metadata;
     }

--- a/app/MetadataResolver/OGPResolver.php
+++ b/app/MetadataResolver/OGPResolver.php
@@ -23,23 +23,30 @@ class OGPResolver implements Resolver, Parser
         return $this->parse($this->client->get($url, [RequestOptions::COOKIES => new CookieJar()])->getBody());
     }
 
-    public function parse(string $html): Metadata
+    public function parse(string $html, ?OGPParsePriority $priority = null): Metadata
     {
+        if ($priority === null) {
+            $priority = OGPParsePriority::preferTo(OGPParsePriority::OGP);
+        }
+
         $dom = new \DOMDocument();
         @$dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'ASCII,JIS,UTF-8,eucJP-win,SJIS-win'));
         $xpath = new \DOMXPath($dom);
 
         $metadata = new Metadata();
 
-        $metadata->title = $this->findContent($xpath, '//meta[@*="og:title"]', '//meta[@*="twitter:title"]');
+        $metadata->title = $this->findContent($xpath, $priority->sortForTitle('//meta[@*="og:title"]', '//meta[@*="twitter:title"]'));
         if (empty($metadata->title)) {
             $nodes = $xpath->query('//title');
             if ($nodes->length !== 0) {
                 $metadata->title = $nodes->item(0)->textContent;
             }
         }
-        $metadata->description = $this->findContent($xpath, '//meta[@*="og:description"]', '//meta[@*="twitter:description"]', '//meta[@name="description"]');
-        $metadata->image = $this->findContent($xpath, '//meta[@*="og:image"]', '//meta[@*="twitter:image"]');
+        $metadata->description = $this->findContent(
+            $xpath,
+            $priority->sortForDescription('//meta[@*="og:description"]', '//meta[@*="twitter:description"]', '//meta[@name="description"]')
+        );
+        $metadata->image = $this->findContent($xpath, $priority->sortForImage('//meta[@*="og:image"]', '//meta[@*="twitter:image"]'));
 
         return $metadata;
     }

--- a/tests/Unit/MetadataResolver/OGPParsePriorityTest.php
+++ b/tests/Unit/MetadataResolver/OGPParsePriorityTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit\MetadataResolver;
+
+use App\MetadataResolver\OGPParsePriority;
+use Tests\TestCase;
+
+class OGPParsePriorityTest extends TestCase
+{
+    public function testPreferToOGP()
+    {
+        $prio = OGPParsePriority::preferTo(OGPParsePriority::OGP);
+
+        $this->assertSame(
+            ['//meta[@*="og:description"]', '//meta[@*="twitter:description"]', '//meta[@name="description"]'],
+            $prio->sortForTitle('//meta[@*="og:description"]', '//meta[@*="twitter:description"]', '//meta[@name="description"]')
+        );
+        $this->assertSame(
+            ['//meta[@*="og:description"]', '//meta[@*="twitter:description"]', '//meta[@name="description"]'],
+            $prio->sortForTitle('//meta[@*="twitter:description"]', '//meta[@*="og:description"]', '//meta[@name="description"]')
+        );
+    }
+
+    public function testPreferToTwitterCards()
+    {
+        $prio = OGPParsePriority::preferTo(OGPParsePriority::TWITTER_CARDS);
+
+        $this->assertSame(
+            ['//meta[@*="twitter:description"]', '//meta[@*="og:description"]', '//meta[@name="description"]'],
+            $prio->sortForTitle('//meta[@*="og:description"]', '//meta[@*="twitter:description"]', '//meta[@name="description"]')
+        );
+        $this->assertSame(
+            ['//meta[@*="twitter:description"]', '//meta[@*="og:description"]', '//meta[@name="description"]'],
+            $prio->sortForTitle('//meta[@*="twitter:description"]', '//meta[@*="og:description"]', '//meta[@name="description"]')
+        );
+    }
+}


### PR DESCRIPTION
内部APIとして欲しい的な要望があったので。

OGPResolver::parse() の第2引数として、タグの優先度を指定するためのオブジェクトを入力できるようにした。  
このオブジェクトは一般的には OGPParsePriority::preferTo() で生成する。全ての目的 (タイトルとか、詳細とか) で指定した優先度を使うという意味で、大抵はこれで事足りると思う。  
タイトルだけTwitter Cardsを優先するといったような指定が必要な場合は、コンストラクタを使えば目的ごとに別々の優先度を指定することができる。