### PR TITLE
いいね一覧のSQLを高速化

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -191,18 +191,24 @@ SQL
         }
 
         $likes = $user->likes()
-            ->orderBy('id', 'desc')
+            ->select('likes.*')
+            ->orderBy('likes.id', 'desc')
             ->with([
                 'ejaculation' => function ($query) {
                     $query->with('user', 'tags')->withMutedStatus();
                 }
             ])
-            ->whereHas('ejaculation', function ($query) {
-                $query->where(function ($query) {
-                    $query->where('user_id', Auth::id())
-                        ->orWhere('is_private', false);
-                })
-                    ->removeMuted();
+            ->join('ejaculations', 'likes.ejaculation_id', '=', 'ejaculations.id')
+            ->leftJoinSub(Ejaculation::queryTagFilterMatches(), 'tag_filter_matches', 'ejaculations.id', '=', 'tag_filter_matches.ejaculation_id')
+            ->where(function ($query) {
+                $query
+                    ->where(function ($query) {
+                        $query->where('ejaculations.user_id', Auth::id())
+                            ->orWhere('ejaculations.is_private', false);
+                    })->where(function ($query) {
+                        $query->where('ejaculations.user_id', Auth::id())
+                            ->orWhereRaw('COALESCE(tag_filter_matches.is_removed_by_tag_filter, 0) < 1');
+                    });
             })
             ->paginate(20);
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -191,7 +191,7 @@ SQL
         }
 
         $likes = $user->likes()
-            ->orderBy('created_at', 'desc')
+            ->orderBy('id', 'desc')
             ->with([
                 'ejaculation' => function ($query) {
                     $query->with('user', 'tags')->withMutedStatus();


### PR DESCRIPTION
fix #759 

いいね一覧のクエリで whereHas を使うのをやめて、相当するJOINを手書きしました。これで相関サブクエリが原因の速度低下が改善されます。  
また、ソート条件を created_at から id に変更することで、indexが使用されるようにします。

## 修正前のクエリ
```sql
-- ページネーション用のカウント
select count(*) as aggregate
from "likes"
where "likes"."user_id" = ?
  and "likes"."user_id" is not null
  and exists(select *
             from "ejaculations"
                      left join (select "ejaculations"."id" as "ejaculation_id", count(*) as is_removed_by_tag_filter
                                 from "ejaculations"
                                          inner join "related_ejaculation_tags"
                                                     on "ejaculations"."id" = "related_ejaculation_tags"."ejaculation_id"
                                          inner join "tags" on "related_ejaculation_tags"."tag_id" = "tags"."id"
                                          inner join "tag_filters" on "tags"."normalized_name" =
                                                                      "tag_filters"."normalized_tag_name" and
                                                                      ("tag_filters"."user_id" = ? and "tag_filters"."mode" = 2)
                                 group by "ejaculations"."id") as "tag_filter_matches"
                                on "ejaculations"."id" = "tag_filter_matches"."ejaculation_id"
             where "likes"."ejaculation_id" = "ejaculations"."id"
               and ("user_id" = ? or "is_private" = false)
               and ("ejaculations"."user_id" = ? or COALESCE(tag_filter_matches.is_removed_by_tag_filter, 0) < 1))
;

-- データ取得
select *
from "likes"
where "likes"."user_id" = ?
  and exists(select *
             from "ejaculations"
                      left join (select "ejaculations"."id" as "ejaculation_id", count(*) as is_removed_by_tag_filter
                                 from "ejaculations"
                                          inner join "related_ejaculation_tags"
                                                     on "ejaculations"."id" = "related_ejaculation_tags"."ejaculation_id"
                                          inner join "tags" on "related_ejaculation_tags"."tag_id" = "tags"."id"
                                          inner join "tag_filters" on "tags"."normalized_name" =
                                                                      "tag_filters"."normalized_tag_name" and
                                                                      ("tag_filters"."user_id" = ? and "tag_filters"."mode" = 2)
                                 group by "ejaculations"."id") as "tag_filter_matches"
                                on "ejaculations"."id" = "tag_filter_matches"."ejaculation_id"
             where "ejaculations"."id" = "likes"."ejaculation_id"
               and ("user_id" = ? or "is_private" = false)
               and ("ejaculations"."user_id" = ? or COALESCE(tag_filter_matches.is_removed_by_tag_filter, 0) < 1))
order by "created_at" desc
limit 20 offset 0
;
```

## 修正後のクエリ
```sql
-- ページネーション用のカウント
select count(*) as aggregate
from "likes"
         inner join "ejaculations" on likes.ejaculation_id = ejaculations.id
         left join (select "ejaculations"."id" as "ejaculation_id", count(*) as is_removed_by_tag_filter
                    from "ejaculations"
                             inner join "related_ejaculation_tags"
                                        on "ejaculations"."id" = "related_ejaculation_tags"."ejaculation_id"
                             inner join "tags" on "related_ejaculation_tags"."tag_id" = "tags"."id"
                             inner join "tag_filters" on "tags"."normalized_name" =
                                                         "tag_filters"."normalized_tag_name" and
                                                         ("tag_filters"."user_id" = ? and "tag_filters"."mode" = 2)
                    group by "ejaculations"."id") as "tag_filter_matches"
                   on "ejaculations"."id" = "tag_filter_matches"."ejaculation_id"
where "likes"."user_id" = ?
  and "likes"."user_id" is not null
  and (ejaculations.user_id = ? or is_private = false)
  and (ejaculations.user_id = ? or COALESCE(tag_filter_matches.is_removed_by_tag_filter, 0) < 1)
;

-- データ取得
select likes.*
from "likes"
         inner join "ejaculations" on likes.ejaculation_id = ejaculations.id
         left join (select "ejaculations"."id" as "ejaculation_id", count(*) as is_removed_by_tag_filter
                    from "ejaculations"
                             inner join "related_ejaculation_tags"
                                        on "ejaculations"."id" = "related_ejaculation_tags"."ejaculation_id"
                             inner join "tags" on "related_ejaculation_tags"."tag_id" = "tags"."id"
                             inner join "tag_filters" on "tags"."normalized_name" =
                                                         "tag_filters"."normalized_tag_name" and
                                                         ("tag_filters"."user_id" = ? and "tag_filters"."mode" = 2)
                    group by "ejaculations"."id") as "tag_filter_matches"
                   on "ejaculations"."id" = "tag_filter_matches"."ejaculation_id"
where "likes"."user_id" = ?
  and "likes"."user_id" is not null
  and (ejaculations.user_id = ? or is_private = false)
  and (ejaculations.user_id = ? or COALESCE(tag_filter_matches.is_removed_by_tag_filter, 0) < 1)
order by likes.id desc
limit 20 offset 0
;
```