### PR TITLE
Docker: xdebug 3になってからデバッグ用設定が動作していなかったのを修正

### DIFF
--- a/dist/php.d/99-xdebug.ini
+++ b/dist/php.d/99-xdebug.ini
@@ -1,4 +1,4 @@
 ; Dockerでのデバッグ用設定
 zend_extension=xdebug.so
-xdebug.remote_enable=true
-xdebug.remote_host=${PHP_XDEBUG_REMOTE_HOST}
+xdebug.mode=debug
+xdebug.client_host=${PHP_XDEBUG_REMOTE_HOST}


### PR DESCRIPTION
IntelliJでデバッグしようとしたら全く動かなくて頭を抱えたけど、単に2.x→3.xの設定マイグレーションをやれということだった。

https://xdebug.org/docs/upgrade_guide/ja