### PR TITLE
ide-helperのコマンドをまとめて実行するscriptを追加

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,11 @@
         ],
         "test": [
             "phpunit"
+        ],
+        "annotate": [
+            "@php artisan ide-helper:generate",
+            "@php artisan ide-helper:model -N",
+            "@php artisan ide-helper:meta"
         ]
     },
     "config": {


### PR DESCRIPTION
laravel-ide-helperのコマンドが一生覚えられないので、composer.jsonに書いておくことにしました。