### PR TITLE
今年よく使ったオカズのランキングを年間統計ページに追加

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -28,3 +28,12 @@ $primary: #e53fb1;
 .tis-status-container + .mt-n1 {
     margin-top: 0 !important;
 }
+
+.tis-rank-badge {
+    padding: 0.25rem 0.75rem;
+    font-size: 1.75rem;
+    font-weight: bold;
+    color: #fff;
+    background-color: #e53fb1;
+    border-radius: 0.5rem;
+}

--- a/resources/views/user/stats/yearly.blade.php
+++ b/resources/views/user/stats/yearly.blade.php
@@ -34,6 +34,11 @@
                         <span class="oi oi-link-intact mr-1"></span><a class="overflow-hidden" href="{{ $item->normalized_link }}" target="_blank" rel="noopener">{{ $item->normalized_link }}</a>
                     </p>
                 </div>
+                <div class="ejaculation-actions">
+                    <button type="button" class="btn btn-link text-secondary"
+                            data-toggle="tooltip" data-placement="bottom"
+                            title="同じオカズでチェックイン" data-href="{{ route('checkin', ['link' => $item->normalized_link]) }}"><span class="oi oi-reload"></span></button>
+                </div>
             </li>
         @empty
             <li class="list-group-item border-bottom-only">

--- a/resources/views/user/stats/yearly.blade.php
+++ b/resources/views/user/stats/yearly.blade.php
@@ -21,8 +21,8 @@
     <hr class="my-4">
     @include('user.stats.components.used-tags')
     <hr class="my-4">
-    <h5 class="my-4">最も使ったオカズ</h5>
-    <p class="text-secondary">2回以上使用したオカズのみ集計しています。</p>
+    <h5 class="mt-4 mb-2">最も使ったオカズ</h5>
+    <p class="mb-4 text-secondary">2回以上使用したオカズのみ集計しています。</p>
     <ul class="list-group">
         @forelse ($mostFrequentlyUsedRanking as $index => $item)
             <li class="list-group-item border-bottom-only pt-3 pb-3 px-0 text-break">

--- a/resources/views/user/stats/yearly.blade.php
+++ b/resources/views/user/stats/yearly.blade.php
@@ -20,6 +20,27 @@
     <canvas id="dow-graph" class="w-100"></canvas>
     <hr class="my-4">
     @include('user.stats.components.used-tags')
+    <hr class="my-4">
+    <h5 class="my-4">最も使ったオカズ</h5>
+    <p class="text-secondary">2回以上使用したオカズのみ集計しています。</p>
+    <ul class="list-group">
+        @forelse ($mostFrequentlyUsedRanking as $index => $item)
+            <li class="list-group-item border-bottom-only pt-3 pb-3 text-break">
+                <p class="mb-1"><span class="mr-3 tis-rank-badge">{{ $index + 1 }}</span><span class="mr-2" style="font-size: 1.75rem">{{ $item->count }}</span>回</p>
+                <div class="row mx-0">
+                    @component('components.link-card', ['link' => $item->normalized_link, 'is_too_sensitive' => false])
+                    @endcomponent
+                    <p class="d-flex align-items-baseline mb-2 col-12 px-0">
+                        <span class="oi oi-link-intact mr-1"></span><a class="overflow-hidden" href="{{ $item->normalized_link }}" target="_blank" rel="noopener">{{ $item->normalized_link }}</a>
+                    </p>
+                </div>
+            </li>
+        @empty
+            <li class="list-group-item border-bottom-only">
+                <p>この期間のチェックインが無いか、2回以上使用したオカズがありません。</p>
+            </li>
+        @endforelse
+    </ul>
 @endsection
 
 @push('script')

--- a/resources/views/user/stats/yearly.blade.php
+++ b/resources/views/user/stats/yearly.blade.php
@@ -25,7 +25,7 @@
     <p class="text-secondary">2回以上使用したオカズのみ集計しています。</p>
     <ul class="list-group">
         @forelse ($mostFrequentlyUsedRanking as $index => $item)
-            <li class="list-group-item border-bottom-only pt-3 pb-3 text-break">
+            <li class="list-group-item border-bottom-only pt-3 pb-3 px-0 text-break">
                 <p class="mb-1"><span class="mr-3 tis-rank-badge">{{ $index + 1 }}</span><span class="mr-2" style="font-size: 1.75rem">{{ $item->count }}</span>回</p>
                 <div class="row mx-0">
                     @component('components.link-card', ['link' => $item->normalized_link, 'is_too_sensitive' => false])


### PR DESCRIPTION
今年よく使ったオカズを振り返る枠を年間統計ページに追加します。  
2回以上使っているオカズを10位まで並べます。

年末企画として直接本番に上げたいです。(なので、master宛)

## Screenshot
<img width="1235" alt="スクリーンショット 2021-12-30 17 31 34" src="https://user-images.githubusercontent.com/1352154/147734950-d9f6efc6-9b08-4569-ba53-57bcd284d754.png">

