### PR TITLE
macOSにおけるタグ確定処理のデグレード修正

### DIFF
--- a/resources/assets/js/components/TagInput.tsx
+++ b/resources/assets/js/components/TagInput.tsx
@@ -22,7 +22,7 @@ export const TagInput: React.FC<TagInputProps> = ({ id, name, values, isInvalid,
                 case 'Tab':
                 case 'Enter':
                 case ' ':
-                    if ((event as any).isComposing !== true) {
+                    if (!event.nativeEvent.isComposing) {
                         commitBuffer();
                     }
                     event.preventDefault();


### PR DESCRIPTION
Reactに移行する際に #184 の対応が適切に移植されていなかった。

- ArchLinux / Chromium 87.0.4280.141 / fcitx-skk
- macOS 10.15.7 / Chrome 87.0.4280.141 / AquaSKK
- macOS 10.15.7 / Safari 14.0.2 / AquaSKK

で確認済。