### PR TITLE
概況欄に中央値を追加

### DIFF
--- a/app/Http/ViewComposers/ProfileStatsComposer.php
+++ b/app/Http/ViewComposers/ProfileStatsComposer.php
@@ -38,6 +38,7 @@ class ProfileStatsComposer
         // 概況欄のデータ取得
         $average = 0;
         $divisor = 0;
+        $medianSources = [];
         $averageSources = DB::select(<<<'SQL'
 SELECT
   extract(epoch from ejaculated_date - lead(ejaculated_date, 1, NULL) OVER (ORDER BY ejaculated_date DESC)) AS span,
@@ -59,10 +60,12 @@ SQL
             }
             $average += $item->span;
             $divisor++;
+            $medianSources[] = $item->span;
         }
         if ($divisor > 0) {
             $average /= $divisor;
         }
+        $median = collect($medianSources)->sort()->median();
 
         $summary = DB::select(<<<'SQL'
 SELECT
@@ -88,6 +91,6 @@ SQL
 
         $total = $user->ejaculations()->count();
 
-        $view->with(compact('latestEjaculation', 'currentSession', 'average', 'summary', 'total'));
+        $view->with(compact('latestEjaculation', 'currentSession', 'average', 'median', 'summary', 'total'));
     }
 }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -16,6 +16,7 @@ $primary: #e53fb1;
 @import "components/tag-input";
 @import "components/metadata-preview";
 @import "components/profile-mini";
+@import "components/profile-stats";
 @import "components/stat-table";
 @import "components/toast";
 

--- a/resources/assets/sass/components/_profile-stats.scss
+++ b/resources/assets/sass/components/_profile-stats.scss
@@ -1,0 +1,10 @@
+.tis-profile-stats-table {
+    th {
+        padding-right: 0.5rem;
+        text-align: right;
+
+        &::after {
+            content: ":";
+        }
+    }
+}

--- a/resources/views/components/profile-stats.blade.php
+++ b/resources/views/components/profile-stats.blade.php
@@ -8,8 +8,29 @@
 @endif
 
 <h6 class="font-weight-bold"><span class="oi oi-graph"></span> 概況</h6>
-<p class="card-text mb-0">平均記録: {{ Formatter::formatInterval($average) }}</p>
-<p class="card-text mb-0">最長記録: {{ Formatter::formatInterval($summary[0]->longest) }}</p>
-<p class="card-text mb-0">最短記録: {{ Formatter::formatInterval($summary[0]->shortest) }}</p>
-<p class="card-text mb-0">合計時間: {{ Formatter::formatInterval($summary[0]->total_times) }}</p>
-<p class="card-text">通算回数: {{ number_format($total) }}回</p>
+<table class="tis-profile-stats-table">
+    <tr>
+        <th>平均記録</th>
+        <td>{{ Formatter::formatInterval($average) }}</td>
+    </tr>
+    <tr>
+        <th>中央値</th>
+        <td>{{ Formatter::formatInterval($median) }}</td>
+    </tr>
+    <tr>
+        <th>最長記録</th>
+        <td>{{ Formatter::formatInterval($summary[0]->longest) }}</td>
+    </tr>
+    <tr>
+        <th>最短記録</th>
+        <td>{{ Formatter::formatInterval($summary[0]->shortest) }}</td>
+    </tr>
+    <tr>
+        <th>合計時間</th>
+        <td>{{ Formatter::formatInterval($summary[0]->total_times) }}</td>
+    </tr>
+    <tr>
+        <th>通算回数</th>
+        <td>{{ number_format($total) }}回</td>
+    </tr>
+</table>


### PR DESCRIPTION
fix #884 

今まで全部の項目が4文字でなんとなく揃っていたのが崩れたので、レイアウトも変更。

<img width="378" alt="スクリーンショット 2022-06-20 21 56 15" src="https://user-images.githubusercontent.com/1352154/174606521-577a8195-5a28-4438-a4ed-2a118a6f887a.png">
