### PR TITLE
Format::formatInterval の日数部をカンマ区切りでフォーマットする

### DIFF
--- a/app/Utilities/Formatter.php
+++ b/app/Utilities/Formatter.php
@@ -22,7 +22,7 @@ class Formatter
      */
     public function formatInterval($value)
     {
-        $days = floor($value / 86400);
+        $days = number_format(floor($value / 86400));
         $hours = floor($value % 86400 / 3600);
         $minutes = floor($value % 3600 / 60);
 

--- a/tests/Unit/Utilities/FormatterTest.php
+++ b/tests/Unit/Utilities/FormatterTest.php
@@ -7,6 +7,18 @@ use Tests\TestCase;
 
 class FormatterTest extends TestCase
 {
+    public function testFormatIntervalHundredDays()
+    {
+        $formatter = new Formatter();
+        $this->assertSame('100日 0時間 0分', $formatter->formatInterval(100 * 86400));
+    }
+
+    public function testFormatIntervalThousandDays()
+    {
+        $formatter = new Formatter();
+        $this->assertSame('1,000日 0時間 0分', $formatter->formatInterval(1000 * 86400));
+    }
+
     public function testNormalizeUrlWithoutQuery()
     {
         $formatter = new Formatter();


### PR DESCRIPTION
fix #835

<img width="306" alt="image" src="https://user-images.githubusercontent.com/1352154/163734752-6ff5c91a-75e0-4655-82a7-59f85fffb70f.png">
