### PR TITLE
DisallowedByProviderExceptionは403扱いで握り潰す

### DIFF
--- a/app/Http/Controllers/Api/CardController.php
+++ b/app/Http/Controllers/Api/CardController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\MetadataResolver\DeniedHostException;
+use App\MetadataResolver\DisallowedByProviderException;
 use App\Services\MetadataResolveService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -17,7 +18,7 @@ class CardController
 
         try {
             $metadata = $service->execute($request->input('url'));
-        } catch (DeniedHostException $e) {
+        } catch (DeniedHostException | DisallowedByProviderException $e) {
             abort(403, $e->getMessage());
         }
         $metadata->load('tags');

--- a/app/Listeners/LinkCollector.php
+++ b/app/Listeners/LinkCollector.php
@@ -4,6 +4,7 @@ namespace App\Listeners;
 
 use App\Events\LinkDiscovered;
 use App\MetadataResolver\DeniedHostException;
+use App\MetadataResolver\DisallowedByProviderException;
 use App\Services\MetadataResolveService;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
@@ -37,7 +38,7 @@ class LinkCollector
 
         try {
             $this->metadataResolveService->execute($event->url);
-        } catch (DeniedHostException $e) {
+        } catch (DeniedHostException | DisallowedByProviderException $e) {
             // ignored
         } catch (\Exception $e) {
             // 今のところこのイベントは同期実行されるので、上流をクラッシュさせないために雑catchする


### PR DESCRIPTION
DisallowedByProviderExceptionがSentryに送られすぎてレートリミットにかかった。

改めて考えてみると、これは管理者側でブロックしている場合のDeniedHostExceptionと全く同じ扱いでいいはずで、そうしておけばSentryに送られることもない。ということで、そのようにする。