### PR TITLE
Docker: node 16にアップデート

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-buster as node
+FROM node:16-buster as node
 
 FROM php:7.3-apache
 


### PR DESCRIPTION
laravel-mix 6.xはnode 12以上じゃないと使えないっぽかった。ローカルの14.xで実行してたので気づかなかった……

どうせまた忘れるので最新版まで上げる。