### PR TITLE
チェックイン表示用テンプレートの統合

### DIFF
--- a/app/Http/Controllers/Api/CheckinController.php
+++ b/app/Http/Controllers/Api/CheckinController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Ejaculation;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class CheckinController extends Controller
+{
+    public function destroy(Request $request, $checkin)
+    {
+        $ejaculation = Ejaculation::with('user')->find($checkin);
+
+        if ($ejaculation !== null) {
+            $this->authorize('edit', $ejaculation);
+
+            DB::transaction(function () use ($ejaculation) {
+                $ejaculation->tags()->detach();
+                $ejaculation->delete();
+            });
+        }
+
+        if ($request->input('flash') === true) {
+            session()->flash('status', '削除しました。');
+        }
+
+        return response()->json([
+            'user' => $ejaculation !== null ? route('user.profile', ['name' => $ejaculation->user->name]) : null
+        ]);
+    }
+}

--- a/app/Http/Controllers/EjaculationController.php
+++ b/app/Http/Controllers/EjaculationController.php
@@ -236,22 +236,6 @@ class EjaculationController extends Controller
         return redirect()->route('checkin.show', ['id' => $ejaculation->id])->with('status', 'チェックインを修正しました！');
     }
 
-    public function destroy($id)
-    {
-        $ejaculation = Ejaculation::findOrFail($id);
-
-        $this->authorize('edit', $ejaculation);
-
-        $user = User::findOrFail($ejaculation->user_id);
-
-        DB::transaction(function () use ($ejaculation) {
-            $ejaculation->tags()->detach();
-            $ejaculation->delete();
-        });
-
-        return redirect()->route('user.profile', ['name' => $user->name])->with('status', '削除しました。');
-    }
-
     public function tools()
     {
         return view('ejaculation.tools');

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -29,6 +29,7 @@ class UserController extends Controller
         $query = Ejaculation::select(DB::raw(
             <<<'SQL'
 ejaculations.id,
+user_id,
 ejaculated_date,
 note,
 is_private,
@@ -46,7 +47,7 @@ SQL
             $query = $query->where('is_private', false);
         }
         $ejaculations = $query->orderBy('ejaculated_date', 'desc')
-            ->with('tags')
+            ->with('user', 'tags')
             ->withLikes()
             ->withMutedStatus()
             ->paginate(20);
@@ -157,6 +158,7 @@ SQL
         $query = Ejaculation::select(DB::raw(
             <<<'SQL'
 ejaculations.id,
+user_id,
 ejaculated_date,
 note,
 is_private,
@@ -175,7 +177,7 @@ SQL
             $query = $query->where('is_private', false);
         }
         $ejaculations = $query->orderBy('ejaculated_date', 'desc')
-            ->with('tags')
+            ->with('user', 'tags')
             ->withLikes()
             ->withMutedStatus()
             ->paginate(20);

--- a/resources/assets/js/tissue.ts
+++ b/resources/assets/js/tissue.ts
@@ -102,7 +102,7 @@ export function deleteCheckinModal(modal: Element) {
                 console.error(e);
                 alert('削除中にエラーが発生しました。');
             })
-            .then(() => {
+            .finally(() => {
                 buttons.forEach((button) => (button.disabled = false));
             });
     });

--- a/resources/assets/js/tissue.ts
+++ b/resources/assets/js/tissue.ts
@@ -1,4 +1,4 @@
-import { fetchGet, ResponseError } from './fetch';
+import { fetchGet, fetchDeleteJson, ResponseError } from './fetch';
 
 export function suicide<T>(e: T) {
     return function (): never {
@@ -73,12 +73,42 @@ export function pageSelector(el: Element) {
 }
 
 export function deleteCheckinModal(modal: Element) {
+    let element: Element;
     let id: any = null;
-    modal.querySelector('form')?.addEventListener('submit', function () {
-        this.action = this.action.replace('@', id);
+    modal.querySelector('form')?.addEventListener('submit', function (event) {
+        event.preventDefault();
+        const buttons = modal.querySelectorAll('button');
+        buttons.forEach((button) => (button.disabled = true));
+
+        const inCheckinPage = location.pathname.startsWith('/checkin/');
+        fetchDeleteJson(`/api/checkin/${id}`, {
+            flash: inCheckinPage,
+        })
+            .then((response) => {
+                if (response.ok) {
+                    return response.json();
+                }
+                throw new ResponseError(response);
+            })
+            .then((data) => {
+                $(modal).modal('hide');
+                if (inCheckinPage) {
+                    location.href = data.user || '/';
+                } else {
+                    element.remove();
+                }
+            })
+            .catch((e) => {
+                console.error(e);
+                alert('削除中にエラーが発生しました。');
+            })
+            .then(() => {
+                buttons.forEach((button) => (button.disabled = false));
+            });
     });
     return $(modal).on('show.bs.modal', function (event) {
         const target = event.relatedTarget || die();
+        element = target.parentElement?.parentElement || die();
         const dateLabel = this.querySelector('.modal-body .date-label') || die();
         dateLabel.textContent = target.dataset.date || null;
         id = target.dataset.id;

--- a/resources/views/components/delete-checkin-modal.blade.php
+++ b/resources/views/components/delete-checkin-modal.blade.php
@@ -4,9 +4,7 @@
     @endslot
     <span class="date-label"></span> のチェックインを削除してもよろしいですか？
     @slot('footer')
-        <form action="{{ route('checkin.destroy', ['id' => '@']) }}" method="post">
-            {{ csrf_field() }}
-            {{ method_field('DELETE') }}
+        <form>
             <button type="button" class="btn btn-secondary" data-dismiss="modal">キャンセル</button>
             <button type="submit" class="btn btn-danger">削除</button>
         </form>

--- a/resources/views/components/delete-checkin-modal.blade.php
+++ b/resources/views/components/delete-checkin-modal.blade.php
@@ -1,0 +1,14 @@
+@component('components.modal', ['id' => 'deleteCheckinModal'])
+    @slot('title')
+        削除確認
+    @endslot
+    <span class="date-label"></span> のチェックインを削除してもよろしいですか？
+    @slot('footer')
+        <form action="{{ route('checkin.destroy', ['id' => '@']) }}" method="post">
+            {{ csrf_field() }}
+            {{ method_field('DELETE') }}
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">キャンセル</button>
+            <button type="submit" class="btn btn-danger">削除</button>
+        </form>
+    @endslot
+@endcomponent

--- a/resources/views/components/ejaculation.blade.php
+++ b/resources/views/components/ejaculation.blade.php
@@ -1,6 +1,5 @@
 <!-- span -->
 <div>
-    {{-- TODO: spanとspanWithLinkが分かれている理由が特に無いので統合して良さそう --}}
     @switch ($header ?? 'user')
         @case ('user')
             <h5>
@@ -10,10 +9,6 @@
             @break
 
         @case ('span')
-            <h5>{{ $ejaculation->ejaculatedSpan() }} <small class="text-muted">{{ !empty($ejaculation->before_date) && !$ejaculation->discard_elapsed_time ? $ejaculation->before_date . ' ～ ' : '' }}{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></h5>
-            @break
-
-        @case ('spanWithLink')
             <h5>{{ $ejaculation->ejaculatedSpan() }} <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ !empty($ejaculation->before_date) && !$ejaculation->discard_elapsed_time ? $ejaculation->before_date . ' ～ ' : '' }}{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a></h5>
             @break
     @endswitch

--- a/resources/views/components/ejaculation.blade.php
+++ b/resources/views/components/ejaculation.blade.php
@@ -1,20 +1,21 @@
 <!-- span -->
 <div>
-    {{-- TODO: showとwithLinkが分かれている理由が特に無いので統合して良さそう --}}
-    @switch ($span ?? '')
-        @case ('show')
-            <h5>{{ $ejaculation->ejaculatedSpan() }} <small class="text-muted">{{ !empty($ejaculation->before_date) && !$ejaculation->discard_elapsed_time ? $ejaculation->before_date . ' ～ ' : '' }}{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></h5>
-            @break
-
-        @case ('withLink')
-            <h5>{{ $ejaculation->ejaculatedSpan() }} <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ !empty($ejaculation->before_date) && !$ejaculation->discard_elapsed_time ? $ejaculation->before_date . ' ～ ' : '' }}{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a></h5>
-            @break
-
-        @default
+    {{-- TODO: spanとspanWithLinkが分かれている理由が特に無いので統合して良さそう --}}
+    @switch ($header ?? 'user')
+        @case ('user')
             <h5>
                 <a href="{{ route('user.profile', ['name' => $ejaculation->user->name]) }}" class="text-dark"><img src="{{ $ejaculation->user->getProfileImageUrl(30) }}" srcset="{{ Formatter::profileImageSrcSet($ejaculation->user, 30) }}" width="30" height="30" class="rounded d-inline-block align-bottom"> <bdi>{{ $ejaculation->user->display_name }}</bdi></a>
                 <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a>
             </h5>
+            @break
+
+        @case ('span')
+            <h5>{{ $ejaculation->ejaculatedSpan() }} <small class="text-muted">{{ !empty($ejaculation->before_date) && !$ejaculation->discard_elapsed_time ? $ejaculation->before_date . ' ～ ' : '' }}{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></h5>
+            @break
+
+        @case ('spanWithLink')
+            <h5>{{ $ejaculation->ejaculatedSpan() }} <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ !empty($ejaculation->before_date) && !$ejaculation->discard_elapsed_time ? $ejaculation->before_date . ' ～ ' : '' }}{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a></h5>
+            @break
     @endswitch
 </div>
 <!-- tags -->

--- a/resources/views/ejaculation/show.blade.php
+++ b/resources/views/ejaculation/show.blade.php
@@ -29,74 +29,8 @@
             @else
                 <div class="card">
                     <div class="card-body">
-                        <!-- span -->
-                        <div>
-                            <h5>{{ $ejaculation->ejaculatedSpan() }} <small class="text-muted">{{ !empty($ejaculation->before_date) && !$ejaculation->discard_elapsed_time ? $ejaculation->before_date . ' ～ ' : '' }}{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></h5>
-                        </div>
-                        <!-- tags -->
-                        @if ($ejaculation->is_private || $ejaculation->source !== 'web' || $ejaculation->tags->isNotEmpty())
-                        <p class="mb-2">
-                            @if ($ejaculation->is_private)
-                                <span class="badge badge-warning"><span class="oi oi-lock-locked"></span> 非公開</span>
-                            @endif
-                            @switch ($ejaculation->source)
-                                @case ('csv')
-                                    <span class="badge badge-info"><span class="oi oi-cloud-upload"></span> インポート</span>
-                                    @break
-                                @case ('webhook')
-                                    <span class="badge badge-info" data-toggle="tooltip" title="Webhookからチェックイン"><span class="oi oi-flash"></span></span>
-                                    @break
-                            @endswitch
-                            @foreach ($ejaculation->tags as $tag)
-                                <a class="badge badge-secondary" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag"></span> {{ $tag->name }}</a>
-                            @endforeach
-                        </p>
-                        @endif
-                        <div class="{{ $ejaculation->isMuted() ? 'tis-checkin-muted' : '' }}">
-                            <!-- okazu link -->
-                            @if (!empty($ejaculation->link))
-                                <div class="row mx-0">
-                                    @component('components.link-card', ['link' => $ejaculation->link, 'is_too_sensitive' => $ejaculation->is_too_sensitive])
-                                    @endcomponent
-                                    <p class="d-flex align-items-baseline mb-2 col-12 px-0">
-                                        <span class="oi oi-link-intact mr-1"></span><a class="overflow-hidden" href="{{ $ejaculation->link }}" target="_blank" rel="noopener">{{ $ejaculation->link }}</a>
-                                    </p>
-                                </div>
-                            @endif
-                            <!-- note -->
-                            @if (!empty($ejaculation->note))
-                                <p class="mb-2 text-break">
-                                    {!! Formatter::linkify(nl2br(e($ejaculation->note))) !!}
-                                </p>
-                            @endif
-                        </div>
-                        @if ($ejaculation->isMuted())
-                            <div class="tis-checkin-muted-warning">
-                                このチェックインはミュートされています<br>クリックまたはタップで表示
-                            </div>
-                        @endif
-                        <!-- likes -->
-                        @if ($ejaculation->likes_count > 0)
-                            <div class="my-2 py-1 border-top border-bottom d-flex align-items-center">
-                                <div class="ml-2 mr-3 text-secondary flex-shrink-0"><small><strong>{{ $ejaculation->likes_count }}</strong> 件のいいね</small></div>
-                                <div class="like-users-tall flex-grow-1 overflow-hidden">
-                                    @foreach ($ejaculation->likes as $like)
-                                        @if ($like->user !== null)
-                                            <a href="{{ route('user.profile', ['name' => $like->user->name]) }}"><img src="{{ $like->user->getProfileImageUrl(36) }}" srcset="{{ Formatter::profileImageSrcSet($like->user, 36) }}" width="36" height="36" class="rounded" data-toggle="tooltip" data-placement="bottom" title="{{ $like->user->display_name }}"></a>
-                                        @endif
-                                    @endforeach
-                                </div>
-                            </div>
-                        @endif
-                        <!-- actions -->
-                        <div class="ejaculation-actions">
-                            <button type="button" class="btn btn-link text-secondary" data-toggle="tooltip" data-placement="bottom" title="同じオカズでチェックイン" data-href="{{ $ejaculation->makeCheckinURL() }}"><span class="oi oi-reload"></span></button>
-                            <button type="button" class="btn btn-link text-secondary like-button" data-toggle="tooltip" data-placement="bottom" data-trigger="hover" title="いいね" data-id="{{ $ejaculation->id }}" data-liked="{{ (bool)$ejaculation->is_liked }}"><span class="oi oi-heart {{ $ejaculation->is_liked ? 'text-danger' : '' }}"></span><span class="like-count">{{ $ejaculation->likes_count ? $ejaculation->likes_count : '' }}</span></button>
-                            @if ($user->isMe())
-                                <button type="button" class="btn btn-link text-secondary" data-toggle="tooltip" data-placement="bottom" title="修正" data-href="{{ route('checkin.edit', ['id' => $ejaculation->id]) }}"><span class="oi oi-pencil"></span></button>
-                                <button type="button" class="btn btn-link text-secondary" data-toggle="tooltip" data-placement="bottom" title="削除" data-target="#deleteCheckinModal" data-id="{{ $ejaculation->id }}" data-date="{{ $ejaculation->ejaculated_date }}"><span class="oi oi-trash"></span></button>
-                            @endif
-                        </div>
+                        @component('components.ejaculation', ['ejaculation' => $ejaculation, 'span' => 'show', 'likeUsersTall' => true])
+                        @endcomponent
                     </div>
                 </div>
             @endif

--- a/resources/views/ejaculation/show.blade.php
+++ b/resources/views/ejaculation/show.blade.php
@@ -29,7 +29,7 @@
             @else
                 <div class="card">
                     <div class="card-body">
-                        @component('components.ejaculation', ['ejaculation' => $ejaculation, 'span' => 'show', 'likeUsersTall' => true])
+                        @component('components.ejaculation', ['ejaculation' => $ejaculation, 'header' => 'span', 'likeUsersTall' => true])
                         @endcomponent
                     </div>
                 </div>

--- a/resources/views/ejaculation/show.blade.php
+++ b/resources/views/ejaculation/show.blade.php
@@ -38,18 +38,6 @@
     </div>
 </div>
 
-@component('components.modal', ['id' => 'deleteCheckinModal'])
-    @slot('title')
-        削除確認
-    @endslot
-    <span class="date-label"></span> のチェックインを削除してもよろしいですか？
-    @slot('footer')
-        <form action="{{ route('checkin.destroy', ['id' => '@']) }}" method="post">
-            {{ csrf_field() }}
-            {{ method_field('DELETE') }}
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">キャンセル</button>
-            <button type="submit" class="btn btn-danger">削除</button>
-        </form>
-    @endslot
+@component('components.delete-checkin-modal')
 @endcomponent
 @endsection

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -55,6 +55,9 @@
         </div>
     </div>
 </div>
+
+@component('components.delete-checkin-modal')
+@endcomponent
 @endsection
 
 @push('script')

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -14,4 +14,7 @@
         </ul>
         {{ $results->links(null, ['className' => 'mt-4 justify-content-center']) }}
     @endif
+
+    @component('components.delete-checkin-modal')
+    @endcomponent
 @endsection

--- a/resources/views/timeline/public.blade.php
+++ b/resources/views/timeline/public.blade.php
@@ -18,4 +18,7 @@
         </div>
         {{ $ejaculations->links(null, ['className' => 'mt-4 justify-content-center']) }}
     </div>
+
+    @component('components.delete-checkin-modal')
+    @endcomponent
 @endsection

--- a/resources/views/user/likes.blade.php
+++ b/resources/views/user/likes.blade.php
@@ -22,4 +22,7 @@
     </ul>
     {{ $likes->links(null, ['className' => 'mt-4 justify-content-center']) }}
 @endif
+
+@component('components.delete-checkin-modal')
+@endcomponent
 @endsection

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -56,74 +56,8 @@
     <ul class="list-group">
         @forelse ($ejaculations as $ejaculation)
             <li class="list-group-item border-bottom-only pt-3 pb-3 text-break">
-                <!-- span -->
-                <div>
-                    <h5>{{ $ejaculation->ejaculatedSpan() }} <a href="{{ route('checkin.show', ['id' => $ejaculation->id]) }}" class="text-muted"><small>{{ !empty($ejaculation->before_date) && !$ejaculation->discard_elapsed_time ? $ejaculation->before_date . ' ～ ' : '' }}{{ $ejaculation->ejaculated_date->format('Y/m/d H:i') }}</small></a></h5>
-                </div>
-                <!-- tags -->
-                @if ($ejaculation->is_private || $ejaculation->source !== 'web' || $ejaculation->tags->isNotEmpty())
-                    <p class="mb-2">
-                        @if ($ejaculation->is_private)
-                            <span class="badge badge-warning"><span class="oi oi-lock-locked"></span> 非公開</span>
-                        @endif
-                        @switch ($ejaculation->source)
-                            @case ('csv')
-                                <span class="badge badge-info"><span class="oi oi-cloud-upload"></span> インポート</span>
-                                @break
-                            @case ('webhook')
-                                <span class="badge badge-info" data-toggle="tooltip" title="Webhookからチェックイン"><span class="oi oi-flash"></span></span>
-                                @break
-                        @endswitch
-                        @foreach ($ejaculation->tags as $tag)
-                            <a class="badge badge-secondary" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag"></span> {{ $tag->name }}</a>
-                        @endforeach
-                    </p>
-                @endif
-                <div class="{{ $ejaculation->isMuted() ? 'tis-checkin-muted' : '' }}">
-                    <!-- okazu link -->
-                    @if (!empty($ejaculation->link))
-                        <div class="row mx-0">
-                            @component('components.link-card', ['link' => $ejaculation->link, 'is_too_sensitive' => $ejaculation->is_too_sensitive])
-                            @endcomponent
-                            <p class="d-flex align-items-baseline mb-2 col-12 px-0">
-                                <span class="oi oi-link-intact mr-1"></span><a class="overflow-hidden" href="{{ $ejaculation->link }}" target="_blank" rel="noopener">{{ $ejaculation->link }}</a>
-                            </p>
-                        </div>
-                    @endif
-                    <!-- note -->
-                    @if (!empty($ejaculation->note))
-                        <p class="mb-2 text-break">
-                            {!! Formatter::linkify(nl2br(e($ejaculation->note))) !!}
-                        </p>
-                    @endif
-                </div>
-                @if ($ejaculation->isMuted())
-                    <div class="tis-checkin-muted-warning">
-                        このチェックインはミュートされています<br>クリックまたはタップで表示
-                    </div>
-                @endif
-                <!-- likes -->
-                @if ($ejaculation->likes_count > 0)
-                    <div class="my-2 py-1 border-top border-bottom d-flex align-items-center">
-                        <div class="ml-2 mr-3 text-secondary flex-shrink-0"><small><strong>{{ $ejaculation->likes_count }}</strong> 件のいいね</small></div>
-                        <div class="like-users flex-grow-1 overflow-hidden">
-                            @foreach ($ejaculation->likes as $like)
-                                @if ($like->user !== null)
-                                    <a href="{{ route('user.profile', ['name' => $like->user->name]) }}"><img src="{{ $like->user->getProfileImageUrl(30) }}" srcset="{{ Formatter::profileImageSrcSet($like->user, 30) }}" width="30" height="30" class="rounded" data-toggle="tooltip" data-placement="bottom" title="{{ $like->user->display_name }}"></a>
-                                @endif
-                            @endforeach
-                        </div>
-                    </div>
-                @endif
-                <!-- actions -->
-                <div class="ejaculation-actions">
-                    <button type="button" class="btn btn-link text-secondary" data-toggle="tooltip" data-placement="bottom" title="同じオカズでチェックイン" data-href="{{ $ejaculation->makeCheckinURL() }}"><span class="oi oi-reload"></span></button>
-                    <button type="button" class="btn btn-link text-secondary like-button" data-toggle="tooltip" data-placement="bottom" data-trigger="hover" title="いいね" data-id="{{ $ejaculation->id }}" data-liked="{{ (bool)$ejaculation->is_liked }}"><span class="oi oi-heart {{ $ejaculation->is_liked ? 'text-danger' : '' }}"></span><span class="like-count">{{ $ejaculation->likes_count ? $ejaculation->likes_count : '' }}</span></button>
-                    @if ($user->isMe())
-                        <button type="button" class="btn btn-link text-secondary" data-toggle="tooltip" data-placement="bottom" title="修正" data-href="{{ route('checkin.edit', ['id' => $ejaculation->id]) }}"><span class="oi oi-pencil"></span></button>
-                        <button type="button" class="btn btn-link text-secondary" data-toggle="tooltip" data-placement="bottom" title="削除" data-target="#deleteCheckinModal" data-id="{{ $ejaculation->id }}" data-date="{{ $ejaculation->ejaculated_date }}"><span class="oi oi-trash"></span></button>
-                    @endif
-                </div>
+                @component('components.ejaculation', ['ejaculation' => $ejaculation, 'span' => 'withLink'])
+                @endcomponent
             </li>
         @empty
             <li class="list-group-item border-bottom-only">

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -56,7 +56,7 @@
     <ul class="list-group">
         @forelse ($ejaculations as $ejaculation)
             <li class="list-group-item border-bottom-only pt-3 pb-3 text-break">
-                @component('components.ejaculation', ['ejaculation' => $ejaculation, 'header' => 'spanWithLink'])
+                @component('components.ejaculation', ['ejaculation' => $ejaculation, 'header' => 'span'])
                 @endcomponent
             </li>
         @empty

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -68,19 +68,7 @@
     {{ $ejaculations->links(null, ['className' => 'mt-4 justify-content-center']) }}
 @endif
 
-@component('components.modal', ['id' => 'deleteCheckinModal'])
-    @slot('title')
-        削除確認
-    @endslot
-    <span class="date-label"></span> のチェックインを削除してもよろしいですか？
-    @slot('footer')
-        <form action="{{ route('checkin.destroy', ['id' => '@']) }}" method="post">
-            {{ csrf_field() }}
-            {{ method_field('DELETE') }}
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">キャンセル</button>
-            <button type="submit" class="btn btn-danger">削除</button>
-        </form>
-    @endslot
+@component('components.delete-checkin-modal')
 @endcomponent
 @endsection
 

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -56,7 +56,7 @@
     <ul class="list-group">
         @forelse ($ejaculations as $ejaculation)
             <li class="list-group-item border-bottom-only pt-3 pb-3 text-break">
-                @component('components.ejaculation', ['ejaculation' => $ejaculation, 'span' => 'withLink'])
+                @component('components.ejaculation', ['ejaculation' => $ejaculation, 'header' => 'spanWithLink'])
                 @endcomponent
             </li>
         @empty

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,7 @@ Route::middleware('stateful')->group(function () {
     Route::middleware(['throttle:60,1', 'auth'])->group(function () {
         Route::post('/likes', 'Api\\LikeController@store');
         Route::delete('/likes/{id}', 'Api\\LikeController@destroy');
+        Route::apiResource('checkin', 'Api\\CheckinController')->only(['destroy']);
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,7 +30,6 @@ Route::middleware('auth')->group(function () {
     Route::post('/checkin', 'EjaculationController@store')->name('checkin');
     Route::get('/checkin/{id}/edit', 'EjaculationController@edit')->name('checkin.edit');
     Route::put('/checkin/{id}', 'EjaculationController@update')->name('checkin.update');
-    Route::delete('/checkin/{id}', 'EjaculationController@destroy')->name('checkin.destroy');
 
     Route::get('/timeline/public', 'TimelineController@showPublic')->name('timeline.public');
 


### PR DESCRIPTION
今までチェックイン表示用のコンポーネントはバラバラに実装されていて、一部のみejaculation.blade.phpに統合されている状態でしたが、ここ1年では実装をバラバラにしておくメリットも薄いと感じたため統合を試みました。

また、今までのチェックイン削除はForm POSTを使っていましたが、Ajaxでの処理に変更しました。  
あらゆる画面で削除が押せるようになり、削除後に一律でプロフィールページにリダイレクトするのが微妙になったためです。  
`/checkin/:id` の画面だけは今まで通りっぽい振る舞いで、他の画面は一覧系なのでリスト上からチェックインを消すような処理を仕込みました。