### PR TITLE
NarouResolverの修正と改善

### DIFF
--- a/app/MetadataResolver/MetadataResolver.php
+++ b/app/MetadataResolver/MetadataResolver.php
@@ -26,7 +26,7 @@ class MetadataResolver implements Resolver
         '~dmm\.co\.jp/~' => FanzaResolver::class,
         '~www\.patreon\.com/~' => PatreonResolver::class,
         '~www\.deviantart\.com/.*/art/.*~' => DeviantArtResolver::class,
-        '~\.syosetu\.com/n\d+[a-z]+~' => NarouResolver::class,
+        '~\.syosetu\.com/(novelview/infotop/ncode/)?n\d+[a-z]+~' => NarouResolver::class,
         '~ci-en\.(jp|net|dlsite\.com)/creator/\d+/article/\d+~' => CienResolver::class,
         '~www\.plurk\.com\/p\/.*~' => PlurkResolver::class,
         '~store\.steampowered\.com/app/\d+~' => SteamResolver::class,

--- a/app/MetadataResolver/NarouResolver.php
+++ b/app/MetadataResolver/NarouResolver.php
@@ -4,7 +4,6 @@ namespace App\MetadataResolver;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
-use Symfony\Component\DomCrawler\Crawler;
 
 class NarouResolver implements Resolver
 {

--- a/app/MetadataResolver/NarouResolver.php
+++ b/app/MetadataResolver/NarouResolver.php
@@ -4,6 +4,7 @@ namespace App\MetadataResolver;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
+use Symfony\Component\DomCrawler\Crawler;
 
 class NarouResolver implements Resolver
 {
@@ -26,30 +27,54 @@ class NarouResolver implements Resolver
     {
         $cookieJar = CookieJar::fromArray(['over18' => 'yes'], '.syosetu.com');
 
-        $res = $this->client->get($url, ['cookies' => $cookieJar]);
-        $metadata = $this->ogpResolver->parse($res->getBody());
-        $metadata->description = '';
 
+        preg_match('~\.syosetu\.com/(?P<ncode>n\d+[a-z]+)~', $url, $matches);
+        $ncode = $matches['ncode'];
+
+        $res = $this->client->get("https://novel18.syosetu.com/novelview/infotop/ncode/$ncode/", ['cookies' => $cookieJar]);
+        $html = $res->getBody()->getContents();
+
+        // 一見旧式のDOMDocumentを使っているように見えるがこれは罠で、なろうのHTMLはDOMCrawlerだとパースに失敗する
         $dom = new \DOMDocument();
-        @$dom->loadHTML(mb_convert_encoding($res->getBody(), 'HTML-ENTITIES', 'ASCII,JIS,UTF-8,eucJP-win,SJIS-win'));
+        @$dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'ASCII,JIS,UTF-8,eucJP-win,SJIS-win'));
         $xpath = new \DOMXPath($dom);
 
+        $metadata = $this->ogpResolver->parse($html);
         $description = [];
 
+        // タイトル
+        $titleNodeList = $xpath->query('//h1/a');
+        if ($titleNodeList->length !== 0) {
+            $metadata->title = $titleNodeList->item(0)->textContent;
+        }
+
+        // タグ
+        $keywordNodeList = $xpath->query('//th[contains(text(), "キーワード")]/following-sibling::td[1]');
+        if ($keywordNodeList->length !== 0) {
+            $keyword =  trim($keywordNodeList->item(0)->textContent);
+            $metadata->tags = explode(' ', $keyword);
+        }
+
         // 作者名
-        $writerNodes = $xpath->query('//*[contains(@class, "novel_writername")]');
-        if ($writerNodes->length !== 0 && !empty($writerNodes->item(0)->textContent)) {
-            $description[] = trim($writerNodes->item(0)->textContent);
+        $authorNodeList = $xpath->query('//a[contains(@href,"mypage.syosetu.com")]');
+        if ($authorNodeList->length !== 0) {
+            $description[] = '作者: ' . trim($authorNodeList->item(0)->textContent);
         }
 
-        // あらすじ
-        $exNodes = $xpath->query('//*[@id="novel_ex"]');
-        if ($exNodes->length !== 0 && !empty($exNodes->item(0)->textContent)) {
-            $summary = trim($exNodes->item(0)->textContent);
-            $description[] = mb_strimwidth($summary, 0, 101, '…'); // 100 + '…'(1)
+        // あらすじがあれば先頭150文字を取得する
+        $exNodeList = $xpath->query('//td[@class="ex"]');
+        if ($exNodeList->length !== 0) {
+            $summary = trim($exNodeList->item(0)->textContent);
+            // 長過ぎたら150文字に切って「……」をつける
+            if (mb_strlen($summary) >= 148) {
+                $description[] = mb_substr($summary, 0, 150) . '……';
+            } else {
+                $description[] = $summary;
+            }
         }
 
-        $metadata->description = implode(' / ', $description);
+        // 作者名とあらすじをくっつける
+        $metadata->description = implode("\n", $description);
 
         return $metadata;
     }

--- a/app/MetadataResolver/NarouResolver.php
+++ b/app/MetadataResolver/NarouResolver.php
@@ -27,7 +27,7 @@ class NarouResolver implements Resolver
         $cookieJar = CookieJar::fromArray(['over18' => 'yes'], '.syosetu.com');
 
 
-        preg_match('~\.syosetu\.com/(?P<ncode>n\d+[a-z]+)~', $url, $matches);
+        preg_match('~\.syosetu\.com/(novelview/infotop/ncode/)?(?P<ncode>n\d+[a-z]+)~', $url, $matches);
         $ncode = $matches['ncode'];
 
         $res = $this->client->get("https://novel18.syosetu.com/novelview/infotop/ncode/$ncode/", ['cookies' => $cookieJar]);

--- a/tests/Unit/MetadataResolver/NarouResolverTest.php
+++ b/tests/Unit/MetadataResolver/NarouResolverTest.php
@@ -32,4 +32,34 @@ class NarouResolverTest extends TestCase
             $this->assertSame('https://novel18.syosetu.com/novelview/infotop/ncode/n2978fx/', (string) $this->handler->getLastRequest()->getUri());
         }
     }
+
+    public function testNovelViewURL()
+    {
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Narou/novel.html');
+
+        $this->createResolver(NarouResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://novel18.syosetu.com/novelview/infotop/ncode/n2978fx/');
+        $this->assertEquals('ぱんつ売りの少女', $metadata->title);
+        $this->assertEquals("作者: 飴宮　地下\n冴えない男「ハルノ・ヒトキ」が仕事からの帰宅途中で美少女に声を掛けられる。\n驚いた事に少女の目的は自分の下着を売る事だった。\nお金に困っていた少女は徐々にヒトキに下着を売っていたが段々とその内容がエスカレートして行き……。", $metadata->description);
+        $this->assertEquals(['ギャグ', '男主人公', '現代', '下着', '匂いフェチ', 'ブルセラ'], $metadata->tags);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://novel18.syosetu.com/novelview/infotop/ncode/n2978fx/', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
+
+    public function testLongDescriptionNovel()
+    {
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Narou/novel_longdescription.html');
+
+        $this->createResolver(NarouResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://novel18.syosetu.com/n0477gn/');
+        $this->assertEquals('俺のことが好き過ぎる双子の天才妹が、「妹と結婚して子作りすること」を合法化して二人がかりで精液を搾りとってくる話', $metadata->title);
+        $this->assertEquals("作者: 伍式\n巨大財閥の跡取りである高校生「菊川笙(きくかわしょう)」。その双子の妹、貧乳美尻丁寧語の「菊川琴(こと)」と巨乳巨尻甘えん坊の「菊川鈴(すず)」。\n巨大財閥を実質的に動かしている天才双子妹は、しかし兄を盲愛して兄の精液で孕みたいと固く決意しているダブルブラコン妹だった。\nある時妹たち二人と一緒に高級……", $metadata->description);
+        $this->assertEquals(['ほのぼの', '男主人公', '妹', 'いちゃらぶ', '近親相姦', 'オナニー', '見せつけ', '尻合わせ', '孕ませっくす', '自慰', '尻ズリ', '兄妹', '双子', 'だいしゅきホールド', '膝立ちバック'], $metadata->tags);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://novel18.syosetu.com/novelview/infotop/ncode/n0477gn/', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
 }

--- a/tests/Unit/MetadataResolver/NarouResolverTest.php
+++ b/tests/Unit/MetadataResolver/NarouResolverTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit\MetadataResolver;
+
+use App\MetadataResolver\NarouResolver;
+use Tests\TestCase;
+
+class NarouResolverTest extends TestCase
+{
+    use CreateMockedResolver;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (!$this->shouldUseMock()) {
+            sleep(1);
+        }
+    }
+
+    public function testNovel()
+    {
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Narou/novel.html');
+
+        $this->createResolver(NarouResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://novel18.syosetu.com/n2978fx/');
+        $this->assertEquals('ぱんつ売りの少女', $metadata->title);
+        $this->assertEquals("作者: 飴宮　地下\n冴えない男「ハルノ・ヒトキ」が仕事からの帰宅途中で美少女に声を掛けられる。\n驚いた事に少女の目的は自分の下着を売る事だった。\nお金に困っていた少女は徐々にヒトキに下着を売っていたが段々とその内容がエスカレートして行き……。", $metadata->description);
+        $this->assertEquals(['ギャグ', '男主人公', '現代', '下着', '匂いフェチ', 'ブルセラ'], $metadata->tags);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://novel18.syosetu.com/novelview/infotop/ncode/n2978fx/', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
+}

--- a/tests/fixture/Narou/novel.html
+++ b/tests/fixture/Narou/novel.html
@@ -1,0 +1,402 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ja" lang="ja">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<title>ぱんつ売りの少女[小説情報]</title>
+<meta http-equiv="Content-Script-Type" content="text/javascript" />
+<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta name="format-detection" content="telephone=no" />
+
+
+<link rel="shortcut icon" href="https://static.syosetu.com/sub/nocview/images/noc.ico" />
+<link rel="icon" href="https://static.syosetu.com/sub/nocview/images/noc.ico" />
+<link rel="apple-touch-icon-precomposed" href="https://static.syosetu.com/sub/nocview/images/apple-touch-icon-precomposed.png?ojjr8y" />
+
+<link href="https://api.syosetu.com/writernovel/x7552j.Atom" rel="alternate" type="application/atom+xml" title="Atom" />
+
+<link rel="stylesheet" type="text/css" href="https://static.syosetu.com/novelview/css/reset.css?piu6zr" media="screen,print" />
+<link rel="stylesheet" type="text/css" href="https://static.syosetu.com/view/css/lib/jquery.hina.css?oyb9lo" media="screen,print" />
+
+<link rel="stylesheet" type="text/css" href="https://static.syosetu.com/novelview/css/novel_view.css?q611hx" media="screen,print" /><link rel="stylesheet" type="text/css" href="https://static.syosetu.com/novelview/css/infotop.css?pyfhdd" media="screen,print" />
+
+
+<script type="text/javascript"><!--
+var domain = 'syosetu.com';
+function wOpen(URL,NAME,OPTION){WO1 = window.open(URL,NAME,OPTION);WO1.window.focus();}
+//--></script>
+
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+<script type="text/javascript" src="https://static.syosetu.com/view/js/lib/jquery.hina.js?oyez8w"></script>
+<script type="text/javascript" src="https://static.syosetu.com/view/js/global.js?oyez8w"></script>
+<script type="text/javascript" src="https://static.syosetu.com/novelview/js/novelview.js?q0j60r"></script>
+
+
+
+<script type="text/javascript">
+var microadCompass = microadCompass || {};
+microadCompass.queue = microadCompass.queue || [];
+</script>
+<script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
+
+
+<!--
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+ xmlns:dc="http://purl.org/dc/elements/1.1/"
+ xmlns:trackback="http://madskills.com/public/xml/rss/module/trackback/">
+
+<rdf:Description
+rdf:about="https://novel18.syosetu.com/n2978fx/
+dc:identifier="https://novel18.syosetu.com/n2978fx/"
+dc:title="ぱんつ売りの少女"
+trackback:ping="https://trackback.syosetu.com/send/novel/ncode/1532825/" />
+</rdf:RDF>
+-->
+
+</head>
+<body onload="initRollovers();">
+
+<a id="pageBottom" href="#footer">↓</a>
+<div id="novel_header">
+<ul id="head_nav">
+<li id="login">
+<a href="https://ssl.syosetu.com/login/input/"><span class="attention">ログイン</span></a>
+</li>
+<li><a href="https://novel18.syosetu.com/novelview/infotop/ncode/n2978fx/">小説情報</a></li>
+<li><a href="https://novelcom18.syosetu.com/impression/list/ncode/1532825/">感想</a></li>
+<li><a href="https://novelcom18.syosetu.com/novelreview/list/ncode/1532825/">レビュー</a></li>
+<li><a href="https://pdfnovels.net/n2978fx/" class="menu" target="_blank">縦書きPDF</a></li>
+
+<li class="booklist"><span class="button_bookmark logout">ブックマークに追加</span></li>
+
+
+
+<li>
+<a
+style="border-left:none;"
+
+href="https://twitter.com/intent/tweet?text=%E3%80%90R18%E3%80%91%E3%81%B1%E3%82%93%E3%81%A4%E5%A3%B2%E3%82%8A%E3%81%AE%E5%B0%91%E5%A5%B3&amp;url=https%3A%2F%2Fnovel18.syosetu.com%2Fn2978fx%2F&amp;hashtags=narou%2CnarouN2978FX">
+
+<img src="https://static.syosetu.com/novelview/img/Twitter_logo_blue.png?nrkioy" class="menu" style="margin-left:7px; margin-right:7px;" height="20px" />
+</a>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+</li></ul>
+</div><!-- novel_header -->
+
+<div id="container">
+
+
+
+<div class="box_infotop_announce_bookmark announce_bookmark">ブックマーク登録する場合は<a href="https://ssl.syosetu.com/login/input/">ログイン</a>してください。</div>
+
+
+<div id="contents_main">
+
+<p title="Nコード" id="ncode">N2978FX</p>
+<h1><a href="https://novel18.syosetu.com/n2978fx/">ぱんつ売りの少女</a></h1>
+
+
+<div class="clearfix">
+<div id="infodata">
+
+<div id="pre_info">
+<span id="age_limit">R18</span>
+<span id="noveltype_notend">連載中</span>全13部分
+<a href="https://novel18.syosetu.com/n2978fx/1/">1部分目を読む</a>
+
+|<a href="https://novel18.syosetu.com/n2978fx/13/">最新部分を読む</a>
+</div>
+
+<table id="noveltable1">
+<tr>
+<th class="ex">あらすじ</th>
+<td class="ex">冴えない男「ハルノ・ヒトキ」が仕事からの帰宅途中で美少女に声を掛けられる。<br />
+驚いた事に少女の目的は自分の下着を売る事だった。<br />
+お金に困っていた少女は徐々にヒトキに下着を売っていたが段々とその内容がエスカレートして行き……。</td>
+</tr>
+<tr>
+<th>作者名</th>
+<td><a href="https://xmypage.syosetu.com/x7552j/">飴宮　地下</a>
+</td>
+</tr>
+<tr>
+<th>キーワード</th>
+<td>
+
+ギャグ 男主人公 現代 下着 匂いフェチ ブルセラ
+</td>
+</tr>
+<tr>
+<th>掲載サイト</th>
+<td>ノクターンノベルズ(男性向け)</td>
+</tr>
+</table>
+
+<div id="qr">
+<img class="images_qrcode" src="https://sbo.syosetu.com/n2978fx/qrcode.png" />
+<a href="https://kasasagi.hinaproject.com/access/top/ncode/n2978fx/">&gt;&gt;アクセス解析</a><br />
+System by <a href="https://kasasagi.hinaproject.com/" target="_blank">ＫＡＳＡＳＡＧＩ</a>
+</div>
+
+<table id="noveltable2">
+<tr>
+<th>掲載日</th>
+<td>2019年 12月09日 00時17分</td>
+</tr>
+<tr>
+<th>最新部分掲載日</th>
+<td>2019年 12月19日 00時03分</td>
+</tr>
+
+<tr>
+<th>感想</th>
+<td>
+10件
+
+<br /><span class="uketuke">※ログイン必須</span>
+</td>
+</tr>
+<tr>
+<th>レビュー</th>
+<td>
+0件
+</td>
+</tr>
+<tr>
+<th>ブックマーク登録</th>
+<td>250件</td>
+</tr>
+<tr>
+<th>総合評価</th>
+<td>641pt</td>
+</tr>
+<tr>
+<th>評価ポイント</th>
+<td>
+141pt
+
+
+</td>
+</tr>
+<tr>
+<th>誤字報告受付</th>
+<td>
+受け付けています<br /><span class="uketuke">※ログイン必須</span></td>
+</tr>
+<tr>
+<th>開示設定</th>
+<td>開示されています</td>
+</tr>
+<tr>
+<th>文字数</th>
+<td>63,365文字</td>
+</tr>
+</table>
+
+</div>
+
+<div id="ad_s_box">
+<a href="https://twitter.com/intent/tweet?text=%E3%80%90R18%E3%80%91%E3%80%8C%E3%81%B1%E3%82%93%E3%81%A4%E5%A3%B2%E3%82%8A%E3%81%AE%E5%B0%91%E5%A5%B3%E3%80%8D%E8%AA%AD%E3%82%93%E3%81%A0%EF%BC%81&url=https%3A%2F%2Fnovel18.syosetu.com%2Fn2978fx%2F&hashtags=narou%2CnarouN2978FX" class="twitter-share-button">Tweet</a>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+
+
+<div class="koukoku">
+
+<div id="9e33cdfe65377a2b3ae04fad9b872d2f" >
+<script type="text/javascript">
+microadCompass.queue.push({
+"spot": "9e33cdfe65377a2b3ae04fad9b872d2f",
+"url": "${COMPASS_EXT_URL}",
+"referrer": "${COMPASS_EXT_REF}"
+});
+</script>
+</div>
+
+
+</div>
+</div><!--ad_s_box-->
+</div><!-- clear -->
+
+<div id="novelindex_button"><a href="https://novel18.syosetu.com/n2978fx/">小説を読む</a></div>
+
+
+
+
+<div class="koukoku_728">
+
+<div id="3b20976a6299b62713a3f40e637416db" >
+<script type="text/javascript">
+microadCompass.queue.push({
+"spot": "3b20976a6299b62713a3f40e637416db",
+"url": "${COMPASS_EXT_URL}",
+"referrer": "${COMPASS_EXT_REF}"
+});
+</script>
+</div>
+
+
+</div><!--koukoku_728-->
+
+
+
+
+
+<div id="onazi">
+<div id="data_link">
+<h2>同一作者の小説</h2>
+<a href="https://xmypage.syosetu.com/mypage/novellist/xid/x7552j/">&gt;&gt;飴宮　地下&nbsp;先生の作品一覧を見る</a>
+</div><!--data_link-->
+
+<div class="th"><a href="https://novel18.syosetu.com/n2978fx/">ぱんつ売りの少女</a></div>
+
+<div class="info">
+N2978FX｜
+<a href="https://novel18.syosetu.com/novelview/infotop/ncode/n2978fx/">小説情報</a>｜
+連載(全13部分)
+｜
+ノクターンノベルズ(男性向け)
+</div>
+<div class="ex">冴えない男「ハルノ・ヒトキ」が仕事からの帰宅途中で美少女に声を掛けられる。
+驚いた事に少女の目的は自分の下着を売る事だった。
+お金に困っていた少女は徐々にヒトキに下着を売っていたが段々とその内容がエスカレートして行き……//</div>
+<div class="th"><a href="https://novel18.syosetu.com/n2976fx/">兇王</a></div>
+
+<div class="info">
+N2976FX｜
+<a href="https://novel18.syosetu.com/novelview/infotop/ncode/n2976fx/">小説情報</a>｜
+連載(全8部分)
+｜
+ノクターンノベルズ(男性向け)
+</div>
+<div class="ex">ある日、世界を創造した男に人生を強制終了された男が別の世界に転生させられた。
+男は特別な力を与えられた訳では無いが、家柄だけは良い所に生まれ落ちる。
+転生した男は自らの才能と鍛錬により人々から羨望の眼差しを受けるながら成//</div>
+<div class="th"><a href="https://novel18.syosetu.com/n2460df/">不細工な俺の人生が変わったら</a></div>
+
+<div class="info">
+N2460DF｜
+<a href="https://novel18.syosetu.com/novelview/infotop/ncode/n2460df/">小説情報</a>｜
+連載(全19部分)
+｜
+ノクターンノベルズ(男性向け)
+</div>
+<div class="ex">　醜悪な容姿のハルノ・ヒトキは、日々嘲りの対象になっていた。
+ある日、誤解によるトラブルで停学処分を喰らったヒトキが、一週間ぶりに家の外に出ると世界は変わっていた。
+知らないうちにヒトキは前と異なる世界に居た。
+ある一点//</div>
+<div class="th"><a href="https://novel18.syosetu.com/n4715ce/">F姉妹と僕</a></div>
+
+<div class="info">
+N4715CE｜
+<a href="https://novel18.syosetu.com/novelview/infotop/ncode/n4715ce/">小説情報</a>｜
+完結済(全31部分)
+｜
+ノクターンノベルズ(男性向け)
+</div>
+<div class="ex">　高校生の「ヒトキ」は、同級生の美少女「美紅」と、その姉の「絵梨」の姉妹だけの悪い遊び「罰ゲーム」を偶然目撃してしまう。
+その時から姉妹に魅了され、姉妹しか参加していない部活に入ってしまう。普段は清楚に見える姉妹がヒトキ//</div>
+<div class="th"><a href="https://novel18.syosetu.com/n0356cx/">ハルノ・ヒトキは二度目の人生を愛欲に溺れる</a></div>
+
+<div class="info">
+N0356CX｜
+<a href="https://novel18.syosetu.com/novelview/infotop/ncode/n0356cx/">小説情報</a>｜
+連載(全8部分)
+｜
+ノクターンノベルズ(男性向け)
+</div>
+<div class="ex">　恋人も友人もいない孤独な人生を事故により終わらせたハルノ・ヒトキは創造神と出会う。
+その孤独な人生は、ステータスの調整を適当に設定したのが原因だったと創造神に告白されたヒトキは涙する。
+ヒトキの涙に罪悪感を覚えた創造神//</div>
+
+</div><!-- onazi -->
+
+
+
+
+<div id="trackback">
+<h2>トラックバック　[<a href="https://syosetu.com/man/trackback/">？</a>]</h2>
+
+<a href="https://syosetu.com/trackback/list/">[&nbsp;全作品のトラックバック一覧はこちら&nbsp;]</a>
+<table>
+<tr>
+<th>◆この小説のトラックバックURL</th>
+<td><input type="text" readonly="readonly" size="64" value="https://trackback.syosetu.com/send/novel/ncode/1532825/" /></td>
+</tr>
+<tr>
+<th>◆この小説のURL<br />&nbsp;&nbsp; (リンク自由)</th>
+<td><input type="text" readonly="readonly" size="64" value="https://ncode.syosetu.com/n2978fx/" /></td>
+</tr>
+</table>
+</div><!--trackback-->
+
+<div id="novel_attention">
++注意+<br />
+<span class="attention">特に記載なき場合、掲載されている小説はすべてフィクションであり実在の人物・団体等とは一切関係ありません。<br />
+特に記載なき場合、掲載されている小説の著作権は作者にあります(一部作品除く)。<br />
+作者以外の方による小説の引用を超える無断転載は禁止しており、行った場合、著作権法の違反となります。<br />
+</span><br />
+この小説はリンクフリーです。ご自由にリンク(紹介)してください。<br />
+小説の読了時間は毎分500文字を読むと想定した場合の時間です。目安にして下さい。
+</div><!--novel_attention-->
+
+
+<div id="novel_footer">
+<ul class="undernavi">
+<li><a href="https://xmypage.syosetu.com/x7552j/">作者Xマイページ</a></li>
+<li><a href="https://novel18.syosetu.com/novelview/infotop/ncode/n2978fx/#trackback">トラックバック</a></li>
+
+
+<li><a href="https://syosetu.com/ihantsuhou/input/ncode/1532825/">情報提供</a></li>
+</ul>
+</div><!--novel_footer-->
+
+
+</div><!--contents_main-->
+
+
+<br />
+<div class="koukoku_728">
+
+<div id="ffc713cc5df57d1e0406a5307a73e442" >
+<script type="text/javascript">
+microadCompass.queue.push({
+"spot": "ffc713cc5df57d1e0406a5307a73e442",
+"url": "${COMPASS_EXT_URL}",
+"referrer": "${COMPASS_EXT_REF}"
+});
+</script>
+</div>
+
+
+</div>
+
+<a id="pageTop" href="#main">↑ページトップへ</a>
+
+</div><!--container-->
+
+<!-- フッタここから -->
+<div id="footer">
+<ul class="undernavi">
+<li><a href="https://syosetu.com">小説家になろう</a></li>
+<li><a href="https://noc.syosetu.com/">ノクターンノベルズ</a></li>
+<li><a href="https://mnlt.syosetu.com/">ムーンライトノベルズ</a></li>
+<li><a href="https://mid.syosetu.com/">ミッドナイトノベルズ</a></li>
+</ul>
+</div><!--footer-->
+<!-- フッタここまで -->
+
+
+
+
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-WQ7JDB"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-WQ7JDB');</script>
+<!-- End Google Tag Manager -->
+
+</body></html>

--- a/tests/fixture/Narou/novel_longdescription.html
+++ b/tests/fixture/Narou/novel_longdescription.html
@@ -1,0 +1,394 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ja" lang="ja">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<title>俺のことが好き過ぎる双子の天才妹が、「妹と結婚して子作りすること」を合法化して二人がかりで精液を搾りとってくる話[小説情報]</title>
+<meta http-equiv="Content-Script-Type" content="text/javascript" />
+<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta name="format-detection" content="telephone=no" />
+
+
+<link rel="shortcut icon" href="https://static.syosetu.com/sub/nocview/images/noc.ico" />
+<link rel="icon" href="https://static.syosetu.com/sub/nocview/images/noc.ico" />
+<link rel="apple-touch-icon-precomposed" href="https://static.syosetu.com/sub/nocview/images/apple-touch-icon-precomposed.png?ojjr8y" />
+
+<link href="https://api.syosetu.com/writernovel/x1215bl.Atom" rel="alternate" type="application/atom+xml" title="Atom" />
+
+<link rel="stylesheet" type="text/css" href="https://static.syosetu.com/novelview/css/reset.css?piu6zr" media="screen,print" />
+<link rel="stylesheet" type="text/css" href="https://static.syosetu.com/view/css/lib/jquery.hina.css?oyb9lo" media="screen,print" />
+
+<link rel="stylesheet" type="text/css" href="https://static.syosetu.com/novelview/css/novel_view.css?q611hx" media="screen,print" /><link rel="stylesheet" type="text/css" href="https://static.syosetu.com/novelview/css/infotop.css?pyfhdd" media="screen,print" />
+
+
+<script type="text/javascript"><!--
+var domain = 'syosetu.com';
+function wOpen(URL,NAME,OPTION){WO1 = window.open(URL,NAME,OPTION);WO1.window.focus();}
+//--></script>
+
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+<script type="text/javascript" src="https://static.syosetu.com/view/js/lib/jquery.hina.js?oyez8w"></script>
+<script type="text/javascript" src="https://static.syosetu.com/view/js/global.js?qnmoft"></script>
+<script type="text/javascript" src="https://static.syosetu.com/novelview/js/novelview.js?q0j60r"></script>
+
+
+
+<script type="text/javascript">
+var microadCompass = microadCompass || {};
+microadCompass.queue = microadCompass.queue || [];
+</script>
+<script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
+
+
+<!--
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+ xmlns:dc="http://purl.org/dc/elements/1.1/"
+ xmlns:trackback="http://madskills.com/public/xml/rss/module/trackback/">
+
+<rdf:Description
+rdf:about="https://novel18.syosetu.com/n0477gn/
+dc:identifier="https://novel18.syosetu.com/n0477gn/"
+dc:title="俺のことが好き過ぎる双子の天才妹が、「妹と結婚して子作りすること」を合法化して二人がかりで精液を搾りとってくる話"
+trackback:ping="https://trackback.syosetu.com/send/novel/ncode/1690308/" />
+</rdf:RDF>
+-->
+
+</head>
+<body onload="initRollovers();">
+
+<a id="pageBottom" href="#footer">↓</a>
+<div id="novel_header">
+<ul id="head_nav">
+<li id="login">
+<a href="https://ssl.syosetu.com/login/input/"><span class="attention">ログイン</span></a>
+</li>
+<li><a href="https://novel18.syosetu.com/novelview/infotop/ncode/n0477gn/">小説情報</a></li>
+<li><a href="https://novelcom18.syosetu.com/impression/list/ncode/1690308/">感想</a></li>
+<li><a href="https://novelcom18.syosetu.com/novelreview/list/ncode/1690308/">レビュー</a></li>
+<li><a href="https://pdfnovels.net/n0477gn/" class="menu" target="_blank">縦書きPDF</a></li>
+
+<li class="booklist"><span class="button_bookmark logout">ブックマークに追加</span></li>
+
+
+
+<li>
+<a
+style="border-left:none;"
+
+href="https://twitter.com/intent/tweet?text=%E3%80%90R18%E3%80%91%E4%BF%BA%E3%81%AE%E3%81%93%E3%81%A8%E3%81%8C%E5%A5%BD%E3%81%8D%E9%81%8E%E3%81%8E%E3%82%8B%E5%8F%8C%E5%AD%90%E3%81%AE%E5%A4%A9%E6%89%8D%E5%A6%B9%E3%81%8C%E3%80%81%E3%80%8C%E5%A6%B9%E3%81%A8%E7%B5%90%E5%A9%9A%E3%81%97%E3%81%A6%E5%AD%90%E4%BD%9C%E3%82%8A%E3%81%99%E3%82%8B%E3%81%93%E3%81%A8%E3%80%8D%E3%82%92%E5%90%88%E6%B3%95%E5%8C%96%E3%81%97%E3%81%A6%E4%BA%8C%E4%BA%BA%E3%81%8C%E3%81%8B%E3%82%8A%E3%81%A7%E7%B2%BE%E6%B6%B2%E3%82%92%E6%90%BE%E3%82%8A%E3%81%A8%E3%81%A3%E3%81%A6%E3%81%8F%E3%82%8B%E8%A9%B1&amp;url=https%3A%2F%2Fnovel18.syosetu.com%2Fn0477gn%2F&amp;hashtags=narou%2CnarouN0477GN">
+
+<img src="https://static.syosetu.com/novelview/img/Twitter_logo_blue.png?nrkioy" class="menu" style="margin-left:7px; margin-right:7px;" height="20px" />
+</a>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+</li></ul>
+</div><!-- novel_header -->
+
+<div id="container">
+
+
+
+<div class="box_infotop_announce_bookmark announce_bookmark">ブックマーク登録する場合は<a href="https://ssl.syosetu.com/login/input/">ログイン</a>してください。</div>
+
+
+<div id="contents_main">
+
+<p title="Nコード" id="ncode">N0477GN</p>
+<h1><a href="https://novel18.syosetu.com/n0477gn/">俺のことが好き過ぎる双子の天才妹が、「妹と結婚して子作りすること」を合法化して二人がかりで精液を搾りとってくる話</a></h1>
+
+
+<div class="clearfix">
+<div id="infodata">
+
+<div id="pre_info">
+<span id="age_limit">R18</span>
+<span id="noveltype">短編</span>
+</div>
+
+<table id="noveltable1">
+<tr>
+<th class="ex">あらすじ</th>
+<td class="ex">巨大財閥の跡取りである高校生「菊川笙(きくかわしょう)」。その双子の妹、貧乳美尻丁寧語の「菊川琴(こと)」と巨乳巨尻甘えん坊の「菊川鈴(すず)」。<br />
+巨大財閥を実質的に動かしている天才双子妹は、しかし兄を盲愛して兄の精液で孕みたいと固く決意しているダブルブラコン妹だった。<br />
+ある時妹たち二人と一緒に高級ホテルに宿泊することになった笙は、そこで「近親婚合法化」のニュースを見せられる…。<br />
+<br />
+タイトル通り、兄大好きの双子の妹が、徹底的にお兄ちゃんといちゃらぶ孕みセックスをする話です。<br />
+<br />
+※喘ぎ声にハートマークが頻繁につきます</td>
+</tr>
+<tr>
+<th>作者名</th>
+<td><a href="https://xmypage.syosetu.com/x1215bl/">伍式</a>
+</td>
+</tr>
+<tr>
+<th>キーワード</th>
+<td>
+
+ほのぼの 男主人公 妹 いちゃらぶ 近親相姦 オナニー 見せつけ 尻合わせ 孕ませっくす 自慰 尻ズリ 兄妹 双子 だいしゅきホールド 膝立ちバック
+</td>
+</tr>
+<tr>
+<th>掲載サイト</th>
+<td>ノクターンノベルズ(男性向け)</td>
+</tr>
+</table>
+
+<div id="qr">
+<img class="images_qrcode" src="https://sbo.syosetu.com/n0477gn/qrcode.png" />
+<a href="https://kasasagi.hinaproject.com/access/top/ncode/n0477gn/">&gt;&gt;アクセス解析</a><br />
+System by <a href="https://kasasagi.hinaproject.com/" target="_blank">ＫＡＳＡＳＡＧＩ</a>
+</div>
+
+<table id="noveltable2">
+<tr>
+<th>掲載日</th>
+<td>2020年 09月22日 07時46分</td>
+</tr>
+<tr>
+<th>最終更新日</th>
+<td>
+2020年 09月23日 19時01分
+</td>
+</tr>
+
+<tr>
+<th>感想</th>
+<td>
+9件
+
+</td>
+</tr>
+<tr>
+<th>レビュー</th>
+<td>
+0件
+</td>
+</tr>
+<tr>
+<th>ブックマーク登録</th>
+<td>1,471件</td>
+</tr>
+<tr>
+<th>総合評価</th>
+<td>5,812pt</td>
+</tr>
+<tr>
+<th>評価ポイント</th>
+<td>
+2,870pt
+
+
+</td>
+</tr>
+<tr>
+<th>誤字報告受付</th>
+<td>
+受け付けています<br /><span class="uketuke">※ログイン必須</span></td>
+</tr>
+<tr>
+<th>開示設定</th>
+<td>開示されています</td>
+</tr>
+<tr>
+<th>文字数</th>
+<td>21,598文字</td>
+</tr>
+</table>
+
+</div>
+
+<div id="ad_s_box">
+<a href="https://twitter.com/intent/tweet?text=%E3%80%90R18%E3%80%91%E3%80%8C%E4%BF%BA%E3%81%AE%E3%81%93%E3%81%A8%E3%81%8C%E5%A5%BD%E3%81%8D%E9%81%8E%E3%81%8E%E3%82%8B%E5%8F%8C%E5%AD%90%E3%81%AE%E5%A4%A9%E6%89%8D%E5%A6%B9%E3%81%8C%E3%80%81%E3%80%8C%E5%A6%B9%E3%81%A8%E7%B5%90%E5%A9%9A%E3%81%97%E3%81%A6%E5%AD%90%E4%BD%9C%E3%82%8A%E3%81%99%E3%82%8B%E3%81%93%E3%81%A8%E3%80%8D%E3%82%92%E5%90%88%E6%B3%95%E5%8C%96%E3%81%97%E3%81%A6%E4%BA%8C%E4%BA%BA%E3%81%8C%E3%81%8B%E3%82%8A%E3%81%A7%E7%B2%BE%E6%B6%B2%E3%82%92%E6%90%BE%E3%82%8A%E3%81%A8%E3%81%A3%E3%81%A6%E3%81%8F%E3%82%8B%E8%A9%B1%E3%80%8D%E8%AA%AD%E3%82%93%E3%81%A0%EF%BC%81&url=https%3A%2F%2Fnovel18.syosetu.com%2Fn0477gn%2F&hashtags=narou%2CnarouN0477GN" class="twitter-share-button">Tweet</a>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+
+
+<div class="koukoku">
+
+<div id="9e33cdfe65377a2b3ae04fad9b872d2f" >
+<script type="text/javascript">
+microadCompass.queue.push({
+"spot": "9e33cdfe65377a2b3ae04fad9b872d2f",
+"url": "${COMPASS_EXT_URL}",
+"referrer": "${COMPASS_EXT_REF}"
+});
+</script>
+</div>
+
+
+</div>
+</div><!--ad_s_box-->
+</div><!-- clear -->
+
+<div id="novelindex_button"><a href="https://novel18.syosetu.com/n0477gn/">小説を読む</a></div>
+
+
+
+
+<div class="koukoku_728">
+
+<div id="3b20976a6299b62713a3f40e637416db" >
+<script type="text/javascript">
+microadCompass.queue.push({
+"spot": "3b20976a6299b62713a3f40e637416db",
+"url": "${COMPASS_EXT_URL}",
+"referrer": "${COMPASS_EXT_REF}"
+});
+</script>
+</div>
+
+
+</div><!--koukoku_728-->
+
+
+
+
+
+<div id="onazi">
+<div id="data_link">
+<h2>同一作者の小説</h2>
+<a href="https://xmypage.syosetu.com/mypage/novellist/xid/x1215bl/">&gt;&gt;伍式&nbsp;先生の作品一覧を見る</a>
+</div><!--data_link-->
+
+<div class="th"><a href="https://novel18.syosetu.com/n6468gs/">伯爵家の淫鑑 ～身分証明の代わりにセックスしないといけない世界で、ショタっ子が無表情巨乳巨尻お姉さんに初めての「捺印」をする話～</a></div>
+
+<div class="info">
+N6468GS｜
+<a href="https://novel18.syosetu.com/novelview/infotop/ncode/n6468gs/">小説情報</a>｜
+連載(全7部分)
+｜
+ノクターンノベルズ(男性向け)
+</div>
+<div class="ex">遺伝子操作によって、特定の遺伝子パターンを含んだ精液を膣内射精されることで淫紋が発動する体質の女性たち。かつては隷属の為の淫術の産物だった彼女たちは、永い時を経て、射精相手が特定の血筋の人間であることを証明する「身分証明//</div>
+<div class="th"><a href="https://novel18.syosetu.com/n4501fz/">お兄ちゃん攻略日記 ～妹が俺の童貞を攻略しようとしている～</a></div>
+
+<div class="info">
+N4501FZ｜
+<a href="https://novel18.syosetu.com/novelview/infotop/ncode/n4501fz/">小説情報</a>｜
+連載(全65部分)
+｜
+ノクターンノベルズ(男性向け)
+</div>
+<div class="ex">ある時、ごく普通の高校生である長津田恭一は、妹の知佳に自慰の瞬間を見られてしまう。人生終わった…と思っていたのに、その時以降、何故か知佳はことあるごとに恭一にえっちなアプローチをしかけてきて、恭一の性欲を煽ろうとしてくる//</div>
+<div class="th"><a href="https://novel18.syosetu.com/n8135gr/">続々・セックスしないと出られない物件 ～ボクっ娘美少女が、お正月に生理になりそうだからとお尻の穴で気持ち良くなる練習をしてくれていた話～</a></div>
+
+<div class="info">
+N8135GR｜
+<a href="https://novel18.syosetu.com/novelview/infotop/ncode/n8135gr/">小説情報</a>｜
+短編｜
+ノクターンノベルズ(男性向け)
+</div>
+<div class="ex">「セックスしないと出られない部屋」を居住用に改装した物件に、ボクっ娘同級生である宮ノ前真琴(みやのまえまこと)と二人で入居した庚申塚洋一(こうしんづかよういち)。恋人同士ではない二人は、単なるルームメイトという関係のまま//</div>
+<div class="th"><a href="https://novel18.syosetu.com/n0411gr/">女性冒険者二人が「角オナで視姦し合いながら同時イキしないと出られない部屋」に閉じ込められてオナったりレズったり触手射精ックスされたりするヤツ</a></div>
+
+<div class="info">
+N0411GR｜
+<a href="https://novel18.syosetu.com/novelview/infotop/ncode/n0411gr/">小説情報</a>｜
+短編｜
+ノクターンノベルズ(男性向け)
+</div>
+<div class="ex">二人組の女性冒険者、シアラとアリス。二人はダンジョンを探索する中、深層で奇妙な部屋に突き当たる。その部屋から出る為の開錠条件は、「角オナでお互いに視姦し合いながら二人で同時イキすること」だった。紆余曲折の末角オナを始める//</div>
+<div class="th"><a href="https://novel18.syosetu.com/n8304gg/">自慰バレゲーム ～オナニーでイッているところを目撃されると罰ゲームでめちゃくちゃ気持ち良く犯されてしまうゲームに強制参加させられる少女たち</a></div>
+
+<div class="info">
+N8304GG｜
+<a href="https://novel18.syosetu.com/novelview/infotop/ncode/n8304gg/">小説情報</a>｜
+連載(全39部分)
+｜
+ノクターンノベルズ(男性向け)
+</div>
+<div class="ex">高校二年生の少女、妙典樹(みょうでんいつき)は、あるお屋敷の広間で目覚める。そこで説明される「自慰バレゲーム」のルールと、見せつけられる脱落者の「罰ゲーム」。
+
+オナニーしたい、身体は発情している、時間制限すらある。けれ//</div>
+
+</div><!-- onazi -->
+
+
+
+
+<div id="trackback">
+<h2>トラックバック　[<a href="https://syosetu.com/man/trackback/">？</a>]</h2>
+
+<a href="https://syosetu.com/trackback/list/">[&nbsp;全作品のトラックバック一覧はこちら&nbsp;]</a>
+<table>
+<tr>
+<th>◆この小説のトラックバックURL</th>
+<td><input type="text" readonly="readonly" size="64" value="https://trackback.syosetu.com/send/novel/ncode/1690308/" /></td>
+</tr>
+<tr>
+<th>◆この小説のURL<br />&nbsp;&nbsp; (リンク自由)</th>
+<td><input type="text" readonly="readonly" size="64" value="https://ncode.syosetu.com/n0477gn/" /></td>
+</tr>
+</table>
+</div><!--trackback-->
+
+<div id="novel_attention">
++注意+<br />
+<span class="attention">特に記載なき場合、掲載されている小説はすべてフィクションであり実在の人物・団体等とは一切関係ありません。<br />
+特に記載なき場合、掲載されている小説の著作権は作者にあります(一部作品除く)。<br />
+作者以外の方による小説の引用を超える無断転載は禁止しており、行った場合、著作権法の違反となります。<br />
+</span><br />
+この小説はリンクフリーです。ご自由にリンク(紹介)してください。<br />
+小説の読了時間は毎分500文字を読むと想定した場合の時間です。目安にして下さい。
+</div><!--novel_attention-->
+
+
+<div id="novel_footer">
+<ul class="undernavi">
+<li><a href="https://xmypage.syosetu.com/x1215bl/">作者Xマイページ</a></li>
+<li><a href="https://novel18.syosetu.com/novelview/infotop/ncode/n0477gn/#trackback">トラックバック</a></li>
+
+
+<li><a href="https://syosetu.com/ihantsuhou/input/ncode/1690308/">情報提供</a></li>
+</ul>
+</div><!--novel_footer-->
+
+
+</div><!--contents_main-->
+
+
+<br />
+<div class="koukoku_728">
+
+<div id="ffc713cc5df57d1e0406a5307a73e442" >
+<script type="text/javascript">
+microadCompass.queue.push({
+"spot": "ffc713cc5df57d1e0406a5307a73e442",
+"url": "${COMPASS_EXT_URL}",
+"referrer": "${COMPASS_EXT_REF}"
+});
+</script>
+</div>
+
+
+</div>
+
+<a id="pageTop" href="#main">↑ページトップへ</a>
+
+</div><!--container-->
+
+<!-- フッタここから -->
+<div id="footer">
+<ul class="undernavi">
+<li><a href="https://syosetu.com">小説家になろう</a></li>
+<li><a href="https://noc.syosetu.com/">ノクターンノベルズ</a></li>
+<li><a href="https://mnlt.syosetu.com/">ムーンライトノベルズ</a></li>
+<li><a href="https://mid.syosetu.com/">ミッドナイトノベルズ</a></li>
+</ul>
+</div><!--footer-->
+<!-- フッタここまで -->
+
+
+
+
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-WQ7JDB"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-WQ7JDB');</script>
+<!-- End Google Tag Manager -->
+
+</body></html>


### PR DESCRIPTION
とデグレ

close #603 

## 修正

- 連載ページ（`novel18.syosetu.com/n0000aa/`）以外でも作者名とあらすじが取れるようになりました。

## 改善

- データを小説情報（`novel18.syosetu.com/novelview/infotop/ncode/n0000aa/`）をからパースするようになりました。どのURLからでもタグ（キーワード）とあらすじを取得できます。
    - ![image](https://user-images.githubusercontent.com/3516343/105745284-75667180-5f81-11eb-955e-485d13f8b29e.png)


## デグレ

- 逆に単話ページ（`novel18.syosetu.com/n0000aa/1`）のリンクを貼っても単話のタイトルや本文（もともと対応してなかったが）が取れなくなりました。
    - これは小説情報ページにタイトルの一覧が載っていないのと、MetadataResolverは1回のメタデータ取得に1つのリクエストしか送れないためです。（正確には送れるがテストができない）
    - この点を問題と捉えるか否かは実際にこのリゾルバを使っているユーザーに聞きたいです。

## WIP

- [x] 小説情報ページのURLもパース対象に含める