### PR TITLE
古い省略表示の無いページャーを現行のものに置換

### DIFF
--- a/resources/views/admin/info/index.blade.php
+++ b/resources/views/admin/info/index.blade.php
@@ -36,22 +36,6 @@
             @endforeach
             </tbody>
         </table>
-        <ul class="pagination mt-4 justify-content-center">
-            <li class="page-item {{ $informations->currentPage() === 1 ? 'disabled' : '' }}">
-                <a class="page-link" href="{{ $informations->previousPageUrl() }}" aria-label="Previous">
-                    <span aria-hidden="true">&laquo;</span>
-                    <span class="sr-only">Previous</span>
-                </a>
-            </li>
-            @for ($i = 1; $i <= $informations->lastPage(); $i++)
-                <li class="page-item {{ $i === $informations->currentPage() ? 'active' : '' }}"><a href="{{ $informations->url($i) }}" class="page-link">{{ $i }}</a></li>
-            @endfor
-            <li class="page-item {{ $informations->currentPage() === $informations->lastPage() ? 'disabled' : '' }}">
-                <a class="page-link" href="{{ $informations->nextPageUrl() }}" aria-label="Next">
-                    <span aria-hidden="true">&raquo;</span>
-                    <span class="sr-only">Next</span>
-                </a>
-            </li>
-        </ul>
+        {{ $informations->links(null, ['className' => 'mt-4 justify-content-center']) }}
     </div>
 @endsection

--- a/resources/views/search/relatedTag.blade.php
+++ b/resources/views/search/relatedTag.blade.php
@@ -8,24 +8,5 @@
         <p class="col-12">このキーワードが含まれるタグはありません。</p>
     @endforelse
     </div>
-
-    @if(!empty($results))
-        <ul class="pagination mt-4 justify-content-center">
-            <li class="page-item {{ $results->currentPage() === 1 ? 'disabled' : '' }}">
-                <a class="page-link" href="{{ $results->previousPageUrl() }}" aria-label="Previous">
-                    <span aria-hidden="true">&laquo;</span>
-                    <span class="sr-only">Previous</span>
-                </a>
-            </li>
-            @for ($i = 1; $i <= $results->lastPage(); $i++)
-                <li class="page-item {{ $i === $results->currentPage() ? 'active' : '' }}"><a href="{{ $results->url($i) }}" class="page-link">{{ $i }}</a></li>
-            @endfor
-            <li class="page-item {{ $results->currentPage() === $results->lastPage() ? 'disabled' : '' }}">
-                <a class="page-link" href="{{ $results->nextPageUrl() }}" aria-label="Next">
-                    <span aria-hidden="true">&raquo;</span>
-                    <span class="sr-only">Next</span>
-                </a>
-            </li>
-        </ul>
-    @endif
+    {{ $results->links(null, ['className' => 'mt-4 justify-content-center']) }}
 @endsection


### PR DESCRIPTION
fix #630 

Issueにて指摘された箇所は #99 で削除したはずの古いページャー実装が使われていたため、大半のページで使用されている現行のものに置き換えました。  
ついでに、管理ページにも残っていたので置き換えておきました。こっちは誰も使わないけど。