### PR TITLE
名前の長いタグがチェックインのコンテナ外にはみ出ないようにする

### DIFF
--- a/resources/assets/sass/components/_ejaculation.scss
+++ b/resources/assets/sass/components/_ejaculation.scss
@@ -34,3 +34,22 @@
     background-color: rgba(240, 240, 240, 0.8);
     border-radius: 5px;
 }
+
+.tis-checkin-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .6ch;
+
+    & > .badge {
+        max-width: 100%;
+        padding: .2em .6em;
+        line-height: 1.5;
+        text-align: left;
+        word-break: break-all;
+        white-space: normal;
+
+        & > .oi-flash {
+            top: 2px;
+        }
+    }
+}

--- a/resources/views/components/ejaculation.blade.php
+++ b/resources/views/components/ejaculation.blade.php
@@ -7,7 +7,7 @@
 </div>
 <!-- tags -->
 @if ($ejaculation->is_private || $ejaculation->source !== 'web' || $ejaculation->tags->isNotEmpty())
-    <p class="mb-2">
+    <p class="tis-checkin-tags mb-2">
         @if ($ejaculation->is_private)
             <span class="badge badge-warning"><span class="oi oi-lock-locked"></span> 非公開</span>
         @endif

--- a/resources/views/ejaculation/show.blade.php
+++ b/resources/views/ejaculation/show.blade.php
@@ -35,7 +35,7 @@
                         </div>
                         <!-- tags -->
                         @if ($ejaculation->is_private || $ejaculation->source !== 'web' || $ejaculation->tags->isNotEmpty())
-                        <p class="mb-2">
+                        <p class="tis-checkin-tags mb-2">
                             @if ($ejaculation->is_private)
                                 <span class="badge badge-warning"><span class="oi oi-lock-locked"></span> 非公開</span>
                             @endif

--- a/resources/views/search/relatedTag.blade.php
+++ b/resources/views/search/relatedTag.blade.php
@@ -3,7 +3,7 @@
 @section('tab-content')
     <div class="row">
     @forelse($results as $tag)
-        <p class="col-md-3"><a href="{{ route('search', ['q' => $tag->name]) }}" class="btn btn-outline-primary btn-block" role="button">{{ $tag->name }}</a></p>
+        <p class="col-md-3 text-break"><a href="{{ route('search', ['q' => $tag->name]) }}" class="btn btn-outline-primary btn-block text-truncate" role="button" title="{{ $tag->name }}">{{ $tag->name }}</a></p>
     @empty
         <p class="col-12">このキーワードが含まれるタグはありません。</p>
     @endforelse

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -62,7 +62,7 @@
                 </div>
                 <!-- tags -->
                 @if ($ejaculation->is_private || $ejaculation->source !== 'web' || $ejaculation->tags->isNotEmpty())
-                    <p class="mb-2">
+                    <p class="tis-checkin-tags mb-2">
                         @if ($ejaculation->is_private)
                             <span class="badge badge-warning"><span class="oi oi-lock-locked"></span> 非公開</span>
                         @endif

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -29,7 +29,7 @@
             <div class="list-group list-group-flush">
                 @foreach ($tags as $tag)
                     <a class="list-group-item d-flex justify-content-between align-items-center text-dark" href="{{ route('search', ['q' => $tag->name]) }}">
-                        <div>
+                        <div style="word-break: break-all;">
                             <span class="oi oi-tag text-secondary"></span>
                             {{ $tag->name }}
                         </div>

--- a/resources/views/user/stats/components/used-tags.blade.php
+++ b/resources/views/user/stats/components/used-tags.blade.php
@@ -12,7 +12,7 @@
                 <tbody>
                 @foreach ($tags as $tag)
                     <tr>
-                        <td>
+                        <td style="word-break: break-all;">
                             <a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a>
                         </td>
                         <td class="text-right">
@@ -36,7 +36,7 @@
                 <tbody>
                 @foreach ($tagsIncludesMetadata as $tag)
                     <tr>
-                        <td>
+                        <td style="word-break: break-all;">
                             <a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a>
                         </td>
                         <td class="text-right">


### PR DESCRIPTION
refs #709 

## 直した

* チェックイン
* 検索結果 > 関連するタグ
* プロフィール > よく使っているタグ
* プロフィール > グラフ > 最も使用したタグ

## 直してない

* チェックインフォーム