### PR TITLE
Downgrade symfony/dom-crawler 4.4.42 to 4.4.37

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "sentry/sentry-laravel": "^2.4.2",
         "staudenmeir/eloquent-eager-limit": "~1.4.1",
         "symfony/css-selector": "^4.3",
-        "symfony/dom-crawler": "^4.3",
+        "symfony/dom-crawler": "4.4.37",
         "t1gor/robots-txt-parser": "^0.2.4"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a0c0fe2126967ff710ec1a8ba3fa852c",
+    "content-hash": "d3ef3a9176bf0ca48333174f895ef224",
     "packages": [
         {
             "name": "anhskohbo/no-captcha",
@@ -5120,16 +5120,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v4.4.42",
+            "version": "v4.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "be5a04618e5d44e71d013f177df80d3ec4b192a0"
+                "reference": "60d36408a3a48500bcc6e30d9f831e51d04d7fa4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/be5a04618e5d44e71d013f177df80d3ec4b192a0",
-                "reference": "be5a04618e5d44e71d013f177df80d3ec4b192a0",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/60d36408a3a48500bcc6e30d9f831e51d04d7fa4",
+                "reference": "60d36408a3a48500bcc6e30d9f831e51d04d7fa4",
                 "shasum": ""
             },
             "require": {
@@ -5174,7 +5174,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v4.4.42"
+                "source": "https://github.com/symfony/dom-crawler/tree/v4.4.37"
             },
             "funding": [
                 {
@@ -5190,7 +5190,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-30T18:34:00+00:00"
+            "time": "2022-01-02T09:41:36+00:00"
         },
         {
             "name": "symfony/error-handler",


### PR DESCRIPTION
[symfony/dom-crawler 4.4.38](https://github.com/symfony/dom-crawler/releases/tag/v4.4.38) で文字コードの判定が変わってテストが落ちた。これを書いている時点のdevelopのCIが通ってるのはよくわからん。

明示的に文字コードを指定してロードさせる方法はありそうな気がするが、下げたところで何も困らないので下げる。