### PR TITLE
既に追加されているタグを候補から追加できるバグの修正

### DIFF
--- a/resources/assets/js/components/MetadataPreview.tsx
+++ b/resources/assets/js/components/MetadataPreview.tsx
@@ -136,7 +136,7 @@ export const MetadataPreview: React.FC<MetadataPreviewProps> = ({ link, tags, on
                                                     <li
                                                         key={tag.name}
                                                         className={tagClasses(tag)}
-                                                        onClick={() => onClickTag(tag.name)}
+                                                        onClick={() => !tag.used && onClickTag(tag.name)}
                                                     >
                                                         <span className="oi oi-tag" /> {tag.name}
                                                     </li>


### PR DESCRIPTION
オカズリンクから表示したタグ候補が無限にクリックできたので修正しました。  
Vue.js時代はこんなん無かったと思うので、たぶんReactに移行した時にデグレした。