### PR TITLE
DatabaseTransactionsを使う

### DIFF
--- a/tests/Feature/Api/Webhook/CheckinWebhookTest.php
+++ b/tests/Feature/Api/Webhook/CheckinWebhookTest.php
@@ -5,13 +5,13 @@ namespace Tests\Feature\Api\Webhook;
 use App\CheckinWebhook;
 use App\Ejaculation;
 use App\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
 class CheckinWebhookTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     protected function setUp(): void
     {

--- a/tests/Feature/Setting/WebhookTest.php
+++ b/tests/Feature/Setting/WebhookTest.php
@@ -4,12 +4,12 @@ namespace Tests\Feature\Setting;
 
 use App\CheckinWebhook;
 use App\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 
 class WebhookTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     protected function setUp(): void
     {

--- a/tests/Feature/SettingTest.php
+++ b/tests/Feature/SettingTest.php
@@ -6,14 +6,14 @@ use App\Ejaculation;
 use App\Like;
 use App\User;
 use Illuminate\Contracts\Auth\Authenticatable;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\WithFaker;
 use Symfony\Component\DomCrawler\Crawler;
 use Tests\TestCase;
 
 class SettingTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Http/Middleware/NormalizeLineEndingTest.php
+++ b/tests/Unit/Http/Middleware/NormalizeLineEndingTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit\Http\Middleware;
 
 use App\Http\Middleware\NormalizeLineEnding;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\Request;
 use Tests\TestCase;

--- a/tests/Unit/Services/CheckinCsvImporterTest.php
+++ b/tests/Unit/Services/CheckinCsvImporterTest.php
@@ -7,13 +7,13 @@ use App\Ejaculation;
 use App\Exceptions\CsvImportException;
 use App\Services\CheckinCsvImporter;
 use App\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
 class CheckinCsvImporterTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Services/MetadataResolverServiceTest.php
+++ b/tests/Unit/Services/MetadataResolverServiceTest.php
@@ -14,13 +14,13 @@ use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Mockery\MockInterface;
 use Tests\TestCase;
 
 class MetadataResolverServiceTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
fix #734 

テスト用のDB接続設定分けてないのにリセットされると誤爆が多くてつらい、とてもつらい、かなりつらい