### PR TITLE
CollectionItemのノート内URLをリンク化し、改行も反映した

### DIFF
--- a/resources/assets/js/user/collection.tsx
+++ b/resources/assets/js/user/collection.tsx
@@ -245,7 +245,9 @@ const CollectionItem: React.FC<CollectionItemProps> = ({ item, onUpdate }) => {
                     ))}
                 </p>
             )}
-            {item.note != '' && <p className="mb-2 text-break" dangerouslySetInnerHTML={{ __html: item.note }} />}
+            {item.note_html != '' && (
+                <p className="mb-2 text-break" dangerouslySetInnerHTML={{ __html: item.note_html }} />
+            )}
             <div className="ejaculation-actions">
                 <OverlayTrigger
                     placement="bottom"


### PR DESCRIPTION
fix #936 

このためにサーバーサイドで note_html というプロパティを内部利用目的で出力していたのに、使うのを忘れていた。