### PR TITLE
投稿ソースを詳細画面で小さく表示するように変更

### DIFF
--- a/resources/views/components/ejaculation.blade.php
+++ b/resources/views/components/ejaculation.blade.php
@@ -14,22 +14,14 @@
     @endswitch
 </div>
 <!-- tags -->
-@if ($ejaculation->is_private || $ejaculation->source !== 'web' || $ejaculation->tags->isNotEmpty())
+@if ($ejaculation->is_private || $ejaculation->source === 'csv' || $ejaculation->tags->isNotEmpty())
     <p class="tis-checkin-tags mb-2">
         @if ($ejaculation->is_private)
             <span class="badge badge-warning"><span class="oi oi-lock-locked"></span> 非公開</span>
         @endif
-        @switch ($ejaculation->source)
-            @case ('csv')
-                <span class="badge badge-info"><span class="oi oi-cloud-upload"></span> インポート</span>
-                @break
-            @case ('webhook')
-                <span class="badge badge-info" data-toggle="tooltip" title="Webhookからチェックイン"><span class="oi oi-flash"></span></span>
-                @break
-            @case ('api')
-                <span class="badge badge-info" data-toggle="tooltip" title="APIからチェックイン"><span class="oi oi-flash"></span></span>
-                @break
-        @endswitch
+        @if ($ejaculation->source === 'csv')
+            <span class="badge badge-info"><span class="oi oi-cloud-upload"></span> インポート</span>
+        @endif
         @foreach ($ejaculation->tags as $tag)
             <a class="badge badge-secondary" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag"></span> {{ $tag->name }}</a>
         @endforeach
@@ -53,6 +45,16 @@
         </p>
     @endif
 </div>
+@if ($showSource ?? false)
+    @switch ($ejaculation->source)
+        @case ('webhook')
+            <p class="mb-2 text-secondary small">Webhookからチェックイン</p>
+            @break
+        @case ('api')
+            <p class="mb-2 text-secondary small">APIからチェックイン</p>
+            @break
+    @endswitch
+@endif
 @if ($ejaculation->isMuted())
     <div class="tis-checkin-muted-warning">
         このチェックインはミュートされています<br>クリックまたはタップで表示

--- a/resources/views/ejaculation/show.blade.php
+++ b/resources/views/ejaculation/show.blade.php
@@ -29,7 +29,7 @@
             @else
                 <div class="card">
                     <div class="card-body">
-                        @component('components.ejaculation', ['ejaculation' => $ejaculation, 'header' => 'span', 'likeUsersTall' => true])
+                        @component('components.ejaculation', ['ejaculation' => $ejaculation, 'header' => 'span', 'likeUsersTall' => true, 'showSource' => true])
                         @endcomponent
                     </div>
                 </div>


### PR DESCRIPTION
fix #824 

CSVについては見なかったことにした

<img width="768" alt="スクリーンショット 2022-01-29 22 39 59" src="https://user-images.githubusercontent.com/1352154/151663383-b94a7f94-5346-4016-a300-3cd20f8ce07a.png">

