### PR TITLE
MelonbooksResolver: ページタイトルフォーマット・DOM構造変更に追従

### DIFF
--- a/app/MetadataResolver/MelonbooksResolver.php
+++ b/app/MetadataResolver/MelonbooksResolver.php
@@ -44,7 +44,7 @@ class MelonbooksResolver implements Resolver
         }
 
         // 抽出
-        preg_match('~^(.+)（(.+)）の通販・購入はメロンブックス$~', $metadata->title, $match);
+        preg_match('~^(.+)（(.+)）の通販・購入はメロンブックス~', $metadata->title, $match);
         $title = $match[1];
         $maker = $match[2];
 

--- a/app/MetadataResolver/MelonbooksResolver.php
+++ b/app/MetadataResolver/MelonbooksResolver.php
@@ -26,7 +26,10 @@ class MelonbooksResolver implements Resolver
     {
         $cookieJar = CookieJar::fromArray(['AUTH_ADULT' => '1'], 'www.melonbooks.co.jp');
 
-        $res = $this->client->get($url, ['cookies' => $cookieJar]);
+        $res = $this->client->get($url, [
+            'cookies' => $cookieJar,
+            'curl' => [CURLOPT_SSL_CIPHER_LIST => 'DEFAULT@SECLEVEL=1']
+        ]);
         $metadata = $this->ogpResolver->parse($res->getBody());
 
         $dom = new \DOMDocument();

--- a/app/MetadataResolver/MelonbooksResolver.php
+++ b/app/MetadataResolver/MelonbooksResolver.php
@@ -35,8 +35,8 @@ class MelonbooksResolver implements Resolver
         $dom = new \DOMDocument();
         @$dom->loadHTML(mb_convert_encoding($res->getBody(), 'HTML-ENTITIES', 'UTF-8'));
         $xpath = new \DOMXPath($dom);
-        $descriptionNodelist = $xpath->query('//div[@id="description"]//p');
-        $specialDescriptionNodelist = $xpath->query('//div[@id="special_description"]//p');
+        $descriptionNodelist = $xpath->query('//div[contains(@class, "item-detail")]/*[contains(@class, "page-headline") and contains(text(), "作品詳細")]/following-sibling::div[1]');
+        $specialDescriptionNodelist = $xpath->query('//div[contains(@class, "item-detail")]/*[contains(@class, "page-headline") and contains(text(), "スタッフのオススメポイント")]/following-sibling::div[1]');
 
         // censoredフラグの除去
         if (mb_strpos($metadata->image, '&c=1') !== false) {
@@ -51,16 +51,12 @@ class MelonbooksResolver implements Resolver
         // 整形
         $description = 'サークル: ' . $maker . "\n";
 
-        if ($specialDescriptionNodelist->length !== 0) {
-            $description .= trim(str_replace('<br>', "\n", $specialDescriptionNodelist->item(0)->nodeValue)) . "\n";
-            if ($specialDescriptionNodelist->length === 2) {
-                $description .= "\n";
-                $description .= trim(str_replace('<br>', "\n", $specialDescriptionNodelist->item(1)->nodeValue)) . "\n";
-            }
+        if ($descriptionNodelist->length !== 0) {
+            $description .= trim(str_replace("\r\n", "\n", $descriptionNodelist->item(0)->textContent)) . "\n\n";
         }
 
-        if ($descriptionNodelist->length !== 0) {
-            $description .= trim(str_replace('<br>', "\n", $descriptionNodelist->item(0)->nodeValue));
+        if ($specialDescriptionNodelist->length !== 0) {
+            $description .= trim(str_replace("\r\n", "\n", $specialDescriptionNodelist->item(0)->textContent));
         }
 
         $metadata->title = $title;

--- a/tests/Unit/MetadataResolver/MelonbooksResolverTest.php
+++ b/tests/Unit/MetadataResolver/MelonbooksResolverTest.php
@@ -27,7 +27,24 @@ class MelonbooksResolverTest extends TestCase
 
         $metadata = $this->resolver->resolve('https://www.melonbooks.co.jp/detail/detail.php?product_id=1836264');
         $this->assertEquals('めいど・で・ろっく!', $metadata->title);
-        $this->assertEquals('サークル: MIX-ISM', $metadata->description);
+        $this->assertEquals(<<<'EOF'
+サークル: MIX-ISM
+サークルMIX-ISM「ぼっち・ざ・ろっく!」本 第2弾!
+ワンマンライブのチケットが売れていない結束バンドは
+ライブハウスでメイドカフェ&ライブをやることに。
+
+SNSで宣伝したりオリジナルフードメニューを考えたり
+星歌、きくり、PAさん大人チームもメイド服でお手伝い。
+
+メインキャラ総出演のドタバタギャグコメディ!
+はたしてライブは成功するのか…?
+
+犬威赤彦先生がお贈りする、ぼ〇ろのハイテンションメイドコメディ本の登場です☆
+チケットノルマが足りないならメイド服になればいいじゃないと言う流れがすでに面白い♪
+ぼっちちゃんの写真を撮っている時の奇跡の一枚が素材の良さを存分に発揮していて可愛い☆
+可愛いメイド姿でカッコいいライブもこなす結束バンドが最高な、極上の一冊をお楽しみ下さい♪
+EOF
+            , $metadata->description);
         $this->assertEquals('https://melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384.jpg', $metadata->image);
         if ($this->shouldUseMock()) {
             $this->assertSame('https://www.melonbooks.co.jp/detail/detail.php?product_id=1836264', (string) $this->handler->getLastRequest()->getUri());
@@ -42,7 +59,20 @@ class MelonbooksResolverTest extends TestCase
 
         $metadata = $this->resolver->resolve('https://www.melonbooks.co.jp/detail/detail.php?product_id=1789342');
         $this->assertEquals('血姫夜交　真祖の姫は発情しているっ!', $metadata->title);
-        $this->assertEquals('サークル: 毛玉牛乳', $metadata->description);
+        $this->assertEquals(<<<'EOF'
+サークル: 毛玉牛乳
+毛玉牛乳オリジナル同人誌新シリーズ「血姫夜交」です。
+森の塔に封じられた真祖(吸血鬼)の姫と出会う少年のおはなし。
+吸血鬼のプラズマはプライドが高くいたずら好き。
+チョロインの人外少女といちゃらぶするシリーズです。
+
+玉之けだま先生の描く、オリジナルシリーズ最新作のヒロインは妖艶な雰囲気の悪戯好きな真祖の吸血鬼です☆
+森の塔で出会った吸血鬼の少女が少年のチ〇コをひんやりとした口でぱくりと食べる様子がエロい♪
+口に精液を出された後に、とろとろになったマ〇コを差し出し挿入してもらうのを待つ彼女に興奮します☆
+膣内にチンコを迎え入れて歓喜しながら全身で感じている様子が最高にエロい♪
+イタズラ好き真祖の少女がチ〇コに簡単に落とされるのがエロい、極上の一冊を是非お手元でお楽しみ下さい♪
+EOF
+            , $metadata->description);
         $this->assertEquals('https://melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380763.jpg', $metadata->image);
         if ($this->shouldUseMock()) {
             $this->assertSame('https://www.melonbooks.co.jp/detail/detail.php?product_id=1789342', (string) $this->handler->getLastRequest()->getUri());

--- a/tests/Unit/MetadataResolver/MelonbooksResolverTest.php
+++ b/tests/Unit/MetadataResolver/MelonbooksResolverTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\MetadataResolver;
+
+use App\MetadataResolver\MelonbooksResolver;
+use Tests\TestCase;
+
+class MelonbooksResolverTest extends TestCase
+{
+    use CreateMockedResolver;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (!$this->shouldUseMock()) {
+            sleep(1);
+        }
+    }
+
+    public function testUncensored()
+    {
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Melonbooks/testUncensored.html');
+
+        $this->createResolver(MelonbooksResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://www.melonbooks.co.jp/detail/detail.php?product_id=1836264');
+        $this->assertEquals('めいど・で・ろっく!', $metadata->title);
+        $this->assertEquals('サークル: MIX-ISM', $metadata->description);
+        $this->assertEquals('https://melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384.jpg', $metadata->image);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://www.melonbooks.co.jp/detail/detail.php?product_id=1836264', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
+
+    public function testCensored()
+    {
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Melonbooks/testCensored.html');
+
+        $this->createResolver(MelonbooksResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://www.melonbooks.co.jp/detail/detail.php?product_id=1789342');
+        $this->assertEquals('血姫夜交　真祖の姫は発情しているっ!', $metadata->title);
+        $this->assertEquals('サークル: 毛玉牛乳', $metadata->description);
+        $this->assertEquals('https://melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380763.jpg', $metadata->image);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://www.melonbooks.co.jp/detail/detail.php?product_id=1789342', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
+}

--- a/tests/fixture/Melonbooks/testCensored.html
+++ b/tests/fixture/Melonbooks/testCensored.html
@@ -1,0 +1,1917 @@
+<!-- ▼BODY部 スタート -->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ja-JP" lang="ja-JP">
+<head>
+    <meta charset="UTF-8"/>
+            <link rel="canonical" href="https://www.melonbooks.co.jp/detail/detail.php?product_id=1789342"/>
+                <meta name="author" content="メロンブックス"/>
+                <meta name="description" itemprop="description" content="血姫夜交　真祖の姫は発情しているっ!はサークル名：毛玉牛乳の作品です。血姫夜交　真祖の姫は発情しているっ!の通販、予約は業界最速のメロンブックスにお任せください。サンプルで血姫夜交　真祖の姫は発情しているっ!の試し読み可能！作品の詳細紹介も。お得な特典情報もお見逃しなく！"/>
+                <meta name="keywords" content="血姫夜交　真祖の姫は発情しているっ! ,血姫夜交　真祖の姫は発情しているっ! 通販,血姫夜交　真祖の姫は発情しているっ! 予約,血姫夜交　真祖の姫は発情しているっ! 購入同人誌,同人ゲーム,同人漫画,マンガ,同人グッズ,通販,メロンブックス"/>
+        <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+            <title>
+                            血姫夜交　真祖の姫は発情しているっ!（毛玉牛乳）の通販・購入はメロンブックス | 作品詳細
+                    </title>
+                            <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:site" content="@melonbooks" />
+            <meta property="og:title" content="血姫夜交　真祖の姫は発情しているっ!（毛玉牛乳）の通販・購入はメロンブックス | 作品詳細">
+            <meta property="og:url" content="https://www.melonbooks.co.jp/detail/detail.php?product_id=1789342">
+            <meta property="og:image" content="https://melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380763.jpg&amp;c=1">
+            <meta property="og:type" content="website">
+            <meta property="og:site_name" content="メロンブックス">
+            <meta property="og:description" content="血姫夜交　真祖の姫は発情しているっ!はサークル名：毛玉牛乳の作品です。血姫夜交　真祖の姫は発情しているっ!の通販、予約は業界最速のメロンブックスにお任せください。サンプルで血姫夜交　真祖の姫は発情しているっ!の試し読み可能！作品の詳細紹介も。お得な特典情報もお見逃しなく！">
+                    <!-- favicon setting-->
+            <link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
+        <link rel="shortcut icon" href="//melonbooks.akamaized.net/user_data/packages/responsive/img/icon/favicon.ico" type="image/vnd.microsoft.ico"/>
+        <link rel="icon" href="/apple-touch-icon.png" type="image/png"/>
+        
+
+    <!-- CSS -->
+            <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/css/main.css?d=1676347938"/>
+        <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/css/lity.css" />
+    <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/css/normalize.css" />
+    <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/css/slick.css" />
+    <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/css/slick-theme.css" />
+    <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/css/swiper.css" />
+    <link type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css" rel="stylesheet">
+    <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/photoswipe.css" />
+    <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/default-skin/default-skin.css" />
+            <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/photoswipe.css" />
+            <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/default-skin/default-skin.css" />
+            
+    <!-- JS -->
+    <script type="text/javascript">//<![CDATA[
+        var site_root = "/";
+        var isFromagee = false;
+        var isPublicDl = false;
+        //]]></script>
+    
+    <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/lib/jquery.easing.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/lib/ajaxzip3.js"></script>
+    <script type="text/javascript" src="/js/eccube.js"></script>
+    <script type="text/javascript" src="/js/eccube.legacy.js"></script>
+    
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/melonbooks.js?d=1669258418"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/melonbooks_old.js?d=1674530325"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/lity.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/slick.min.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.slidemenu.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/photoswipe.min.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/photoswipe-ui-default.min.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.infinitescroll.min.js"></script>
+    
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/lazysizes.min.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/recommend.js?d=1670217711"></script>
+    <script type="text/javascript" src="//js.rtoaster.jp/Rtoaster.js"></script>
+    <script src="https://auth.atone.be/v1/register.js"></script>
+            <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/photoswipe.min.js" charset="UTF-8"></script>
+            <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/photoswipe-ui-default.min.js" charset="UTF-8"></script>
+    
+        <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+        ga('create', 'UA-55322222-1', 'auto');
+        ga('send', 'pageview');
+
+            </script>
+            <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-N0L4LE6F64"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-N0L4LE6F64');
+
+            </script>
+            <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "cmc03jnsmo");
+    </script>
+        <!-- User Insight PCDF Code Start :  -->
+    <script type="" type="text/javascript">
+    var _uic = _uic ||{}; var _uih = _uih ||{};_uih['id'] = 55232;
+    _uih['lg_id'] = '';
+    _uih['fb_id'] = '';
+    _uih['tw_id'] = '';
+    _uih['uigr_1'] = ''; _uih['uigr_2'] = ''; _uih['uigr_3'] = ''; _uih['uigr_4'] = ''; _uih['uigr_5'] = '';
+    _uih['uigr_6'] = ''; _uih['uigr_7'] = ''; _uih['uigr_8'] = ''; _uih['uigr_9'] = ''; _uih['uigr_10'] = '';
+    _uic['uls'] = 1;
+
+    /* DO NOT ALTER BELOW THIS LINE */
+    /* WITH FIRST PARTY COOKIE */
+    (function() {
+    var bi = document.createElement('script');bi.type = 'text/javascript'; bi.async = true;
+    bi.src = '//cs.nakanohito.jp/b3/bi.js';
+    var s = document.getElementsByTagName('script')[0];s.parentNode.insertBefore(bi, s);
+    })();
+    </script>
+    <!-- User Insight PCDF Code End :  -->
+    <script type="text/javascript">
+        window.lazySizesConfig = window.lazySizesConfig || {};
+        window.lazySizesConfig.expand = 50;
+        $(function () {
+            $('.lazyload').show();
+        });
+    </script>
+        <script type="text/javascript">
+        recommendOptions = {"contractId":"RTA-f22a-d92528fa82b5","memberHashCookieName":"R_CUSTOMER","productIdForViewTrack":null,"convertedItems":{},"items":{},"omitItems":{"0":"1789342","1":"1680497","2":"591211","3":"604251","4":"1593374","5":"1572489","6":"1470179"},"category":["\u540c\u4eba\u8a8c","","","","00000011"]};
+
+        var memberHash = Rtoaster.Cookie.get(recommendOptions.memberHashCookieName);
+        Rtoaster.init(recommendOptions.contractId, memberHash);
+
+        Recommend.registerCallback(Rtoaster);
+
+        if (recommendOptions.productIdForViewTrack) {
+            Rtoaster.item("" + recommendOptions.productIdForViewTrack);
+        }
+
+        if (!$.isEmptyObject(recommendOptions.convertedItems)) {
+                        if(isFromagee){
+                clipboard_url='/fromagee/clipboard/';
+            }else{
+                clipboard_url='/clipboard/';
+            }
+                        if(clipboard_url){
+                Rtoaster.track(recommendOptions.convertedItems,clipboard_url);
+            }else{
+                Rtoaster.track(recommendOptions.convertedItems);
+            }
+        } else {
+            Rtoaster.track();
+        }
+
+        recommendFooterProc = function (options) {
+            if (!$.isEmptyObject(options.items)) {
+                Rtoaster.item(options.items);
+            }
+
+            if (!$.isEmptyObject(options.omitItems)) {
+                Rtoaster.omit(Object.values(options.omitItems).join(','));
+            }
+
+            var recommendIds = $('.rt-recommend').map(function () {
+                return $(this).attr('id');
+            }).get();
+
+            if (options.category) {
+                Rtoaster.category.apply(null, options.category);
+            }
+
+            if (recommendIds.length) {
+                Rtoaster.recommendNow.apply(null, recommendIds);
+            }
+            //Rtoaster.recommendNow(recommendIds.join(','));
+        };
+
+        var footerProcTag = document.createElement('script');
+        footerProcTag.text = 'recommendFooterProc(window.recommendOptions);';
+        $(function () {
+            document.body.appendChild(footerProcTag);
+        });
+    </script>
+    
+    <script data-a8stoplog="1" src="//statics.a8.net/a8sales/a8sales.js"></script>
+    <script type="text/javascript">
+        var send_at_search = true;
+        function fnCheckSubmitAtSearch() {
+            if (send_at_search) {
+                send_at_search = false;
+                return true;
+            } else {
+                alert("只今、処理中です。しばらくお待ち下さい。");
+                return false;
+            }
+        }
+    </script>
+</head>
+<!-- ▼BODY部 スタート -->
+
+<!-- TODO : 出し分けの調整 -->
+    <body id="pagetop" class="index-page __pc">
+
+
+
+
+    <div id="header_free_html">
+    <!--ここはweb反映のない領域です-->
+
+
+
+<style>
+.header_belt_penetration{
+  /* background-color:#ebf5f0; */
+  background-color:#fff;
+  padding: 0 1.5% 0 0%;
+  margin-bottom: -5px;
+  margin-top:3px;
+  /*border-bottom:1px solid #e2ddcd;*/
+}
+
+.header_ul_right{
+  display:flex ;
+  text-align: right;
+}
+
+.header_li_right{
+  text-align: right;
+  padding: 0 0 0 10px;
+}
+.header_li_left{
+  padding: 0 0 0 0.5px;
+  flex-grow: 1;
+}
+
+.header_area_right :before {
+    content: '\f2bd';
+    font-family: FontAwesome;
+    position: absolute;
+    top: 50%;
+    right: 16px;
+    transform: translateY(-50%);
+    color: #a6a6a6;
+}
+.a_area_style1{
+    color :#00a667;
+    /*color:#666;*/
+    font-size:12px
+}
+.a_area_style2{
+    color :#00a667;
+    /*color:#444;*/
+    /*color:#338a41;*/
+    font-size:12px
+}
+ .awesomeicon{
+    color :#00a667;
+    /*color:#444;*/
+    /*color:#338a41;*/
+}
+
+@media screen and (max-width:617px) {
+.header_belt_penetration {
+display:none;
+}
+}
+
+
+</style>
+
+<div class="header_belt_penetration">
+  <p class="header_area_right">
+    <ul class="header_ul_right">
+
+<!--出荷状況入れてもいい-->
+      <li class="header_li_left">
+        <a class="a_area_style1">
+        </a>
+      </li>
+
+      <li class="header_li_right">
+        <a href="https://www.melonbooks.co.jp/special/b/0/special/melonbooks_flomagee_staff/recruit.html" class="a_area_style2">
+          <i class="fa-solid fa-users awesomeicon"></i>求人案内
+        </a>
+      </li>
+
+      <li class="header_li_right">
+        <a href="https://circle.melonbooks.co.jp/login/" class="a_area_style2">
+          <i class="fa-regular fa-circle-user awesomeicon"></i>サークルポータル
+        </a>
+      </li>
+
+      <li class="header_li_right">
+        <a href="https://www.melonbooks.co.jp/special/service/circle/melon_floma_consign/index.html" class="a_area_style2">
+          <i class="fa-regular fa-circle awesomeicon"></i>サークルの方へ
+        </a>
+      </li>
+    </ul>
+  </p>
+</div>
+</div>
+<div id="g-header" class="g-header_otherpage">
+    <div class="btn-nav-open" style="position: relative;"></div>
+    <h2 class="g-header_logo">        <a href="/">
+            <!-- 画像のパスは必要に応じて変更してください -->
+                            <img src="/user_data/packages/responsive/img/logo_min.png" alt="メロンブックス" height="30" class="_logo_min">
+                <img src="/user_data/packages/responsive/img/logo.png" alt="メロンブックス" height="42" class="_logo_row">
+                    </a>
+    </h2>    <div class="g-header_search-area search-area_background-color_switch">
+        <form action="/search/search.php" method="get">
+            <input type="hidden" name="mode" value="search" />
+            <input type="hidden" name="search_disp" value="" />
+            <input type="hidden" name="category_id" id ="spc" value="0" />
+            <input type="hidden" name="text_type" />
+            <input type="text" name="name" id="name" maxlength="50" placeholder="商品名、キーワード、ジャンル名…" value="" autocomplete="off" class="wordbox">
+            <input type="submit" value="&#xf002;" onClick="return $('#name').val().length>0;">
+            <a href="#" class="cancel-btn">キャンセル</a>
+        </form>
+        <a class="g-header_search-area__button" href="https://www.melonbooks.co.jp/search/search.php?mode=no_products">詳細検索</a>
+    </div>
+    <ul class="g-header_nav_primary">
+        <li class="g-nav-age"><a href="https://www.melonbooks.co.jp/?adult_auth=0">R18 ON</a></li>
+                                    <li class="g-nav-logo g-nav-logo--fromagee">
+                    <a href="/fromagee/">
+                        <img src="/user_data/packages/responsive/img/fromagee_logo_min.png" alt="fromagee">
+                        <span class="ruby">フロマージュ</span>
+                    </a>
+                </li>
+                                        <li class="g-nav-logo g-nav-logo--public_dl">
+                    <a href="/cplus/">
+                        <img src="/user_data/packages/responsive/img/public_dl/logo_min.png" alt="comic plus">
+                        <span class="ruby">コミックプラス</span>
+                    </a>
+                </li>
+                        <li class="g-nav-shop">
+                <a href="/shop/"><i class="fa-solid fa-shop"></i><span class="ruby">店舗情報</span></a>
+            </li>
+                <li class="g-nav-login"><a href="/mypage/">
+                          <i class="fa fa-user"></i>
+                          <span class="ruby">マイページ</span>
+                      </a></li>
+        <li class="g-nav-cart">
+            <span class="cart-label"  style="display:none;"></span>
+                            <a href="https://www.melonbooks.co.jp/clipboard/"><i class="fa fa-shopping-cart"></i><span class="ruby">カート</span></a>
+                    </li>
+    </ul>
+</div>
+<div id="search-keyword">
+    <ul>
+                <li class="current"><a href="#search-keyword-rank">人気検索ワード</a></li>
+        <li><a href="#search-keyword-trend">注目ワード</a></li>
+            </ul>
+    <div class="search-keyword-list">
+                    <div id="search-keyword-rank" class="current">
+                <ul>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%82%B5%E3%82%A4%E3%83%B3%E6%9C%AC">
+                            <li>
+                                <span class="rank rank1">
+                                    1
+                                </span>
+                                <span>サイン本</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%82%BF%E3%83%9A%E3%82%B9%E3%83%88%E3%83%AA%E3%83%BC">
+                            <li>
+                                <span class="rank rank2">
+                                    2
+                                </span>
+                                <span>タペストリー</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%81%8A%E9%9A%A3%E3%81%AE%E5%A4%A9%E4%BD%BF%E6%A7%98">
+                            <li>
+                                <span class="rank rank3">
+                                    3
+                                </span>
+                                <span>お隣の天使様</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%83%96%E3%83%AB%E3%83%BC%E3%82%A2%E3%83%BC%E3%82%AB%E3%82%A4%E3%83%96">
+                            <li>
+                                <span class="rank rank4">
+                                    4
+                                </span>
+                                <span>ブルーアーカイブ</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E9%9B%A8%E6%B3%A2">
+                            <li>
+                                <span class="rank rank5">
+                                    5
+                                </span>
+                                <span>雨波</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%82%A6%E3%83%9E%E5%A8%98">
+                            <li>
+                                <span class="rank rank6">
+                                    6
+                                </span>
+                                <span>ウマ娘</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%83%9B%E3%83%AD%E3%83%A9%E3%82%A4%E3%83%96">
+                            <li>
+                                <span class="rank rank7">
+                                    7
+                                </span>
+                                <span>ホロライブ</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E7%99%BE%E5%90%88">
+                            <li>
+                                <span class="rank rank8">
+                                    8
+                                </span>
+                                <span>百合</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%81%A0%E3%81%AB%E3%81%BE%E3%82%8B">
+                            <li>
+                                <span class="rank rank9">
+                                    9
+                                </span>
+                                <span>だにまる</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%81%BF%E3%81%A1%E3%81%8D%E3%82%93%E3%81%90">
+                            <li>
+                                <span class="rank rank10">
+                                    10
+                                </span>
+                                <span>みちきんぐ</span>
+                            </li>
+                        </a>
+                                    </ul>
+            </div>
+            <div id="search-keyword-trend">
+                <ul>
+                                                                                                <a href="https://www.melonbooks.co.jp/tags/index.php?chara=%E3%82%B3%E3%83%9F%E3%83%86%E3%82%A3%E3%82%A2143">
+                                <li>
+                                    <span class="rank rank1">1</span>
+                                    <span>コミティア143</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&amp;search_disp=&amp;category_id=0&amp;text_type=&amp;name=%E3%81%A0%E3%81%AB%E3%81%BE%E3%82%8B">
+                                <li>
+                                    <span class="rank rank2">2</span>
+                                    <span>だにまる</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/tags/index.php?tag=PRIME%20MARKET%202023%20Winter">
+                                <li>
+                                    <span class="rank rank3">3</span>
+                                    <span>PRIME MARKET</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/special/a/1/fair/novel11th/">
+                                <li>
+                                    <span class="rank rank4">4</span>
+                                    <span>ノベル祭り</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/tags/index.php?tag=COLLECTION%27s%20by%20%E3%81%9F%E3%81%AC%E3%81%BE">
+                                <li>
+                                    <span class="rank rank5">5</span>
+                                    <span>COLLECTION&#039;s by たぬま</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/tags/index.php?tag=PRIME%20MARKET%202023%20Winter%E3%80%90220%E5%86%86%E4%BD%9C%E5%93%81%E3%80%91">
+                                <li>
+                                    <span class="rank rank6">6</span>
+                                    <span>220円作品</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&amp;name=%E7%99%BE%E5%90%88">
+                                <li>
+                                    <span class="rank rank7">7</span>
+                                    <span>百合</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E5%90%8C%E4%BA%BA%E3%83%AA%E3%82%B3%E3%83%AA%E3%82%B3%E7%89%B9%E9%9B%86">
+                                <li>
+                                    <span class="rank rank8">8</span>
+                                    <span>リコリコ</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/tags/index.php?chara=%E3%82%B3%E3%83%9F%E3%83%83%E3%82%AF%E3%83%9E%E3%83%BC%E3%82%B1%E3%83%83%E3%83%88101">
+                                <li>
+                                    <span class="rank rank9">9</span>
+                                    <span>コミックマーケット101</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E5%B0%82%E5%A3%B2%E3%80%90C101%E3%80%91">
+                                <li>
+                                    <span class="rank rank10">10</span>
+                                    <span>C101 専売</span>
+                                </li>
+                            </a>
+                                                            </ul>
+            </div>
+                
+    </div>
+</div>
+<div id="slidemenu" class="">
+    <div class="slidemenu_shade"></div>
+    <div class="btn-nav-close"></div>
+    <div class="slide-nav">
+        <div id="slidemenu_contents">
+            <div id="slidemenu_inner">
+                <div class="registration">
+                <a href="https://www.melonbooks.co.jp/mypage/" class="registration-login">
+                    ログイン
+                </a>
+                <a href="https://www.melonbooks.co.jp/entry/" class="registration-entry">
+                    ユーザー登録
+                </a>
+            </div>
+                <div class="slide-nav-list">
+                    <ul>
+                        <!--RSP_HEADER_SLIDEMENU_MY_PAGE-->
+                        <li>
+                            <a href="/clipboard/">カートを見る</a>
+                        </li>
+                        <li>
+                            <a href="/dl_clipboard/">電子カートを見る</a>
+                        </li>
+                        <li>
+                            <a href="/news/">お知らせ</a>
+                        </li>
+                        <li>
+                            <span>カテゴリから探す</span>
+                            <ul class="slide-nav-inner">
+                                <li class="cplus_not"><a href="/book/list.php?category_id=1">同人誌</a></li>
+                                <li class="cplus_not"><a href="/soft/list.php?category_id=2">同人ソフト&音楽</a></li>
+                                <li class="cplus_not"><a href="/goods/list.php?category_id=3">同人アイテム</a></li>
+                                <li class="cplus_not"><a href="/comic/list.php?category_id=4">コミック</a></li>
+                                <li class="cplus_not"><a href="/products/list.php?category_id=145">サブカル書籍</a></li>
+                                <li class="cplus_not"><a href="/game/list.php?category_id=5">ゲーム</a></li>
+                                <li class="cplus_not"><a href="/audio/list.php?category_id=6">音楽</a></li>
+                                <li class="cplus_not"><a href="/video/list.php?category_id=17">映像</a></li>
+                                <li class="cplus_not"><a href="/business/list.php?category_id=7">グッズ</a></li>
+                                <li class="melon_only"><a href="/company/list.php?category_id=8">うりぼうさっか店</a></li>
+                                <li class="melon_only"><a href="/products/list.php?category_id=99">アダルト</a></li>
+                                <li class="cplus_not"><a href="/digital/">同人電子・DL</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=189">コミック(電子)</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=190">ノベル(電子)</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=191">雑誌(電子)</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=86">BLコミック</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=192">BLノベル</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=87">TLコミック</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=193">TLノベル</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span>作品を探す</span>
+                            <ul class="slide-nav-inner">
+                                <li><a href="/products/circle.php">サークルで探す</a></li>
+                                <li><a href="/products/genre.php">ジャンルで探す</a></li>
+                                <li><a href="/products/character.php">キャラで探す</a></li>
+                                <li><a href="/ebook/list.php?category_id=77">電子書籍で探す<!-- <i style="color:#f77;font-style:italic; display: inline;">(NEW)</i>--></a></li>
+                                <li><a href="/dl/list.php?category_id=169">DL音楽・ソフトで探す</a></li>
+                                <li class="fromagee_only"><a href="/fromagee/search/search_coupling.php">カップリングで探す</a></li>
+                            </ul>
+                        </li>
+                        <li><span>一覧・ランキングから探す</span>
+                            <ul class="slide-nav-inner">
+                                <li><a href="/calender/">発売カレンダー</a></li>
+                                <li><a href="/ranking/">ランキング</a></li>
+                                <li><a href="/new/new.php">新着作品</a></li>
+                                <li><a href="/monopoly/monopoly.php">専売作品</a></li>
+                                <li><a href="/privilege/privilege.php">特典付き</a></li>
+                                <li><a href="/reserve/reserve.php">予約開始</a></li>
+                                <li><a href="/new/arrival.php">新入荷</a></li>
+                                <li><a href="/restock/restock.php">再入荷</a></li>
+                            </ul>
+                        </li>
+                        <li><a href="/digital/">電子書籍・DL</a></li>
+                        <li><a href="/tags/index.php?tag=%E3%82%B5%E3%83%BC%E3%82%AF%E3%83%AB%E3%82%B7%E3%83%A7%E3%83%83%E3%83%97%E3%80%80%E3%82%B0%E3%83%83%E3%82%BA%E5%8F%97%E6%B3%A8%E8%B2%A9%E5%A3%B2" title="サークルショップ">サークルショップ</a></li>
+                        <li><a href="/special/a/6/pb/hp/gallery/index.html" title="バーチャルギャラリー">バーチャルギャラリー</a></li>
+                        <li><a href="/help/index.php" title="よくある質問" target="_blank">よくある質問</a></li>
+                        <li><a href="/special/service/start/" title="はじめての方へ" target="_blank">はじめての方へ</a></li>
+                        <li><span>サークルの方へ</span>
+                            <ul class="slide-nav-inner">
+                                <li><a href="https://circle.melonbooks.co.jp/" title="サークルポータル" target="_blank">サークルポータル</a></li>
+                                <li><a href="/special/service/circle/melon_floma_consign/index.html">サークルの方へ</a></li>
+                                <li><a href="https://circle.melonbooks.co.jp/news/">お知らせ</a></li>
+                                <li><a href="/special/service/circle/shop/">同人委託依頼</a></li>
+                                <li><a href="/guide/privacy.php">個人情報保護方針</a></li>
+                                <li><a href="/help/circle.php">Q&Aコーナー</a></li>
+                            </ul>
+                        </li>
+                        <li><span>店舗情報</span>
+                            <ul class="slide-nav-inner">
+                                <li><a href="/shop/" title="メロンブックス店舗情報">メロンブックス店舗情報</a></li>
+                                <li><a href="/fromagee/shop/" title="フロマージュ店舗情報" target="_blank">フロマージュ店舗情報</a></li>
+                                                                <li><a href="/shop/event.php?type=fair">フェア情報</a></li>
+                                <li><a href="/shop/event.php?type=privilege">特典情報</a></li>
+                                <li><a href="/help/shop.php">店舗FAQ</a></li>
+                                                            </ul>
+                        </li>
+                        <li><span>インフォメーション</span>
+                            <ul class="slide-nav-inner">
+                                <!-- <li><a href="/mailmagazine/index.php">メルマガについて</a></li> -->
+                                <li><a href="/feature/detail.php?feature_id=710">ポイントシステムについて</a></li>
+                                <li><a href="/special/b/0/uribou/201909_melonbooks_mascot/">マスコット紹介</a></li>
+                                <li><a href="/special/service/twitter/" title="SNS一覧">SNS一覧</a></li>
+                                <li><a href="/special/b/0/special/melonbooks_flomagee_staff/recruit.html">求人案内</a></li>
+                            </ul>
+                        </li>
+                        <li><a href="/special/b/0/service/overseas_en/">For Overseas</a></li>
+                        <li class="melon_not"><a href="/" title="Melonbooks TOP" style="color:#ffff66">Melonbooks TOP</a></li>
+                        <li class="fromagee_not"><a href="/fromagee/" title="Fromageebooks TOP" style="color:#ffff66">Fromageebooks TOP</a></li>
+                        <li class="cplus_not"><a href="/cplus/" title="Comicplus TOP" style="color:#ffff66">Comicplus TOP<i style="color:#f77;font-style:italic; display: inline;">(NEW)</i></a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div><!-- ▼サイトジャック -->
+<div id="container" class="container_otherpage">
+    <div class="filter">&nbsp;</div>
+    <div class="utBReFvXjp-wrap utBReFvXjp-wrap_otherpage">
+    <div class="utBReFvXjp-column-main">
+        <div id="contents">
+                                                            <!-- ▼パンくず -->
+                                                            <p class="breadcrumb">
+    <a href="/" itemprop="url"><span itemprop="title">HOME</span></a>
+    <i class="fa fa-angle-right" aria-hidden="true"></i>
+    <meta itemprop="position" content="1" />  
+                                                                                <a href="https://www.melonbooks.co.jp/book/list.php?category_id=1" itemprop="url">
+                                        <span itemprop="title">
+                同人誌            </span>
+                            </a>
+                                        <i class="fa fa-angle-right" aria-hidden="true"></i>
+                        <meta itemprop="position" content="2" />
+                                                                    <a href="https://www.melonbooks.co.jp/book/list.php?category_id=71" itemprop="url">
+                                        <span itemprop="title">
+                成年同人誌            </span>
+                            </a>
+                                        <i class="fa fa-angle-right" aria-hidden="true"></i>
+                        <meta itemprop="position" content="3" />
+                                            <span itemprop="title">
+                血姫夜交　真祖の姫は発情しているっ!            </span>
+                                    <meta itemprop="position" content="4" />
+            </p>                                        <!-- ▲パンくず -->
+                                                                <script type="text/javascript">
+        $(window).load(function () {
+            var element = $('figure a img');
+            element.each(function () {
+                var img = new Image();
+                img.src = $(this).attr('src');
+                var width = img.width;
+                var height = img.height;
+                $(this).closest('a').attr('data-size', width + 'x' + height);
+            });
+        });
+        $(window).load(function () {
+            var initPhotoSwipeFromDOM = function (gallerySelector) {
+                // parse slide data (url, title, size ...) from DOM elements 
+                // (children of gallerySelector)
+                var parseThumbnailElements = function (el) {
+                    var thumbElements = el.childNodes,
+                        numNodes = thumbElements.length,
+                        items = [],
+                        figureEl,
+                        linkEl,
+                        size,
+                        item;
+                    for (var i = 0; i < numNodes; i++) {
+                        figureEl = thumbElements[i]; // <figure> element
+
+                        // include only element nodes 
+                        if (figureEl.nodeType !== 1) {
+                            continue;
+                        }
+
+                        linkEl = figureEl.children[0]; // <a> element
+
+                        size = linkEl.getAttribute('data-size').split('x');
+
+                        // create slide object
+                        item = {
+                            src: linkEl.getAttribute('href'),
+                            w: parseInt(size[0], 10),
+                            h: parseInt(size[1], 10)
+                        };
+
+
+                        if (figureEl.children.length > 1) {
+                            // <figcaption> content
+                            item.title = figureEl.children[1].innerHTML;
+                        }
+
+                        if (linkEl.children.length > 0) {
+                            // <img> thumbnail element, retrieving thumbnail url
+                            item.msrc = linkEl.children[0].getAttribute('src');
+                        }
+
+                        item.el = figureEl; // save link to element for getThumbBoundsFn
+                        items.push(item);
+                    }
+
+                    return items;
+                };
+
+                // find nearest parent element
+                var closest = function closest(el, fn) {
+                    return el && (fn(el) ? el : closest(el.parentNode, fn));
+                };
+
+                // triggers when user clicks on thumbnail
+                var onThumbnailsClick = function (e) {
+                    e = e || window.event;
+                    e.preventDefault ? e.preventDefault() : e.returnValue = false;
+
+                    var eTarget = e.target || e.srcElement;
+
+                    // find root element of slide
+                    var clickedListItem = closest(eTarget, function (el) {
+                        return (el.tagName && el.tagName.toUpperCase() === 'FIGURE');
+                    });
+
+                    if (!clickedListItem) {
+                        return;
+                    }
+
+                    // find index of clicked item by looping through all child nodes
+                    // alternatively, you may define index via data- attribute
+                    var clickedGallery = clickedListItem.parentNode,
+                        childNodes = clickedListItem.parentNode.childNodes,
+                        numChildNodes = childNodes.length,
+                        nodeIndex = 0,
+                        index;
+
+                    for (var i = 0; i < numChildNodes; i++) {
+                        if (childNodes[i].nodeType !== 1) {
+                            continue;
+                        }
+
+                        if (childNodes[i] === clickedListItem) {
+                            index = nodeIndex;
+                            break;
+                        }
+                        nodeIndex++;
+                    }
+
+
+                    if (index >= 0) {
+                        // open PhotoSwipe if valid index found
+                        openPhotoSwipe(index, clickedGallery);
+                    }
+                    return false;
+                };
+
+                // parse picture index and gallery index from URL (#&pid=1&gid=2)
+                var photoswipeParseHash = function () {
+                    var hash = window.location.hash.substring(1),
+                        params = {};
+
+                    if (hash.length < 5) {
+                        return params;
+                    }
+
+                    var vars = hash.split('&');
+                    for (var i = 0; i < vars.length; i++) {
+                        if (!vars[i]) {
+                            continue;
+                        }
+                        var pair = vars[i].split('=');
+                        if (pair.length < 2) {
+                            continue;
+                        }
+                        params[pair[0]] = pair[1];
+                    }
+
+                    if (params.gid) {
+                        params.gid = parseInt(params.gid, 10);
+                    }
+
+                    if (!params.hasOwnProperty('pid')) {
+                        return params;
+                    }
+                    params.pid = parseInt(params.pid, 10);
+                    return params;
+                };
+
+                var openPhotoSwipe = function (index, galleryElement, disableAnimation) {
+                    var pswpElement = document.querySelectorAll('.pswp')[0],
+                        gallery,
+                        options,
+                        items;
+                    items = parseThumbnailElements(galleryElement);
+
+                    // define options (if needed)
+                    options = {
+                        index: index,
+                        // define gallery index (for URL)
+                        galleryUID: galleryElement.getAttribute('data-pswp-uid'),
+                        getThumbBoundsFn: function (index) {
+                            // See Options -> getThumbBoundsFn section of documentation for more info
+                            var thumbnail = items[index].el.getElementsByTagName('img')[0], // find thumbnail
+                                pageYScroll = window.pageYOffset || document.documentElement.scrollTop,
+                                rect = thumbnail.getBoundingClientRect();
+
+                            return {x: rect.left, y: rect.top + pageYScroll, w: rect.width};
+                        },
+                        shareEl: false
+
+                    };
+
+                    if (disableAnimation) {
+                        options.showAnimationDuration = 0;
+                    }
+
+                    // Pass data to PhotoSwipe and initialize it
+                    gallery = new PhotoSwipe(pswpElement, PhotoSwipeUI_Default, items, options);
+                    gallery.init();
+                };
+
+                // loop through all gallery elements and bind events
+                var galleryElements = document.querySelectorAll(gallerySelector);
+
+                for (var i = 0, l = galleryElements.length; i < l; i++) {
+                    galleryElements[i].setAttribute('data-pswp-uid', i + 1);
+                    galleryElements[i].onclick = onThumbnailsClick;
+                }
+
+                // Parse URL and open gallery if it contains #&pid=3&gid=1
+                var hashData = photoswipeParseHash();
+                if (hashData.pid > 0 && hashData.gid > 0) {
+                    openPhotoSwipe(hashData.pid - 1, galleryElements[hashData.gid - 1], true);
+                }
+            };
+            // PhotoSwipeを起動する
+            initPhotoSwipeFromDOM('.my-gallery');
+        });
+        var product_id;
+
+        function login() {
+            $('input[name=mode]').val('');
+            var form = $('<form/>', {'action': '/mypage/', 'method': 'get'});
+            var returnUrl = $('<input>', {'type': 'hidden', 'name': 'ru', 'value': 'https://www.melonbooks.co.jp/detail/detail.php?product_id=' + product_id});
+
+            form.append(returnUrl);
+            form.appendTo(document.body);
+            form.submit();
+            return false;
+        }
+        // 上部にある大きいお気に入りボタンの場合はこちら
+        function displayResult(data,target,parent){
+            var dataArray = JSON.parse(data);
+            if(dataArray.status == true){
+                    target.find('i').removeClass('add_wish');
+                    target.find('i').addClass('favorited');
+                    target.find('i').removeClass('fa-regular');
+                    target.find('i').addClass('fa-solid');
+                    
+                    if(target.hasClass('add_wish')){
+                        target.addClass('__active');
+                        target.find('span').html('ほしいもの<br>リストに追加済');
+                    } else if(target.hasClass('favorite_circle')){
+                        target.addClass('__active');
+                        target.find('span').html('お気に入り<br>サークルに追加済');
+                    } else if(target.hasClass('favorite_label')){
+                        target.addClass('__active');
+                        target.find('span').html('お気に入り<br>レーベルに追加済');
+                    }
+            }
+            if (parent.find('div.message_box').length) {
+
+            } else {
+                if(dataArray.message.indexOf('ログイン') > -1){
+                    login();
+                }
+            }
+        }
+        // 下部にある商品詳細内の小さいお気に入りボタンの場合はこちら
+        function displayResultShort(data,target,parent){
+            var dataArray = JSON.parse(data);
+            if(dataArray.status == true){
+                    target.removeClass('favorite');
+                    target.addClass('favorited');
+                    target.removeClass('fa-regular');
+                    target.addClass('fa-solid');
+            }
+            if (parent.find('div.message_box').length) {
+
+            } else {
+                if(dataArray.message.indexOf('ログイン') > -1){
+                    login();
+                }
+            }
+        }
+        $(function(){
+            var doubleClick=false;
+            var param = location.search;
+            var m = location.search.match(/product_id=([0-9]+)/);
+            product_id = m[1];
+            $('.add_wish').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.product_id = product_id;
+                data.mode = 'regist_wish_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResult(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+            $('.favorite_author').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.favorite_author_name = $(this).data('authorname');
+                data.product_id = product_id;
+                data.mode = 'regist_author_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResultShort(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+            $('.favorite_circle').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.favorite_circle_id = $(this).data('circleid');
+                data.product_id = product_id;
+                data.mode = 'regist_circle_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResult(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+            $('.favorite_circle_short').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.favorite_circle_id = $(this).data('circleid');
+                data.product_id = product_id;
+                data.mode = 'regist_circle_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResultShort(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+            $('.favorite_coupling').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.favorite_seme = $(this).data('seme');
+                data.favorite_uke = $(this).data('uke');
+                data.favorite_genre_id = $(this).data('genreid');
+                data.product_id = product_id;
+                data.mode = 'regist_coupling_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResultShort(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+            $('.favorite_label').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.favorite_label_id = $(this).data('labelid');
+                data.product_id = product_id;
+                data.mode = 'regist_label_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResult(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+            $('.favorite_label_short').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.favorite_label_id = $(this).data('labelid');
+                data.product_id = product_id;
+                data.mode = 'regist_label_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResultShort(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+        });
+    </script>
+        <a href="http://www.tenso.com/en/static/lp_shop_index?bn_code=melonbooks" target="_blank" style="line-height:0;"><img src="//www2.tenso.com/ext/banner.php?f=ipb_melonbooks_1400x200.png" alt="海外発送/国際配送サービスの転送コム" style="max-width: 100%; display: block;margin-bottom: 3px;"></a>
+    <a href="https://promotion.leyifan.com/adv/link/melonbooks" target="_blank" style="line-height:0;"><img src="https://promotion.leyifan.com/adv/banner/melonbooks" style="max-width: 100%; display: block;margin-bottom: 3px;"></a>
+    <script defer src="https://overseas-ship.wre.jp/melonbooks"></script>
+    <div class="whiterabbit-banner"></div>
+        <div class="item-page">
+        <div class="item-header">
+                            <span class="item-notes notes-analog">成年同人誌</span><span class="item-notes notes-red">同人</span><span class="item-notes notes-red">R18</span><span class="item-notes notes-red">専売</span>
+            <h1 class="page-header">血姫夜交　真祖の姫は発情しているっ!</h1>
+                            <p class="author-name">
+                    <a href="https://www.melonbooks.co.jp/circle/index.php?circle_id=22405">毛玉牛乳</a>
+                </p>
+                        
+        </div>
+        <div class="item-body-wrap">
+            <div class="item-img">
+                                    <p class="label-monopoly"></p>
+                                <div class="slider my-gallery">
+                                                                    <figure>
+                                                            <a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380763.jpg">
+                                    <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380763.jpg" alt="血姫夜交　真祖の姫は発情しているっ!" height="250"/>
+                                </a>
+                                                    </figure>
+                                                                                    <figure>
+                            <a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380763a.jpg&sp=1">
+                                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380763a.jpg&sp=1" alt="血姫夜交　真祖の姫は発情しているっ!" height="250"/>
+                            </a>
+                        </figure>
+                                            <figure>
+                            <a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380763b.jpg&sp=1">
+                                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380763b.jpg&sp=1" alt="血姫夜交　真祖の姫は発情しているっ!" height="250"/>
+                            </a>
+                        </figure>
+                                            <figure>
+                            <a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380763c.jpg&sp=1">
+                                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380763c.jpg&sp=1" alt="血姫夜交　真祖の姫は発情しているっ!" height="250"/>
+                            </a>
+                        </figure>
+                                            <figure>
+                            <a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380763d.jpg&sp=1">
+                                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380763d.jpg&sp=1" alt="血姫夜交　真祖の姫は発情しているっ!" height="250"/>
+                            </a>
+                        </figure>
+                                    </div>
+                <div class="item-img-nav">
+                </div>
+            </div>
+
+            <div class="item-metas-wrap">
+
+                <div class="item-meta3">
+                    <p class="price">
+                        価格（税込み）
+                                                                                    <span class="yen __discount">
+                                    &yen;1,100
+                                </span>
+                                                                        </p>
+                                            <p class="point">3%（30ポイント）還元</p>
+                                        <div class="state mt12">
+                        販売状況
+                        <span class="state-instock">在庫あり</span>
+                    </div>
+                                            <p class="mt6">
+                            ※こちらは通販の在庫状態になります。
+                        </p>
+                        <p id="zaiko_open" data-lity="data-lity" href="#zaiko_wrapper">店舗在庫はこちらをご確認お願いいたします</p>
+                        
+                                                        </div>
+                
+                <form data-page="detail" name="form1" id="form_product" method="POST" action="?">
+                                        <div class="item-cart" id="cart_anchor">
+                        <input type="hidden" name="transactionid" value="7549a3c9d31f9e62f4d32a92ec8728439b4a5737"/>
+                        <input type="hidden" id="mode" name="mode" value="cart_ajax"/>
+                        <input type="hidden" name="product_id" value="1789342"/>
+                        <input type="hidden" name="product_class_id" value="" id="product_class_id"/>
+                        <input type="hidden" name="favorite_product_id" value=""/>
+                        <input type="hidden" name="favorite_author_name" value=""/>
+                                                                                    <div class="select">
+                                    <div>個数
+                                        <select name="quantity" id="prouct_quantity">
+<option label="1" value="1">1</option>
+<option label="2" value="2">2</option>
+<option label="3" value="3">3</option>
+<option label="4" value="4">4</option>
+<option label="5" value="5">5</option>
+<option label="6" value="6">6</option>
+<option label="7" value="7">7</option>
+<option label="8" value="8">8</option>
+<option label="9" value="9">9</option>
+<option label="10" value="10">10</option>
+</select>
+
+                                    </div>
+                                </div>
+                                <div class="btn-cart">
+                                    <i class="fa fa-shopping-cart fa-2x" aria-hidden="true"></i>カートに入れる
+                                    <input class="submit cart tag_cart_main2" type="submit" value="&#xf07a; カートに入れる"/>
+                                </div>
+                                                                                                    <!--/.item-cart-->
+                    </div>
+                                                                            </form>
+                                <div class="view-environment">
+                                        <div class="headline_noline">配送方法</div>
+                    <div class="row_product_set">
+                        宅配便
+                                                                                    <a href="https://www.melonbooks.co.jp/special/service/mail-bin/" title="メール便" target="_blank">
+                                    / メール便OK！ (<i class="fa fa-archive fa-fw" aria-hidden="true"></i>容量 : 36%)
+                                </a>
+                                                                                                                                        <a href="https://www.melonbooks.co.jp/special/service/c_uketori/" title="コンビニ受取" target="_blank">
+                                    / コンビニ受取OK！
+                                </a>
+                                                                                                        / ＠店舗受取り
+                                                                                                    / さくっと注文
+                                                                    </div>
+                    <div class="headline_noline">お支払方法</div>
+                    <div class="row_product_set">
+                                                    クレジット / コンビニ前払い / コンビニ後払い / 代金引換 / atone 翌月後払い(コンビニ)
+                                            </div>
+                    <div class="row_sale_date">
+                                                                        発売日：2022年12月31日
+                                                                                                                    </div>
+                </div>
+                                                <div class="item-favorite mt24">
+                                            <a href="#" class="btn-favorite-circle favorite_circle"  data-circleid="22405">
+                            <i class="fa-regular fa-circle favorite" aria-hidden="true"></i>
+                            <span>お気に入り<br>サークルに追加</span>
+                        </a>
+                    
+                    <a href="#" class="btn-favorite-item add_wish"> <i class="fa-regular fa-heart favorite"></i><span>ほしいもの<br>リストに追加</span></a>
+                </div>
+
+                <div class="item-share mt24">
+                    <a class="btn-share-twitter" alt="Tweet" href="http://twitter.com/share?text=%E8%A1%80%E5%A7%AB%E5%A4%9C%E4%BA%A4%E3%80%80%E7%9C%9F%E7%A5%96%E3%81%AE%E5%A7%AB%E3%81%AF%E7%99%BA%E6%83%85%E3%81%97%E3%81%A6%E3%81%84%E3%82%8B%E3%81%A3%21%EF%BC%88%E6%AF%9B%E7%8E%89%E7%89%9B%E4%B9%B3%EF%BC%89%E3%81%AE%E9%80%9A%E8%B2%A9%E3%83%BB%E8%B3%BC%E5%85%A5%E3%81%AF%E3%83%A1%E3%83%AD%E3%83%B3%E3%83%96%E3%83%83%E3%82%AF%E3%82%B9%20%7C%20&amp;url=https%3A%2F%2Fwww.melonbooks.co.jp%2Fdetail%2Fdetail.php%3Fproduct_id%3D1789342" target="_blank">
+                        <i class="fa-brands fa-twitter"></i>
+                    </a>
+                    <a class="btn-share-line" alt="LINEで送る" href="http://line.me/R/msg/text/?%E8%A1%80%E5%A7%AB%E5%A4%9C%E4%BA%A4%E3%80%80%E7%9C%9F%E7%A5%96%E3%81%AE%E5%A7%AB%E3%81%AF%E7%99%BA%E6%83%85%E3%81%97%E3%81%A6%E3%81%84%E3%82%8B%E3%81%A3%21%EF%BC%88%E6%AF%9B%E7%8E%89%E7%89%9B%E4%B9%B3%EF%BC%89%E3%81%AE%E9%80%9A%E8%B2%A9%E3%83%BB%E8%B3%BC%E5%85%A5%E3%81%AF%E3%83%A1%E3%83%AD%E3%83%B3%E3%83%96%E3%83%83%E3%82%AF%E3%82%B9%0D%0Ahttps%3A%2F%2Fwww.melonbooks.co.jp%2Fdetail%2Fdetail.php%3Fproduct_id%3D1789342" target="_blank">
+                        <i class="fa-brands fa-line"></i>
+                    </a>
+                    <a class="btn-share-facebook" alt="Facebookで送る" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.melonbooks.co.jp%2Fdetail%2Fdetail.php%3Fproduct_id%3D1789342" target="_blank">
+                        <i class="fa-brands fa-facebook-f"></i>
+                    </a>
+                </div>
+                <div class="item-detail2">
+                    <p class="mt6">
+                                                                            <a href="https://www.melonbooks.co.jp/tags/index.php?genre=%E3%82%AA%E3%83%AA%E3%82%B8%E3%83%8A%E3%83%AB">#オリジナル</a> 
+                                                                            <a href="https://www.melonbooks.co.jp/tags/index.php?chara=%E6%BC%AB%E7%94%BB" title="">#漫画</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?chara=%E3%82%B3%E3%83%9F%E3%83%83%E3%82%AF%E3%83%9E%E3%83%BC%E3%82%B1%E3%83%83%E3%83%88101" title="">#コミックマーケット101</a> 
+                                                                            <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E3%82%B3%E3%83%9F%E3%83%83%E3%82%AF%E3%83%9E%E3%83%BC%E3%82%B1%E3%83%83%E3%83%88101%E8%B6%85%E6%96%B0%E5%88%8A%E7%89%B9%E9%9B%86" title="">#コミックマーケット101超新刊特集</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E3%82%B3%E3%83%9F%E3%83%83%E3%82%AF%E3%83%9E%E3%83%BC%E3%82%B1%E3%83%83%E3%83%88101%E8%B6%85%E6%96%B0%E5%88%8A%E7%89%B9%E9%9B%86%E3%80%902%E6%97%A5%E7%9B%AE%E4%BD%9C%E5%93%81%E4%B8%80%E8%A6%A7%E3%80%91" title="">#コミックマーケット101超新刊特集【2日目作品一覧】</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E5%90%B8%E8%A1%80%E9%AC%BC" title="">#吸血鬼</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E5%B0%82%E5%A3%B2" title="">#専売</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E5%B0%82%E5%A3%B2%E3%80%90%E6%88%90%E5%B9%B4%E5%90%8C%E4%BA%BA%E8%AA%8C%E3%80%91" title="">#専売【成年同人誌】</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E5%B0%82%E5%A3%B2%E3%80%90%E3%82%AA%E3%83%AA%E3%82%B8%E3%83%8A%E3%83%AB%E5%90%8C%E4%BA%BA%E8%AA%8C%E3%80%91" title="">#専売【オリジナル同人誌】</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E6%88%90%E5%B9%B4%E3%82%AA%E3%83%AA%E3%82%B8%E3%83%8A%E3%83%AB" title="">#成年オリジナル</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=2022%E5%B9%B412%E6%9C%88%E6%96%B0%E5%88%8A%E5%90%8C%E4%BA%BA%E4%BD%9C%E5%93%81%E7%89%B9%E9%9B%86" title="">#2022年12月新刊同人作品特集</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E3%82%AA%E3%83%AA%E3%82%B8%E3%83%8A%E3%83%AB%E5%90%8C%E4%BA%BA%E3%83%95%E3%82%A7%E3%82%B9%E3%83%86%E3%82%A3%E3%83%90%E3%83%ABwinterfrm_spcsurprise2022" title="">#オリジナル同人フェスティバルwinter surprise2022</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E5%B0%82%E5%A3%B2%E3%80%90C101%E3%80%91" title="">#専売【C101】</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=2022%E5%B9%B4%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E6%96%B0%E5%88%8A%E7%89%B9%E9%9B%86" title="">#2022年イベント新刊特集</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=2023%E5%B9%B4%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E6%96%B0%E5%88%8A%E7%89%B9%E9%9B%86" title="">#2023年イベント新刊特集</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E3%82%B3%E3%83%9F%E3%83%83%E3%82%AF%E3%83%9E%E3%83%BC%E3%82%B1%E3%83%83%E3%83%88101%E6%96%B0%E5%88%8A%E3%83%A9%E3%83%B3%E3%82%AD%E3%83%B3%E3%82%B0" title="">#コミックマーケット101新刊ランキング</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E3%82%AA%E3%83%AA%E3%82%B8%E3%83%8A%E3%83%AB%E5%90%8C%E4%BA%BA%E3%83%95%E3%82%A7%E3%82%B9%E3%83%86%E3%82%A3%E3%83%90%E3%83%ABfrm_spcFastfrm_spcSpringfrm_spc2023" title="">#オリジナル同人フェスティバル Fast Spring 2023</a> 
+                                            </p>
+                </div>
+            </div>
+        </div>
+                            <div id="movie" class="item-detail __light mt24" style="background-color: white;">
+                <h3 class="page-headline mb12">サンプル</h3>
+                <div style="text-align: center;">
+                    <!--//血姫夜交　真祖の姫は発情しているっ!//--><div class="modal_wrap" style="display:inline-block;"><input id="trigger" type="checkbox"><div class="modal_overlay"><label for="trigger" class="modal_trigger"></label><div class="modal_content"><div class="close_button"><label for="trigger" class="close_icon"><span></span></label></div><img src="https://melonbooks.akamaized.net/special/a/2/POP/images/212001380763t.jpg"></div></div></div><div class="sample_box" style="display:inline-block; margin:10px 15px; vertical-align:top; width:200px;"><p class="title" style="font-size:14px; font-weight: bold; text-align: center;">●手書きPOP</p><label for="trigger" class="open_button"><img src="https://melonbooks.akamaized.net/special/a/2/POP/images/212001380763t.jpg" width="200px;"></label><span class="update" style="display:block; text-align: right">(更新日:2023/01/08)</span></div><style>.modal_wrap input{display: none;}.modal_overlay{display: flex;justify-content: center;overflow: auto;position: fixed;top: 0;left: 0;z-index: 9999;width: 100%;height: 100%;background: rgba(0,0,0,0.7);opacity: 0;transition: opacity 0.5s, transform 0s 0.5s;transform: scale(0);}.modal_trigger{position: absolute;width: 100%;height: 100%;}.modal_content{position: relative;align-self: center;height: 80%;max-height: 800px;text-align: center;padding: 20px 20px 10px;margin: 0 10px;box-sizing: border-box;background: #fff;transition: 0.5s;border: 4px solid #2fa769;border-radius: 10px;box-shadow: 2px 3px 10px rgba(0, 0, 0, 0.2);}.modal_content img{width: 100%;height: 100%;object-fit: scale-down;}.close_button{position: absolute;top: 0;right: 0;-webkit-transform: translate(50%,-50%);-ms-transform: translate(50%,-50%);transform: translate(50%,-50%);}.close_icon{display: inline-block;position: relative;cursor: pointer;width: 24px;height: 24px;background-color: #2fa769;}.close_icon span::before,.close_icon span::after{display: block;content: "";position: absolute;top: 50%;left: 50%;width: 60%;height: 6%;margin: -3% 0 0 -30%;background: #fff;}.close_icon span::before {transform: rotate(45deg);}.close_icon span::after {transform: rotate(-45deg);}.modal_wrap input:checked ~ .modal_overlay{opacity: 1;transform: scale(1);transition: opacity 0.5s;}</style>
+
+
+
+<!--//血姫夜交　真祖の姫は発情しているっ!//--><div class="modal_wrap" style="display:inline-block;"><input id="trigger2" type="checkbox"><div class="modal_overlay"><label for="trigger2" class="modal_trigger"></label><div class="modal_content"><div class="close_button"><label for="trigger2" class="close_icon"><span></span></label></div><img src="https://melonbooks.akamaized.net/special/a/2/POP/images/212001380763.jpg"></div></div></div><div class="sample_box" style="display:inline-block; margin:10px 15px; vertical-align:top; width:200px;"><p class="title" style="font-size:14px; font-weight: bold; text-align: center;">●店舗ポスター</p><label for="trigger2" class="open_button"><img src="https://melonbooks.akamaized.net/special/a/2/POP/images/212001380763.jpg" width="200px;"></label><span class="update" style="display:block; text-align: right">(更新日:2023/02/16)</span></div><style>.modal_wrap input{display: none;}.modal_overlay{display: flex;justify-content: center;overflow: auto;position: fixed;top: 0;left: 0;z-index: 9999;width: 100%;height: 100%;background: rgba(0,0,0,0.7);opacity: 0;transition: opacity 0.5s, transform 0s 0.5s;transform: scale(0);}.modal_trigger{position: absolute;width: 100%;height: 100%;}.modal_content{position: relative;align-self: center;height: 80%;max-height: 800px;text-align: center;padding: 20px 20px 10px;margin: 0 10px;box-sizing: border-box;background: #fff;transition: 0.5s;border: 4px solid #2fa769;border-radius: 10px;box-shadow: 2px 3px 10px rgba(0, 0, 0, 0.2);}.modal_content img{width: 100%;height: 100%;object-fit: scale-down;}.close_button{position: absolute;top: 0;right: 0;-webkit-transform: translate(50%,-50%);-ms-transform: translate(50%,-50%);transform: translate(50%,-50%);}.close_icon{display: inline-block;position: relative;cursor: pointer;width: 24px;height: 24px;background-color: #2fa769;}.close_icon span::before,.close_icon span::after{display: block;content: "";position: absolute;top: 50%;left: 50%;width: 60%;height: 6%;margin: -3% 0 0 -30%;background: #fff;}.close_icon span::before {transform: rotate(45deg);}.close_icon span::after {transform: rotate(-45deg);}.modal_wrap input:checked ~ .modal_overlay{opacity: 1;transform: scale(1);transition: opacity 0.5s;}</style>
+                </div>
+            </div>
+                                <div class="item-detail __light mt24" style="background-color: white;">
+                                                <h3 class="page-headline mb12">サークル(先生)からのコメント/作品詳細</h3>
+                                        <div>
+                <p>
+                    毛玉牛乳オリジナル同人誌新シリーズ「血姫夜交」です。<br />
+森の塔に封じられた真祖(吸血鬼)の姫と出会う少年のおはなし。<br />
+吸血鬼のプラズマはプライドが高くいたずら好き。<br />
+チョロインの人外少女といちゃらぶするシリーズです。
+                </p>
+            </div>
+        </div>
+                        <div class="item-detail __light mt24" style="background-color: white;">
+                                                <h3 class="page-headline mb12">スタッフのオススメポイント</h3>
+                                        <div>
+                <p>
+                    玉之けだま先生の描く、オリジナルシリーズ最新作のヒロインは妖艶な雰囲気の悪戯好きな真祖の吸血鬼です☆<br />
+森の塔で出会った吸血鬼の少女が少年のチ〇コをひんやりとした口でぱくりと食べる様子がエロい♪<br />
+口に精液を出された後に、とろとろになったマ〇コを差し出し挿入してもらうのを待つ彼女に興奮します☆<br />
+膣内にチンコを迎え入れて歓喜しながら全身で感じている様子が最高にエロい♪<br />
+イタズラ好き真祖の少女がチ〇コに簡単に落とされるのがエロい、極上の一冊を是非お手元でお楽しみ下さい♪
+                </p>
+            </div>
+        </div>
+                                <div class="item-detail __light">
+            <div>
+                <div class="table-wrapper">
+                    <table>
+                        <tr>
+                            <th>サークル名</th>
+                                                            <td class="product_info">
+                                    <a href="https://www.melonbooks.co.jp/circle/index.php?circle_id=22405">毛玉牛乳&nbsp;(作品数:31)</a>
+                                                            <a href="#" class="favorite fa-regular fa-heart favorite_circle_short" aria-hidden="true" data-circleid="22405"></a>
+                                                                    </td>
+                                                    </tr>
+                                                                            <tr>
+                                <th>作家名</th>
+                                <td class="product_info">
+                                                               <a href="https://www.melonbooks.co.jp/search/search.php?name=%E7%8E%89%E4%B9%8B%E3%81%91%E3%81%A0%E3%81%BE&text_type=author">玉之けだま</a>                           <a href="#" class="favorite fa-regular fa-heart favorite_author" aria-hidden="true" data-authorName="玉之けだま"></a>
+                                </td>
+                            </tr>
+                                                                            <tr>
+                                <th>ジャンル</th>
+                                <td>
+                                                                            <a href="https://www.melonbooks.co.jp/tags/index.php?genre=%E3%82%AA%E3%83%AA%E3%82%B8%E3%83%8A%E3%83%AB">オリジナル</a>
+                                                                                                            </td>
+                            </tr>
+                                                                                                    <tr>
+                                <th>発行日</th>
+                                <td>2022/12/31</td>
+                            </tr>
+                                                                            <tr>
+                                <th>版型・メディア</th>
+                                <td>B5</td>
+                            </tr>
+                                                                            <tr>
+                                <th>総ページ数・CG数・曲数</th>
+                                <td>56</td>
+                            </tr>
+                                                                            <tr>
+                                <th>イベント</th>
+                                <td>
+                                    <a href="https://www.melonbooks.co.jp/search/search.php?name=%E3%82%B3%E3%83%9F%E3%83%83%E3%82%AF%E3%83%9E%E3%83%BC%E3%82%B1%E3%83%83%E3%83%88101&text_type=event">
+                                        コミックマーケット101
+                                    </a>
+                                </td>
+                            </tr>
+                                                <tr>
+                            <th>作品種別</th>
+                            <td>
+                                                                    18禁
+                                                            </td>
+                        </tr>
+                                                                                            </table>
+                </div>
+            </div>
+        </div>
+    </div>
+                <div class="main-section top-recent green_belt">
+            <h3 class="section-find">
+                このサークルのほかの作品
+            </h3>
+            <a class="more-link" href="https://www.melonbooks.co.jp/circle/index.php?circle_id=22405" title="もっと見る">もっと見る</a>
+            <div class="item-list">
+                <ul>
+                                                    <li class="product_1680497">
+            
+            <div class="item-info">
+                <p class="item-state item-state-analog">抱き枕カバー</p>
+                
+            </div>
+            <div class="item-image">
+                <a href="/detail/detail.php?product_id=1680497" title="伊賀すとら抱き枕カバー">
+                    <span class="label-monopoly"></span>
+                    
+                    <div class="item-thumbnail">
+                                    <img class="lazyload lazyload_product" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=215001105391.jpg&amp;c=1&amp;aa=1" alt="伊賀すとら抱き枕カバー" />
+            <noscript>
+                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=215001105391.jpg&amp;c=1&amp;aa=1"  alt="伊賀すとら抱き枕カバー">
+            </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <p style="opacity: 0;">.</p>
+                <a href="/detail/detail.php?product_id=1680497">
+                    <p class="item-ttl product_title">伊賀すとら抱き枕カバー</p>
+                </a>
+                <p class="search-item-author-author ancillary_info">
+                        <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                        <a href="/circle/index.php?circle_id=22405" title="毛玉牛乳">毛玉牛乳</a>
+                    </p>
+                <p class="search-item-author-author ancillary_info"><i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i><a href="/search/search.php?mode=search&text_type=author&name=%E7%8E%89%E4%B9%8B%E3%81%91%E3%81%A0%E3%81%BE" title="玉之けだま">玉之けだま</a></p>
+                <p class="search-item-author-author ancillary_info coupling_info"><a href="/tags/index.php?genre=%E3%82%AA%E3%83%AA%E3%82%B8%E3%83%8A%E3%83%AB" title="オリジナル">#オリジナル</a></p>
+                <p class="item-state item-state-cation">売り切れ</p>
+                <p class="item-price">&yen;16,250</p>
+                <div class="search-item-detail-btn-list">※こちらは通販在庫です。</div>
+            </div>
+        </li>
+                                                    <li class="product_591211">
+            
+            <div class="item-info">
+                <p class="item-state item-state-analog">成年同人誌</p>
+                
+            </div>
+            <div class="item-image">
+                <a href="/detail/detail.php?product_id=591211" title="りりすぱ">
+                    
+                    
+                    <div class="item-thumbnail">
+                                    <img class="lazyload lazyload_product" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001237482.jpg&amp;c=1&amp;aa=1" alt="りりすぱ" />
+            <noscript>
+                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001237482.jpg&amp;c=1&amp;aa=1"  alt="りりすぱ">
+            </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <p style="opacity: 0;">.</p>
+                <a href="/detail/detail.php?product_id=591211">
+                    <p class="item-ttl product_title">りりすぱ</p>
+                </a>
+                <p class="search-item-author-author ancillary_info">
+                        <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                        <a href="/circle/index.php?circle_id=22405" title="毛玉牛乳">毛玉牛乳</a>
+                    </p>
+                <p class="search-item-author-author ancillary_info"><i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i><a href="/search/search.php?mode=search&text_type=author&name=%E7%8E%89%E4%B9%8B%E3%81%91%E3%81%A0%E3%81%BE" title="玉之けだま">玉之けだま</a></p>
+                <p class="search-item-author-author ancillary_info coupling_info"><a href="/tags/index.php?genre=%E3%82%AA%E3%83%AA%E3%82%B8%E3%83%8A%E3%83%AB" title="オリジナル">#オリジナル</a></p>
+                <p class="item-state item-state-cation">売り切れ</p>
+                <p class="item-price">&yen;1,210</p>
+                <div class="search-item-detail-btn-list">※こちらは通販在庫です。</div>
+            </div>
+        </li>
+                                                    <li class="product_604251">
+            
+            <div class="item-info">
+                <p class="item-state item-state-analog">成年同人誌</p>
+                
+            </div>
+            <div class="item-image">
+                <a href="/detail/detail.php?product_id=604251" title="全部君のせいだ。II">
+                    
+                    
+                    <div class="item-thumbnail">
+                                    <img class="lazyload lazyload_product" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001242272.jpg&amp;c=1&amp;aa=1" alt="全部君のせいだ。II" />
+            <noscript>
+                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001242272.jpg&amp;c=1&amp;aa=1"  alt="全部君のせいだ。II">
+            </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <p style="opacity: 0;">.</p>
+                <a href="/detail/detail.php?product_id=604251">
+                    <p class="item-ttl product_title">全部君のせいだ。II</p>
+                </a>
+                <p class="search-item-author-author ancillary_info">
+                        <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                        <a href="/circle/index.php?circle_id=22405" title="毛玉牛乳">毛玉牛乳</a>
+                    </p>
+                <p class="search-item-author-author ancillary_info"><i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i><a href="/search/search.php?mode=search&text_type=author&name=%E7%8E%89%E4%B9%8B%E3%81%91%E3%81%A0%E3%81%BE" title="玉之けだま">玉之けだま</a></p>
+                <p class="search-item-author-author ancillary_info coupling_info"><a href="/tags/index.php?genre=%E3%82%AA%E3%83%AA%E3%82%B8%E3%83%8A%E3%83%AB" title="オリジナル">#オリジナル</a></p>
+                <p class="item-state item-state-cation">売り切れ</p>
+                <p class="item-price">&yen;785</p>
+                <div class="search-item-detail-btn-list">※こちらは通販在庫です。</div>
+            </div>
+        </li>
+                                                    <li class="product_1593374">
+            
+            <div class="item-info">
+                <p class="item-state item-state-analog">同人グッズ</p>
+                
+            </div>
+            <div class="item-image">
+                <a href="/detail/detail.php?product_id=1593374" title="C100毛玉牛乳新刊セット">
+                    <span class="label-monopoly"></span>
+                    
+                    <div class="item-thumbnail">
+                                    <img class="lazyload lazyload_product" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=215001102670.jpg&amp;c=1&amp;aa=1" alt="C100毛玉牛乳新刊セット" />
+            <noscript>
+                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=215001102670.jpg&amp;c=1&amp;aa=1"  alt="C100毛玉牛乳新刊セット">
+            </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <p style="opacity: 0;">.</p>
+                <a href="/detail/detail.php?product_id=1593374">
+                    <p class="item-ttl product_title">C100毛玉牛乳新刊セット</p>
+                </a>
+                <p class="search-item-author-author ancillary_info">
+                        <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                        <a href="/circle/index.php?circle_id=22405" title="毛玉牛乳">毛玉牛乳</a>
+                    </p>
+                <p class="search-item-author-author ancillary_info"><i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i><a href="/search/search.php?mode=search&text_type=author&name=%E7%8E%89%E4%B9%8B%E3%81%91%E3%81%A0%E3%81%BE" title="玉之けだま">玉之けだま</a></p>
+                <p class="search-item-author-author ancillary_info coupling_info"><a href="/tags/index.php?genre=%E3%82%AA%E3%83%AA%E3%82%B8%E3%83%8A%E3%83%AB" title="オリジナル">#オリジナル</a></p>
+                <p class="item-state item-state-cation">売り切れ</p>
+                <p class="item-price">&yen;6,270</p>
+                <div class="search-item-detail-btn-list">※こちらは通販在庫です。</div>
+            </div>
+        </li>
+                                                    <li class="product_1572489">
+            
+            <div class="item-info">
+                <p class="item-state item-state-analog">成年同人誌</p>
+                
+            </div>
+            <div class="item-image">
+                <a href="/detail/detail.php?product_id=1572489" title="甘みるく　サキュママと夏休み">
+                    <span class="label-monopoly"></span>
+                    
+                    <div class="item-thumbnail">
+                                    <img class="lazyload lazyload_product" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001358129.jpg&amp;c=1&amp;aa=1" alt="甘みるく　サキュママと夏休み" />
+            <noscript>
+                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001358129.jpg&amp;c=1&amp;aa=1"  alt="甘みるく　サキュママと夏休み">
+            </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <p style="opacity: 0;">.</p>
+                <a href="/detail/detail.php?product_id=1572489">
+                    <p class="item-ttl product_title">甘みるく　サキュママと夏休み</p>
+                </a>
+                <p class="search-item-author-author ancillary_info">
+                        <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                        <a href="/circle/index.php?circle_id=22405" title="毛玉牛乳">毛玉牛乳</a>
+                    </p>
+                <p class="search-item-author-author ancillary_info"><i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i><a href="/search/search.php?mode=search&text_type=author&name=%E7%8E%89%E4%B9%8B%E3%81%91%E3%81%A0%E3%81%BE" title="玉之けだま">玉之けだま</a></p>
+                <p class="search-item-author-author ancillary_info coupling_info"><a href="/tags/index.php?genre=%E3%82%AA%E3%83%AA%E3%82%B8%E3%83%8A%E3%83%AB" title="オリジナル">#オリジナル</a></p>
+                
+                <p class="item-price">&yen;1,210</p>
+                <div  class="search-item-detail-btn-list">
+                            <a class="open_sample" href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001358129.jpg&amp;c=1&amp;aa=1"><i class="fa-solid fa-image" aria-hidden="true"></i> サンプル</a> <a class="to_cart cart" href="/detail/detail.php?product_id=1572489" data-product_id="1572489" data-product_class_id="1189096" data-quantity="1"><i style="color: white;" class="fa fa-shopping-cart" aria-hidden="true"></i> カート</a>
+                        </div>
+                        <div class="sample_data sample_data_1572489">
+                            <figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129.jpg&amp;c=1&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129.jpg&amp;c=1&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129a.jpg&amp;c=1&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129a.jpg&amp;c=1&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129b.jpg&amp;c=1&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129b.jpg&amp;c=1&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129c.jpg&amp;c=1&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129c.jpg&amp;c=1&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129d.jpg&amp;c=1&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129d.jpg&amp;c=1&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129e.jpg&amp;c=1&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129e.jpg&amp;c=1&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129f.jpg&amp;c=1&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001358129f.jpg&amp;c=1&amp;aa=1" /></img></a></figure>
+                        </div>
+            </div>
+        </li>
+                                                    <li class="product_1470179">
+            
+            <div class="item-info">
+                <p class="item-state item-state-analog">成年同人誌</p>
+                
+            </div>
+            <div class="item-image">
+                <a href="/detail/detail.php?product_id=1470179" title="orico.">
+                    <span class="label-monopoly"></span>
+                    
+                    <div class="item-thumbnail">
+                                    <img class="lazyload lazyload_product" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001348490.jpg&amp;c=1&amp;aa=1" alt="orico." />
+            <noscript>
+                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001348490.jpg&amp;c=1&amp;aa=1"  alt="orico.">
+            </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <p style="opacity: 0;">.</p>
+                <a href="/detail/detail.php?product_id=1470179">
+                    <p class="item-ttl product_title">orico.</p>
+                </a>
+                <p class="search-item-author-author ancillary_info">
+                        <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                        <a href="/circle/index.php?circle_id=22405" title="毛玉牛乳">毛玉牛乳</a>
+                    </p>
+                <p class="search-item-author-author ancillary_info"><i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i><a href="/search/search.php?mode=search&text_type=author&name=%E7%8E%89%E4%B9%8B%E3%81%91%E3%81%A0%E3%81%BE" title="玉之けだま">玉之けだま</a> , <a href="/search/search.php?mode=search&text_type=author&name=%E3%81%95%E3%81%8D%E3%81%A0%E5%92%B2%E7%B4%80" title="さきだ咲紀">さきだ咲紀</a></p>
+                <p class="search-item-author-author ancillary_info coupling_info"><a href="/tags/index.php?genre=%E3%82%AA%E3%83%AA%E3%82%B8%E3%83%8A%E3%83%AB" title="オリジナル">#オリジナル</a></p>
+                
+                <p class="item-price">&yen;550</p>
+                <div  class="search-item-detail-btn-list">
+                            <a class="open_sample" href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001348490.jpg&amp;c=1&amp;aa=1"><i class="fa-solid fa-image" aria-hidden="true"></i> サンプル</a> <a class="to_cart cart" href="/detail/detail.php?product_id=1470179" data-product_id="1470179" data-product_class_id="1119375" data-quantity="1"><i style="color: white;" class="fa fa-shopping-cart" aria-hidden="true"></i> カート</a>
+                        </div>
+                        <div class="sample_data sample_data_1470179">
+                            <figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001348490.jpg&amp;c=1&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001348490.jpg&amp;c=1&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001348490a.jpg&amp;c=1&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001348490a.jpg&amp;c=1&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001348490b.jpg&amp;c=1&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001348490b.jpg&amp;c=1&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001348490c.jpg&amp;c=1&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001348490c.jpg&amp;c=1&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001348490d.jpg&amp;c=1&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001348490d.jpg&amp;c=1&amp;aa=1" /></img></a></figure>
+                        </div>
+            </div>
+        </li>
+                                    </ul>
+            </div>
+        </div>
+            
+    <div class="main-section top-recent green_belt" style="display: none;">
+        <h3 class="section-find">よく一緒に買われている商品</h3>
+        <div class="item-list buy-together">
+            <ul class="rt-recommend" id="rt_rwd_detail_auto2"
+                data-auth-adult="1"
+                data-transactionid="7549a3c9d31f9e62f4d32a92ec8728439b4a5737">
+                <form data-page="detail" name="form_999_product" id="form_999_product" method="POST" action="https://www.melonbooks.co.jp/bulk/bulk_purchase_detail.php">
+                    <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto2_1"></li>
+                    <li class="product buy-together-product clearfix">
+                        <input type="hidden" name="transactionid" value="7549a3c9d31f9e62f4d32a92ec8728439b4a5737" />
+                        <input type="hidden" id="mode" name="mode" value="cart_ajax" />
+                        <input type="hidden" name="product_ids[]" value="1789342" />
+                        <input type="hidden" id="buy-together-product-id" name="product_ids[]" value="" />
+                        <div class="item-meta">
+                            <p class="item-ttl">2つの商品を同時に</p>
+                            <div class="search-item-detail-btn-list">
+                                <a href="" onClick="
+                                        if(Rtoaster){
+                                            Rtoaster.click('rt_rwd_detail_auto2_1');
+                                        }
+                                        $('#form_999_product').submit();
+                                        return false;">
+                                    <i class="fa fa-shopping-cart" aria-hidden="true"></i> カートに入れる
+                                </a>
+                            </div>
+                        </div>
+                    </li>
+                </form>
+            </ul>
+        </div>
+        <script>
+            $(function () {
+                Recommend.registerPostProcessBoxed($('#rt_rwd_detail_auto2'));
+                var buyTogether = $("[id^='form_999_product']");
+                if (typeof buyTogether !== "undefined") {
+                    Recommend.setTrackingBuyTogether(buyTogether);
+                }
+            });
+        </script>
+    </div>
+    
+    
+    
+    <div class="main-section top-recent green_belt" style="display: none">
+        <h3 class="section-find">ほかの人はこんな商品もチェックしています</h3>
+        <div class="item-list">
+            <ul class="rt-recommend" id="rt_rwd_detail_auto1" data-auth-adult="1" data-transactionid="7549a3c9d31f9e62f4d32a92ec8728439b4a5737">
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_1"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_2"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_3"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_4"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_5"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_6"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_7"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_8"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_9"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_10"></li>
+                            </ul>
+        </div>
+        <script>
+            $(function () {
+                Recommend.registerPostProcessBoxed($('#rt_rwd_detail_auto1'));
+            });
+        </script>
+    </div>
+
+    
+    
+    
+    <div class="main-section top-recent green_belt" style="display: none">
+        <h3 class="section-find">最近チェックした商品</h3>
+        <div class="item-list">
+            <ul class="rt-recommend" id="rt_rwd_history_auto1" data-auth-adult="1" data-transactionid="7549a3c9d31f9e62f4d32a92ec8728439b4a5737">
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_1"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_2"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_3"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_4"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_5"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_6"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_7"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_8"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_9"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_10"></li>
+                            </ul>
+        </div>
+        <script>
+            $(function () {
+                Recommend.registerPostProcessBoxed($('#rt_rwd_history_auto1'));
+            });
+        </script>
+    </div>
+
+
+        <!--/.item-page-->
+            <script type="text/javascript" src="/user_data/packages/responsive/js/shoptech.js?d=1674446597"></script>
+        <script type="text/javascript">
+            $(function () {
+                zaiko({
+                    product_code:'2120013807637',
+                    product_name:'血姫夜交　真祖の姫は発情しているっ!',
+                    product_code_for_cart:'',
+                    is_sp:false
+                });
+            });
+        </script>
+    
+<script>
+    $(function(){
+        var fl_targets = $('#movie a.opacity.pop');
+        if(fl_targets.length > 0){
+            fl_targets.css('visibility','hidden');
+
+            var fl_base = $('<div>').addClass('feather_lightbox');
+            var fl_base_post = $('<div>').addClass('fl_post');
+            var fl_base_image = $('<div>').addClass('fl_image');
+            fl_base_post.append(fl_base_image);
+            fl_base.append(fl_base_post);
+            fl_targets.each(function(index,element){
+                $(this).attr('data-featherlight','#fl'+index).addClass('gallery');
+
+                var fl_box = fl_base.clone();
+                fl_box.attr('id','fl'+index);
+
+                var image = $(this).find('img').clone();
+                image.attr('width','').attr('height','');
+                fl_box.find('.fl_image').append(image);
+
+                var fl_count = $('<span>').addClass('fl_count');
+                fl_count.text( (index+1) + '/' + $('a.opacity.pop').length );
+                fl_box.find('.fl_post').append(fl_count);
+
+                $('#fl_wrapper').append(fl_box);
+            })
+
+            $('.gallery').featherlightGallery({
+                galleryFadeIn: 300,
+                previousIcon: '<i class="fa fa-angle-left"></i>',
+                nextIcon: '<i class="fa fa-angle-right"></i>',
+                openSpeed: 300,
+                variant:'melonbooks_fl melonbooks_fl--pc melonbooks_fl--product',
+                afterContent:function(){
+
+                }
+            });
+
+            fl_targets.css('visibility','visible');
+        }
+    })
+</script>
+<div id="fl_wrapper">
+
+</div>
+<div id="fl_mask">
+
+</div>
+<div id="zaiko_lity">
+    <div id="zaiko">
+        <div id="zaiko_wrapper">
+            <div id="zaiko_overlay"><i class="fas fa-spinner fa-spin"></i></div>
+            <h3 id="zaiko_title" class="page-headline"></h3>
+            <div id="zaiko_info"></div>
+            <div id="zaiko_notice"></div>
+            <div id="zaiko_shop">
+                <div class="simple-buttons simple-buttons--center-one">
+                    <p class="simple-buttons__button simple-buttons__button--yellow">
+                        <a class="" href="https://www.melonbooks.co.jp/shop/#kensaku" target="_blank" title="">店舗一覧</a>
+                    </p>
+                </div>
+            </div>
+            <div id="zaiko_data">読み込み中です...</div>
+            <div id="zaiko_notice2">
+                <div class="simple-buttons simple-buttons--center-one">
+                    <p class="simple-buttons__button simple-buttons__button--yellow">
+                        <a class="" href="#" title="">店舗取り寄せ「さくっと注文」で購入する</a>
+                    </p>
+                </div>
+            </div>
+            <div id="zaiko_close_box" style="">
+                <div class="simple-buttons simple-buttons--center-one">
+                    <p class="simple-buttons__button simple-buttons__button--return">
+                        <a class="" href="#" title="">とじる</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<link href="//cdn.rawgit.com/noelboss/featherlight/1.7.13/release/featherlight.min.css" type="text/css" rel="stylesheet" />
+<link href="//cdn.rawgit.com/noelboss/featherlight/1.7.13/release/featherlight.gallery.min.css" type="text/css" rel="stylesheet" />
+
+<script src="//cdn.rawgit.com/noelboss/featherlight/1.7.13/release/featherlight.min.js" type="text/javascript" charset="utf-8"></script>
+<script src="//cdn.rawgit.com/noelboss/featherlight/1.7.13/release/featherlight.gallery.min.js" type="text/javascript" charset="utf-8"></script>                                                        </div>
+    </div>
+            </div>
+
+    <!-- ▼ボトムナビ -->
+<!-- ▲ボトムナビ --></div>
+<script type="text/javascript" src="//js.rtoaster.jp/Rtoaster.Popup.js"></script>
+<script type="text/javascript">
+Rtoaster.Popup.register("top_oversea_bnr");
+$('body').append('<div class="rt-recommend" id="top_oversea_bnr"></div>');
+</script>
+
+<footer class="global_footer">
+    <nav class="f-u-nav">
+        <ul>
+            <li><a href="/special/service/start/">初めての方へ</a></li>
+            <li><a href="/help/index.php">よくある質問</a></li>
+            <!--
+                        <li><a href="https://www.melonbooks.co.jp/contact/index.php">お問い合わせ</a></li>
+            -->
+            <li><a href="/entry/kiyaku.php">利用規約</a></li>
+            <li><a href="/guide/privacy.php">プライバシーポリシー</a></li>
+            <li><a href="/guide/security.php">セキュリティポリシー</a></li>
+            <li><a href="/user_data/point_rule.php">ポイント規約</a></li>
+            <li><a href="/order/index.php">特定商法取引法</a></li>
+            <li><a href="/help/tpl.php?cid=413#1452">推奨環境</a></li>
+            <li><a href="/abouts/index.php">会社概要</a></li>
+            <li><a href="https://www.melonbooks.co.jp/special/b/0/special/melonbooks_flomagee_staff/recruit.html">求人案内</a></li>
+        </ul>
+        <!--
+                <ul>
+                    <li><a href="https://www.melonbooks.co.jp/help/tpl.php?cid=413#1452">スマートフォン推奨環境</a></li>
+                </ul>
+        -->
+    </nav>
+        <div class="f-u-nav" style="padding: 0;padding-bottom:10px;text-align: center;">
+        <div id="google_translate_element" style="display: inline-block;"></div><script type="text/javascript">
+            function googleTranslateElementInit() {
+                new google.translate.TranslateElement({pageLanguage: 'ja', includedLanguages: 'en,ja,ko,zh-CN,zh-TW', layout: google.translate.TranslateElement.InlineLayout.SIMPLE}, 'google_translate_element');
+            }
+        </script><script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+    </div>
+    <small class="copyright">Copyright © MELONBOOKS Inc. All Rights Reserved.
+    </small>
+</footer>
+<div id="cookie_agree" class="ca_sp" style="display:none;">
+    <p >当サイトでは、サイトの利便性向上のため、クッキー(Cookie)を使用しています。
+    サイトのクッキー(Cookie)の使用に関しては、<a href ="/guide/privacy.php" target="_blank">「プライバシーポリシー」</a>をお読みください。</p>
+    <button>同意する</button>
+</div>
+<script type="text/javascript" src = "//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.cookie.js"></script>
+<script type="text/javascript" src = "//melonbooks.akamaized.net/user_data/packages/responsive/js/coag.js"></script><!--▲ FOOTER-->
+
+<p class="general-fab-btn cart-fab-btn circular-button" style="right: 15px;">
+            <a href="/clipboard/"><i class="fa fa-shopping-cart"></i></a>
+    </p>
+<p class="general-fab-btn top-fab-btn circular-button" style="right: 20px;">
+    <a href="#"><i class="fa fa-chevron-up"></i></a>
+</p>
+
+<form id="form_for_product_parts" action="/detail/detail.php" method="post">
+    <input type="hidden" name="transactionid" value="7549a3c9d31f9e62f4d32a92ec8728439b4a5737" />
+    <input type="hidden" name="mode" value="" />
+    <input type="hidden" name="product_id" value="" />
+    <input type="hidden" name="product_class_id" value="" />
+    <input type="hidden" name="quantity" value="1" />
+    <input type="hidden" name="text_type" />
+</form>
+
+<div class="lity-hide" id="lity-image-overlay">
+    <img src="" alt="">
+</div>
+
+
+<!-- Root element of PhotoSwipe. Must have class pswp. -->
+<div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
+
+    <!-- Background of PhotoSwipe.
+         It's a separate element as animating opacity is faster than rgba(). -->
+    <div class="pswp__bg"></div>
+
+    <!-- Slides wrapper with overflow:hidden. -->
+    <div class="pswp__scroll-wrap">
+
+        <!-- Container that holds slides.
+            PhotoSwipe keeps only 3 of them in the DOM to save memory.
+            Don't modify these 3 pswp__item elements, data is added later on. -->
+        <div class="pswp__container">
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+        </div>
+
+        <!-- Default (PhotoSwipeUI_Default) interface on top of sliding area. Can be changed. -->
+        <div class="pswp__ui pswp__ui--hidden">
+
+            <div class="pswp__top-bar">
+
+                <!--  Controls are self-explanatory. Order can be changed. -->
+
+                <div class="pswp__counter"></div>
+
+                <button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
+
+                <button class="pswp__button pswp__button--share" title="Share"></button>
+
+                <button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
+
+                <button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+
+                <!-- Preloader demo http://codepen.io/dimsemenov/pen/yyBWoR -->
+                <!-- element will get class pswp__preloader--active when preloader is running -->
+                <div class="pswp__preloader">
+                    <div class="pswp__preloader__icn">
+                        <div class="pswp__preloader__cut">
+                            <div class="pswp__preloader__donut"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap">
+                <div class="pswp__share-tooltip"></div>
+            </div>
+
+            <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)">
+            </button>
+
+            <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)">
+            </button>
+
+            <div class="pswp__caption">
+                <div class="pswp__caption__center"></div>
+            </div>
+        </div>
+    </div>
+</div>
+<div id="rtoaster-template">
+    <ul>
+        <li class="product">
+            <div class="item-info">
+                <p class="item-state category"></p>
+                <p class="item-state item-state-special"></p>
+            </div>
+            <div class="item-image">
+                <a href="" title="">
+                    <div class="item-thumbnail">
+                        <p class="label-monopoly"></p>
+                                                    <img class="lazyload lazyload_product" src="/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="" alt="" />
+                                                <noscript>
+                            <img src=""  alt="">
+                        </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <a class="item-link" href="">
+                    <p class="item-ttl"></p>
+                </a>
+                <p class="search-item-author-author circle">
+                    <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                </p>
+                <p class="search-item-author-author author">
+                    <i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i>
+                </p>
+                <p class="search-item-author-author genre">
+                    <i class="fa fa-tags fa-fw" aria-hidden="true"></i>
+
+                </p>
+                <p class="item-price">
+
+                </p>
+                <div class="search-item-detail-btn-list">
+                </div>
+            </div>
+        </li>
+        <li class="circle">
+            <div class="item-image">
+                <a href="" title="">
+                    <div class="item-thumbnail">
+                                                <img class="lazyload lazyload_product" src="/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="" alt="" />
+                                                <noscript>
+                            <img src=""  alt="">
+                        </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <p class="search-item-author-author circle">
+                    <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                    <a href="" title=""></a>
+                </p>
+            </div>
+        </li>
+    </ul>
+</div>
+</body>
+<!-- ▲BODY部 エンド -->
+</html>

--- a/tests/fixture/Melonbooks/testUncensored.html
+++ b/tests/fixture/Melonbooks/testUncensored.html
@@ -1,0 +1,1907 @@
+<!-- ▼BODY部 スタート -->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ja-JP" lang="ja-JP">
+<head>
+    <meta charset="UTF-8"/>
+            <link rel="canonical" href="https://www.melonbooks.co.jp/detail/detail.php?product_id=1836264"/>
+                <meta name="author" content="メロンブックス"/>
+                <meta name="description" itemprop="description" content="めいど・で・ろっく!はサークル名：MIX-ISMの作品です。めいど・で・ろっく!の通販、予約は業界最速のメロンブックスにお任せください。サンプルでめいど・で・ろっく!の試し読み可能！作品の詳細紹介も。お得な特典情報もお見逃しなく！"/>
+                <meta name="keywords" content="めいど・で・ろっく! ,めいど・で・ろっく! 通販,めいど・で・ろっく! 予約,めいど・で・ろっく! 購入同人誌,同人ゲーム,同人漫画,マンガ,同人グッズ,通販,メロンブックス"/>
+        <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+            <title>
+                            めいど・で・ろっく!（MIX-ISM）の通販・購入はメロンブックス | 作品詳細
+                    </title>
+                            <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:site" content="@melonbooks" />
+            <meta property="og:title" content="めいど・で・ろっく!（MIX-ISM）の通販・購入はメロンブックス | 作品詳細">
+            <meta property="og:url" content="https://www.melonbooks.co.jp/detail/detail.php?product_id=1836264">
+            <meta property="og:image" content="https://melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384.jpg">
+            <meta property="og:type" content="website">
+            <meta property="og:site_name" content="メロンブックス">
+            <meta property="og:description" content="めいど・で・ろっく!はサークル名：MIX-ISMの作品です。めいど・で・ろっく!の通販、予約は業界最速のメロンブックスにお任せください。サンプルでめいど・で・ろっく!の試し読み可能！作品の詳細紹介も。お得な特典情報もお見逃しなく！">
+                    <!-- favicon setting-->
+            <link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
+        <link rel="shortcut icon" href="//melonbooks.akamaized.net/user_data/packages/responsive/img/icon/favicon.ico" type="image/vnd.microsoft.ico"/>
+        <link rel="icon" href="/apple-touch-icon.png" type="image/png"/>
+        
+
+    <!-- CSS -->
+            <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/css/main.css?d=1676347938"/>
+        <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/css/lity.css" />
+    <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/css/normalize.css" />
+    <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/css/slick.css" />
+    <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/css/slick-theme.css" />
+    <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/css/swiper.css" />
+    <link type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css" rel="stylesheet">
+    <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/photoswipe.css" />
+    <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/default-skin/default-skin.css" />
+            <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/photoswipe.css" />
+            <link type="text/css" rel="stylesheet" media="all" href="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/default-skin/default-skin.css" />
+            
+    <!-- JS -->
+    <script type="text/javascript">//<![CDATA[
+        var site_root = "/";
+        var isFromagee = false;
+        var isPublicDl = false;
+        //]]></script>
+    
+    <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/lib/jquery.easing.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/lib/ajaxzip3.js"></script>
+    <script type="text/javascript" src="/js/eccube.js"></script>
+    <script type="text/javascript" src="/js/eccube.legacy.js"></script>
+    
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/melonbooks.js?d=1669258418"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/melonbooks_old.js?d=1674530325"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/lity.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/slick.min.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.slidemenu.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/photoswipe.min.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/photoswipe-ui-default.min.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.infinitescroll.min.js"></script>
+    
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/lazysizes.min.js"></script>
+    <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/recommend.js?d=1670217711"></script>
+    <script type="text/javascript" src="//js.rtoaster.jp/Rtoaster.js"></script>
+    <script src="https://auth.atone.be/v1/register.js"></script>
+            <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/photoswipe.min.js" charset="UTF-8"></script>
+            <script type="text/javascript" src="//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.photoswipe/photoswipe-ui-default.min.js" charset="UTF-8"></script>
+    
+        <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+        ga('create', 'UA-55322222-1', 'auto');
+        ga('send', 'pageview');
+
+            </script>
+            <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-N0L4LE6F64"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-N0L4LE6F64');
+
+            </script>
+            <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "cmc03jnsmo");
+    </script>
+        <!-- User Insight PCDF Code Start :  -->
+    <script type="" type="text/javascript">
+    var _uic = _uic ||{}; var _uih = _uih ||{};_uih['id'] = 55232;
+    _uih['lg_id'] = '';
+    _uih['fb_id'] = '';
+    _uih['tw_id'] = '';
+    _uih['uigr_1'] = ''; _uih['uigr_2'] = ''; _uih['uigr_3'] = ''; _uih['uigr_4'] = ''; _uih['uigr_5'] = '';
+    _uih['uigr_6'] = ''; _uih['uigr_7'] = ''; _uih['uigr_8'] = ''; _uih['uigr_9'] = ''; _uih['uigr_10'] = '';
+    _uic['uls'] = 1;
+
+    /* DO NOT ALTER BELOW THIS LINE */
+    /* WITH FIRST PARTY COOKIE */
+    (function() {
+    var bi = document.createElement('script');bi.type = 'text/javascript'; bi.async = true;
+    bi.src = '//cs.nakanohito.jp/b3/bi.js';
+    var s = document.getElementsByTagName('script')[0];s.parentNode.insertBefore(bi, s);
+    })();
+    </script>
+    <!-- User Insight PCDF Code End :  -->
+    <script type="text/javascript">
+        window.lazySizesConfig = window.lazySizesConfig || {};
+        window.lazySizesConfig.expand = 50;
+        $(function () {
+            $('.lazyload').show();
+        });
+    </script>
+        <script type="text/javascript">
+        recommendOptions = {"contractId":"RTA-f22a-d92528fa82b5","memberHashCookieName":"R_CUSTOMER","productIdForViewTrack":null,"convertedItems":{},"items":{},"omitItems":{"0":"1836264","1":"1830901","2":"1788785","3":"1665468","4":"1665466","5":"1665465","6":"1618399"},"category":["\u540c\u4eba\u8a8c","","","","00000001"]};
+
+        var memberHash = Rtoaster.Cookie.get(recommendOptions.memberHashCookieName);
+        Rtoaster.init(recommendOptions.contractId, memberHash);
+
+        Recommend.registerCallback(Rtoaster);
+
+        if (recommendOptions.productIdForViewTrack) {
+            Rtoaster.item("" + recommendOptions.productIdForViewTrack);
+        }
+
+        if (!$.isEmptyObject(recommendOptions.convertedItems)) {
+                        if(isFromagee){
+                clipboard_url='/fromagee/clipboard/';
+            }else{
+                clipboard_url='/clipboard/';
+            }
+                        if(clipboard_url){
+                Rtoaster.track(recommendOptions.convertedItems,clipboard_url);
+            }else{
+                Rtoaster.track(recommendOptions.convertedItems);
+            }
+        } else {
+            Rtoaster.track();
+        }
+
+        recommendFooterProc = function (options) {
+            if (!$.isEmptyObject(options.items)) {
+                Rtoaster.item(options.items);
+            }
+
+            if (!$.isEmptyObject(options.omitItems)) {
+                Rtoaster.omit(Object.values(options.omitItems).join(','));
+            }
+
+            var recommendIds = $('.rt-recommend').map(function () {
+                return $(this).attr('id');
+            }).get();
+
+            if (options.category) {
+                Rtoaster.category.apply(null, options.category);
+            }
+
+            if (recommendIds.length) {
+                Rtoaster.recommendNow.apply(null, recommendIds);
+            }
+            //Rtoaster.recommendNow(recommendIds.join(','));
+        };
+
+        var footerProcTag = document.createElement('script');
+        footerProcTag.text = 'recommendFooterProc(window.recommendOptions);';
+        $(function () {
+            document.body.appendChild(footerProcTag);
+        });
+    </script>
+    
+    <script data-a8stoplog="1" src="//statics.a8.net/a8sales/a8sales.js"></script>
+    <script type="text/javascript">
+        var send_at_search = true;
+        function fnCheckSubmitAtSearch() {
+            if (send_at_search) {
+                send_at_search = false;
+                return true;
+            } else {
+                alert("只今、処理中です。しばらくお待ち下さい。");
+                return false;
+            }
+        }
+    </script>
+</head>
+<!-- ▼BODY部 スタート -->
+
+<!-- TODO : 出し分けの調整 -->
+    <body id="pagetop" class="index-page __pc">
+
+
+
+
+    <div id="header_free_html">
+    <!--ここはweb反映のない領域です-->
+
+
+
+<style>
+.header_belt_penetration{
+  /* background-color:#ebf5f0; */
+  background-color:#fff;
+  padding: 0 1.5% 0 0%;
+  margin-bottom: -5px;
+  margin-top:3px;
+  /*border-bottom:1px solid #e2ddcd;*/
+}
+
+.header_ul_right{
+  display:flex ;
+  text-align: right;
+}
+
+.header_li_right{
+  text-align: right;
+  padding: 0 0 0 10px;
+}
+.header_li_left{
+  padding: 0 0 0 0.5px;
+  flex-grow: 1;
+}
+
+.header_area_right :before {
+    content: '\f2bd';
+    font-family: FontAwesome;
+    position: absolute;
+    top: 50%;
+    right: 16px;
+    transform: translateY(-50%);
+    color: #a6a6a6;
+}
+.a_area_style1{
+    color :#00a667;
+    /*color:#666;*/
+    font-size:12px
+}
+.a_area_style2{
+    color :#00a667;
+    /*color:#444;*/
+    /*color:#338a41;*/
+    font-size:12px
+}
+ .awesomeicon{
+    color :#00a667;
+    /*color:#444;*/
+    /*color:#338a41;*/
+}
+
+@media screen and (max-width:617px) {
+.header_belt_penetration {
+display:none;
+}
+}
+
+
+</style>
+
+<div class="header_belt_penetration">
+  <p class="header_area_right">
+    <ul class="header_ul_right">
+
+<!--出荷状況入れてもいい-->
+      <li class="header_li_left">
+        <a class="a_area_style1">
+        </a>
+      </li>
+
+      <li class="header_li_right">
+        <a href="https://www.melonbooks.co.jp/special/b/0/special/melonbooks_flomagee_staff/recruit.html" class="a_area_style2">
+          <i class="fa-solid fa-users awesomeicon"></i>求人案内
+        </a>
+      </li>
+
+      <li class="header_li_right">
+        <a href="https://circle.melonbooks.co.jp/login/" class="a_area_style2">
+          <i class="fa-regular fa-circle-user awesomeicon"></i>サークルポータル
+        </a>
+      </li>
+
+      <li class="header_li_right">
+        <a href="https://www.melonbooks.co.jp/special/service/circle/melon_floma_consign/index.html" class="a_area_style2">
+          <i class="fa-regular fa-circle awesomeicon"></i>サークルの方へ
+        </a>
+      </li>
+    </ul>
+  </p>
+</div>
+</div>
+<div id="g-header" class="g-header_otherpage">
+    <div class="btn-nav-open" style="position: relative;"></div>
+    <h2 class="g-header_logo">        <a href="/">
+            <!-- 画像のパスは必要に応じて変更してください -->
+                            <img src="/user_data/packages/responsive/img/logo_min.png" alt="メロンブックス" height="30" class="_logo_min">
+                <img src="/user_data/packages/responsive/img/logo.png" alt="メロンブックス" height="42" class="_logo_row">
+                    </a>
+    </h2>    <div class="g-header_search-area search-area_background-color_switch">
+        <form action="/search/search.php" method="get">
+            <input type="hidden" name="mode" value="search" />
+            <input type="hidden" name="search_disp" value="" />
+            <input type="hidden" name="category_id" id ="spc" value="0" />
+            <input type="hidden" name="text_type" />
+            <input type="text" name="name" id="name" maxlength="50" placeholder="商品名、キーワード、ジャンル名…" value="" autocomplete="off" class="wordbox">
+            <input type="submit" value="&#xf002;" onClick="return $('#name').val().length>0;">
+            <a href="#" class="cancel-btn">キャンセル</a>
+        </form>
+        <a class="g-header_search-area__button" href="https://www.melonbooks.co.jp/search/search.php?mode=no_products">詳細検索</a>
+    </div>
+    <ul class="g-header_nav_primary">
+        <li class="g-nav-age"><a href="https://www.melonbooks.co.jp/?adult_auth=0">R18 ON</a></li>
+                                    <li class="g-nav-logo g-nav-logo--fromagee">
+                    <a href="/fromagee/">
+                        <img src="/user_data/packages/responsive/img/fromagee_logo_min.png" alt="fromagee">
+                        <span class="ruby">フロマージュ</span>
+                    </a>
+                </li>
+                                        <li class="g-nav-logo g-nav-logo--public_dl">
+                    <a href="/cplus/">
+                        <img src="/user_data/packages/responsive/img/public_dl/logo_min.png" alt="comic plus">
+                        <span class="ruby">コミックプラス</span>
+                    </a>
+                </li>
+                        <li class="g-nav-shop">
+                <a href="/shop/"><i class="fa-solid fa-shop"></i><span class="ruby">店舗情報</span></a>
+            </li>
+                <li class="g-nav-login"><a href="/mypage/">
+                          <i class="fa fa-user"></i>
+                          <span class="ruby">マイページ</span>
+                      </a></li>
+        <li class="g-nav-cart">
+            <span class="cart-label"  style="display:none;"></span>
+                            <a href="https://www.melonbooks.co.jp/clipboard/"><i class="fa fa-shopping-cart"></i><span class="ruby">カート</span></a>
+                    </li>
+    </ul>
+</div>
+<div id="search-keyword">
+    <ul>
+                <li class="current"><a href="#search-keyword-rank">人気検索ワード</a></li>
+        <li><a href="#search-keyword-trend">注目ワード</a></li>
+            </ul>
+    <div class="search-keyword-list">
+                    <div id="search-keyword-rank" class="current">
+                <ul>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%82%B5%E3%82%A4%E3%83%B3%E6%9C%AC">
+                            <li>
+                                <span class="rank rank1">
+                                    1
+                                </span>
+                                <span>サイン本</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%82%BF%E3%83%9A%E3%82%B9%E3%83%88%E3%83%AA%E3%83%BC">
+                            <li>
+                                <span class="rank rank2">
+                                    2
+                                </span>
+                                <span>タペストリー</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%81%8A%E9%9A%A3%E3%81%AE%E5%A4%A9%E4%BD%BF%E6%A7%98">
+                            <li>
+                                <span class="rank rank3">
+                                    3
+                                </span>
+                                <span>お隣の天使様</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%83%96%E3%83%AB%E3%83%BC%E3%82%A2%E3%83%BC%E3%82%AB%E3%82%A4%E3%83%96">
+                            <li>
+                                <span class="rank rank4">
+                                    4
+                                </span>
+                                <span>ブルーアーカイブ</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E9%9B%A8%E6%B3%A2">
+                            <li>
+                                <span class="rank rank5">
+                                    5
+                                </span>
+                                <span>雨波</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%82%A6%E3%83%9E%E5%A8%98">
+                            <li>
+                                <span class="rank rank6">
+                                    6
+                                </span>
+                                <span>ウマ娘</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%83%9B%E3%83%AD%E3%83%A9%E3%82%A4%E3%83%96">
+                            <li>
+                                <span class="rank rank7">
+                                    7
+                                </span>
+                                <span>ホロライブ</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E7%99%BE%E5%90%88">
+                            <li>
+                                <span class="rank rank8">
+                                    8
+                                </span>
+                                <span>百合</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%81%A0%E3%81%AB%E3%81%BE%E3%82%8B">
+                            <li>
+                                <span class="rank rank9">
+                                    9
+                                </span>
+                                <span>だにまる</span>
+                            </li>
+                        </a>
+                                            <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&name=%E3%81%BF%E3%81%A1%E3%81%8D%E3%82%93%E3%81%90">
+                            <li>
+                                <span class="rank rank10">
+                                    10
+                                </span>
+                                <span>みちきんぐ</span>
+                            </li>
+                        </a>
+                                    </ul>
+            </div>
+            <div id="search-keyword-trend">
+                <ul>
+                                                                                                <a href="https://www.melonbooks.co.jp/tags/index.php?chara=%E3%82%B3%E3%83%9F%E3%83%86%E3%82%A3%E3%82%A2143">
+                                <li>
+                                    <span class="rank rank1">1</span>
+                                    <span>コミティア143</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&amp;search_disp=&amp;category_id=0&amp;text_type=&amp;name=%E3%81%A0%E3%81%AB%E3%81%BE%E3%82%8B">
+                                <li>
+                                    <span class="rank rank2">2</span>
+                                    <span>だにまる</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/tags/index.php?tag=PRIME%20MARKET%202023%20Winter">
+                                <li>
+                                    <span class="rank rank3">3</span>
+                                    <span>PRIME MARKET</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/special/a/1/fair/novel11th/">
+                                <li>
+                                    <span class="rank rank4">4</span>
+                                    <span>ノベル祭り</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/tags/index.php?tag=COLLECTION%27s%20by%20%E3%81%9F%E3%81%AC%E3%81%BE">
+                                <li>
+                                    <span class="rank rank5">5</span>
+                                    <span>COLLECTION&#039;s by たぬま</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/tags/index.php?tag=PRIME%20MARKET%202023%20Winter%E3%80%90220%E5%86%86%E4%BD%9C%E5%93%81%E3%80%91">
+                                <li>
+                                    <span class="rank rank6">6</span>
+                                    <span>220円作品</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/search/search.php?mode=search&amp;name=%E7%99%BE%E5%90%88">
+                                <li>
+                                    <span class="rank rank7">7</span>
+                                    <span>百合</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E5%90%8C%E4%BA%BA%E3%83%AA%E3%82%B3%E3%83%AA%E3%82%B3%E7%89%B9%E9%9B%86">
+                                <li>
+                                    <span class="rank rank8">8</span>
+                                    <span>リコリコ</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/tags/index.php?chara=%E3%82%B3%E3%83%9F%E3%83%83%E3%82%AF%E3%83%9E%E3%83%BC%E3%82%B1%E3%83%83%E3%83%88101">
+                                <li>
+                                    <span class="rank rank9">9</span>
+                                    <span>コミックマーケット101</span>
+                                </li>
+                            </a>
+                                                                                                                        <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E5%B0%82%E5%A3%B2%E3%80%90C101%E3%80%91">
+                                <li>
+                                    <span class="rank rank10">10</span>
+                                    <span>C101 専売</span>
+                                </li>
+                            </a>
+                                                            </ul>
+            </div>
+                
+    </div>
+</div>
+<div id="slidemenu" class="">
+    <div class="slidemenu_shade"></div>
+    <div class="btn-nav-close"></div>
+    <div class="slide-nav">
+        <div id="slidemenu_contents">
+            <div id="slidemenu_inner">
+                <div class="registration">
+                <a href="https://www.melonbooks.co.jp/mypage/" class="registration-login">
+                    ログイン
+                </a>
+                <a href="https://www.melonbooks.co.jp/entry/" class="registration-entry">
+                    ユーザー登録
+                </a>
+            </div>
+                <div class="slide-nav-list">
+                    <ul>
+                        <!--RSP_HEADER_SLIDEMENU_MY_PAGE-->
+                        <li>
+                            <a href="/clipboard/">カートを見る</a>
+                        </li>
+                        <li>
+                            <a href="/dl_clipboard/">電子カートを見る</a>
+                        </li>
+                        <li>
+                            <a href="/news/">お知らせ</a>
+                        </li>
+                        <li>
+                            <span>カテゴリから探す</span>
+                            <ul class="slide-nav-inner">
+                                <li class="cplus_not"><a href="/book/list.php?category_id=1">同人誌</a></li>
+                                <li class="cplus_not"><a href="/soft/list.php?category_id=2">同人ソフト&音楽</a></li>
+                                <li class="cplus_not"><a href="/goods/list.php?category_id=3">同人アイテム</a></li>
+                                <li class="cplus_not"><a href="/comic/list.php?category_id=4">コミック</a></li>
+                                <li class="cplus_not"><a href="/products/list.php?category_id=145">サブカル書籍</a></li>
+                                <li class="cplus_not"><a href="/game/list.php?category_id=5">ゲーム</a></li>
+                                <li class="cplus_not"><a href="/audio/list.php?category_id=6">音楽</a></li>
+                                <li class="cplus_not"><a href="/video/list.php?category_id=17">映像</a></li>
+                                <li class="cplus_not"><a href="/business/list.php?category_id=7">グッズ</a></li>
+                                <li class="melon_only"><a href="/company/list.php?category_id=8">うりぼうさっか店</a></li>
+                                <li class="melon_only"><a href="/products/list.php?category_id=99">アダルト</a></li>
+                                <li class="cplus_not"><a href="/digital/">同人電子・DL</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=189">コミック(電子)</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=190">ノベル(電子)</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=191">雑誌(電子)</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=86">BLコミック</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=192">BLノベル</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=87">TLコミック</a></li>
+                                <li class="cplus_only"><a href="/ebook/list.php?category_id=193">TLノベル</a></li>
+                            </ul>
+                        </li>
+                        <li>
+                            <span>作品を探す</span>
+                            <ul class="slide-nav-inner">
+                                <li><a href="/products/circle.php">サークルで探す</a></li>
+                                <li><a href="/products/genre.php">ジャンルで探す</a></li>
+                                <li><a href="/products/character.php">キャラで探す</a></li>
+                                <li><a href="/ebook/list.php?category_id=77">電子書籍で探す<!-- <i style="color:#f77;font-style:italic; display: inline;">(NEW)</i>--></a></li>
+                                <li><a href="/dl/list.php?category_id=169">DL音楽・ソフトで探す</a></li>
+                                <li class="fromagee_only"><a href="/fromagee/search/search_coupling.php">カップリングで探す</a></li>
+                            </ul>
+                        </li>
+                        <li><span>一覧・ランキングから探す</span>
+                            <ul class="slide-nav-inner">
+                                <li><a href="/calender/">発売カレンダー</a></li>
+                                <li><a href="/ranking/">ランキング</a></li>
+                                <li><a href="/new/new.php">新着作品</a></li>
+                                <li><a href="/monopoly/monopoly.php">専売作品</a></li>
+                                <li><a href="/privilege/privilege.php">特典付き</a></li>
+                                <li><a href="/reserve/reserve.php">予約開始</a></li>
+                                <li><a href="/new/arrival.php">新入荷</a></li>
+                                <li><a href="/restock/restock.php">再入荷</a></li>
+                            </ul>
+                        </li>
+                        <li><a href="/digital/">電子書籍・DL</a></li>
+                        <li><a href="/tags/index.php?tag=%E3%82%B5%E3%83%BC%E3%82%AF%E3%83%AB%E3%82%B7%E3%83%A7%E3%83%83%E3%83%97%E3%80%80%E3%82%B0%E3%83%83%E3%82%BA%E5%8F%97%E6%B3%A8%E8%B2%A9%E5%A3%B2" title="サークルショップ">サークルショップ</a></li>
+                        <li><a href="/special/a/6/pb/hp/gallery/index.html" title="バーチャルギャラリー">バーチャルギャラリー</a></li>
+                        <li><a href="/help/index.php" title="よくある質問" target="_blank">よくある質問</a></li>
+                        <li><a href="/special/service/start/" title="はじめての方へ" target="_blank">はじめての方へ</a></li>
+                        <li><span>サークルの方へ</span>
+                            <ul class="slide-nav-inner">
+                                <li><a href="https://circle.melonbooks.co.jp/" title="サークルポータル" target="_blank">サークルポータル</a></li>
+                                <li><a href="/special/service/circle/melon_floma_consign/index.html">サークルの方へ</a></li>
+                                <li><a href="https://circle.melonbooks.co.jp/news/">お知らせ</a></li>
+                                <li><a href="/special/service/circle/shop/">同人委託依頼</a></li>
+                                <li><a href="/guide/privacy.php">個人情報保護方針</a></li>
+                                <li><a href="/help/circle.php">Q&Aコーナー</a></li>
+                            </ul>
+                        </li>
+                        <li><span>店舗情報</span>
+                            <ul class="slide-nav-inner">
+                                <li><a href="/shop/" title="メロンブックス店舗情報">メロンブックス店舗情報</a></li>
+                                <li><a href="/fromagee/shop/" title="フロマージュ店舗情報" target="_blank">フロマージュ店舗情報</a></li>
+                                                                <li><a href="/shop/event.php?type=fair">フェア情報</a></li>
+                                <li><a href="/shop/event.php?type=privilege">特典情報</a></li>
+                                <li><a href="/help/shop.php">店舗FAQ</a></li>
+                                                            </ul>
+                        </li>
+                        <li><span>インフォメーション</span>
+                            <ul class="slide-nav-inner">
+                                <!-- <li><a href="/mailmagazine/index.php">メルマガについて</a></li> -->
+                                <li><a href="/feature/detail.php?feature_id=710">ポイントシステムについて</a></li>
+                                <li><a href="/special/b/0/uribou/201909_melonbooks_mascot/">マスコット紹介</a></li>
+                                <li><a href="/special/service/twitter/" title="SNS一覧">SNS一覧</a></li>
+                                <li><a href="/special/b/0/special/melonbooks_flomagee_staff/recruit.html">求人案内</a></li>
+                            </ul>
+                        </li>
+                        <li><a href="/special/b/0/service/overseas_en/">For Overseas</a></li>
+                        <li class="melon_not"><a href="/" title="Melonbooks TOP" style="color:#ffff66">Melonbooks TOP</a></li>
+                        <li class="fromagee_not"><a href="/fromagee/" title="Fromageebooks TOP" style="color:#ffff66">Fromageebooks TOP</a></li>
+                        <li class="cplus_not"><a href="/cplus/" title="Comicplus TOP" style="color:#ffff66">Comicplus TOP<i style="color:#f77;font-style:italic; display: inline;">(NEW)</i></a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div><!-- ▼サイトジャック -->
+<div id="container" class="container_otherpage">
+    <div class="filter">&nbsp;</div>
+    <div class="utBReFvXjp-wrap utBReFvXjp-wrap_otherpage">
+    <div class="utBReFvXjp-column-main">
+        <div id="contents">
+                                                            <!-- ▼パンくず -->
+                                                            <p class="breadcrumb">
+    <a href="/" itemprop="url"><span itemprop="title">HOME</span></a>
+    <i class="fa fa-angle-right" aria-hidden="true"></i>
+    <meta itemprop="position" content="1" />  
+                                                                                <a href="https://www.melonbooks.co.jp/book/list.php?category_id=1" itemprop="url">
+                                        <span itemprop="title">
+                同人誌            </span>
+                            </a>
+                                        <i class="fa fa-angle-right" aria-hidden="true"></i>
+                        <meta itemprop="position" content="2" />
+                                                                    <a href="https://www.melonbooks.co.jp/book/list.php?category_id=9" itemprop="url">
+                                        <span itemprop="title">
+                一般同人誌            </span>
+                            </a>
+                                        <i class="fa fa-angle-right" aria-hidden="true"></i>
+                        <meta itemprop="position" content="3" />
+                                            <span itemprop="title">
+                めいど・で・ろっく!            </span>
+                                    <meta itemprop="position" content="4" />
+            </p>                                        <!-- ▲パンくず -->
+                                                                <script type="text/javascript">
+        $(window).load(function () {
+            var element = $('figure a img');
+            element.each(function () {
+                var img = new Image();
+                img.src = $(this).attr('src');
+                var width = img.width;
+                var height = img.height;
+                $(this).closest('a').attr('data-size', width + 'x' + height);
+            });
+        });
+        $(window).load(function () {
+            var initPhotoSwipeFromDOM = function (gallerySelector) {
+                // parse slide data (url, title, size ...) from DOM elements 
+                // (children of gallerySelector)
+                var parseThumbnailElements = function (el) {
+                    var thumbElements = el.childNodes,
+                        numNodes = thumbElements.length,
+                        items = [],
+                        figureEl,
+                        linkEl,
+                        size,
+                        item;
+                    for (var i = 0; i < numNodes; i++) {
+                        figureEl = thumbElements[i]; // <figure> element
+
+                        // include only element nodes 
+                        if (figureEl.nodeType !== 1) {
+                            continue;
+                        }
+
+                        linkEl = figureEl.children[0]; // <a> element
+
+                        size = linkEl.getAttribute('data-size').split('x');
+
+                        // create slide object
+                        item = {
+                            src: linkEl.getAttribute('href'),
+                            w: parseInt(size[0], 10),
+                            h: parseInt(size[1], 10)
+                        };
+
+
+                        if (figureEl.children.length > 1) {
+                            // <figcaption> content
+                            item.title = figureEl.children[1].innerHTML;
+                        }
+
+                        if (linkEl.children.length > 0) {
+                            // <img> thumbnail element, retrieving thumbnail url
+                            item.msrc = linkEl.children[0].getAttribute('src');
+                        }
+
+                        item.el = figureEl; // save link to element for getThumbBoundsFn
+                        items.push(item);
+                    }
+
+                    return items;
+                };
+
+                // find nearest parent element
+                var closest = function closest(el, fn) {
+                    return el && (fn(el) ? el : closest(el.parentNode, fn));
+                };
+
+                // triggers when user clicks on thumbnail
+                var onThumbnailsClick = function (e) {
+                    e = e || window.event;
+                    e.preventDefault ? e.preventDefault() : e.returnValue = false;
+
+                    var eTarget = e.target || e.srcElement;
+
+                    // find root element of slide
+                    var clickedListItem = closest(eTarget, function (el) {
+                        return (el.tagName && el.tagName.toUpperCase() === 'FIGURE');
+                    });
+
+                    if (!clickedListItem) {
+                        return;
+                    }
+
+                    // find index of clicked item by looping through all child nodes
+                    // alternatively, you may define index via data- attribute
+                    var clickedGallery = clickedListItem.parentNode,
+                        childNodes = clickedListItem.parentNode.childNodes,
+                        numChildNodes = childNodes.length,
+                        nodeIndex = 0,
+                        index;
+
+                    for (var i = 0; i < numChildNodes; i++) {
+                        if (childNodes[i].nodeType !== 1) {
+                            continue;
+                        }
+
+                        if (childNodes[i] === clickedListItem) {
+                            index = nodeIndex;
+                            break;
+                        }
+                        nodeIndex++;
+                    }
+
+
+                    if (index >= 0) {
+                        // open PhotoSwipe if valid index found
+                        openPhotoSwipe(index, clickedGallery);
+                    }
+                    return false;
+                };
+
+                // parse picture index and gallery index from URL (#&pid=1&gid=2)
+                var photoswipeParseHash = function () {
+                    var hash = window.location.hash.substring(1),
+                        params = {};
+
+                    if (hash.length < 5) {
+                        return params;
+                    }
+
+                    var vars = hash.split('&');
+                    for (var i = 0; i < vars.length; i++) {
+                        if (!vars[i]) {
+                            continue;
+                        }
+                        var pair = vars[i].split('=');
+                        if (pair.length < 2) {
+                            continue;
+                        }
+                        params[pair[0]] = pair[1];
+                    }
+
+                    if (params.gid) {
+                        params.gid = parseInt(params.gid, 10);
+                    }
+
+                    if (!params.hasOwnProperty('pid')) {
+                        return params;
+                    }
+                    params.pid = parseInt(params.pid, 10);
+                    return params;
+                };
+
+                var openPhotoSwipe = function (index, galleryElement, disableAnimation) {
+                    var pswpElement = document.querySelectorAll('.pswp')[0],
+                        gallery,
+                        options,
+                        items;
+                    items = parseThumbnailElements(galleryElement);
+
+                    // define options (if needed)
+                    options = {
+                        index: index,
+                        // define gallery index (for URL)
+                        galleryUID: galleryElement.getAttribute('data-pswp-uid'),
+                        getThumbBoundsFn: function (index) {
+                            // See Options -> getThumbBoundsFn section of documentation for more info
+                            var thumbnail = items[index].el.getElementsByTagName('img')[0], // find thumbnail
+                                pageYScroll = window.pageYOffset || document.documentElement.scrollTop,
+                                rect = thumbnail.getBoundingClientRect();
+
+                            return {x: rect.left, y: rect.top + pageYScroll, w: rect.width};
+                        },
+                        shareEl: false
+
+                    };
+
+                    if (disableAnimation) {
+                        options.showAnimationDuration = 0;
+                    }
+
+                    // Pass data to PhotoSwipe and initialize it
+                    gallery = new PhotoSwipe(pswpElement, PhotoSwipeUI_Default, items, options);
+                    gallery.init();
+                };
+
+                // loop through all gallery elements and bind events
+                var galleryElements = document.querySelectorAll(gallerySelector);
+
+                for (var i = 0, l = galleryElements.length; i < l; i++) {
+                    galleryElements[i].setAttribute('data-pswp-uid', i + 1);
+                    galleryElements[i].onclick = onThumbnailsClick;
+                }
+
+                // Parse URL and open gallery if it contains #&pid=3&gid=1
+                var hashData = photoswipeParseHash();
+                if (hashData.pid > 0 && hashData.gid > 0) {
+                    openPhotoSwipe(hashData.pid - 1, galleryElements[hashData.gid - 1], true);
+                }
+            };
+            // PhotoSwipeを起動する
+            initPhotoSwipeFromDOM('.my-gallery');
+        });
+        var product_id;
+
+        function login() {
+            $('input[name=mode]').val('');
+            var form = $('<form/>', {'action': '/mypage/', 'method': 'get'});
+            var returnUrl = $('<input>', {'type': 'hidden', 'name': 'ru', 'value': 'https://www.melonbooks.co.jp/detail/detail.php?product_id=' + product_id});
+
+            form.append(returnUrl);
+            form.appendTo(document.body);
+            form.submit();
+            return false;
+        }
+        // 上部にある大きいお気に入りボタンの場合はこちら
+        function displayResult(data,target,parent){
+            var dataArray = JSON.parse(data);
+            if(dataArray.status == true){
+                    target.find('i').removeClass('add_wish');
+                    target.find('i').addClass('favorited');
+                    target.find('i').removeClass('fa-regular');
+                    target.find('i').addClass('fa-solid');
+                    
+                    if(target.hasClass('add_wish')){
+                        target.addClass('__active');
+                        target.find('span').html('ほしいもの<br>リストに追加済');
+                    } else if(target.hasClass('favorite_circle')){
+                        target.addClass('__active');
+                        target.find('span').html('お気に入り<br>サークルに追加済');
+                    } else if(target.hasClass('favorite_label')){
+                        target.addClass('__active');
+                        target.find('span').html('お気に入り<br>レーベルに追加済');
+                    }
+            }
+            if (parent.find('div.message_box').length) {
+
+            } else {
+                if(dataArray.message.indexOf('ログイン') > -1){
+                    login();
+                }
+            }
+        }
+        // 下部にある商品詳細内の小さいお気に入りボタンの場合はこちら
+        function displayResultShort(data,target,parent){
+            var dataArray = JSON.parse(data);
+            if(dataArray.status == true){
+                    target.removeClass('favorite');
+                    target.addClass('favorited');
+                    target.removeClass('fa-regular');
+                    target.addClass('fa-solid');
+            }
+            if (parent.find('div.message_box').length) {
+
+            } else {
+                if(dataArray.message.indexOf('ログイン') > -1){
+                    login();
+                }
+            }
+        }
+        $(function(){
+            var doubleClick=false;
+            var param = location.search;
+            var m = location.search.match(/product_id=([0-9]+)/);
+            product_id = m[1];
+            $('.add_wish').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.product_id = product_id;
+                data.mode = 'regist_wish_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResult(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+            $('.favorite_author').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.favorite_author_name = $(this).data('authorname');
+                data.product_id = product_id;
+                data.mode = 'regist_author_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResultShort(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+            $('.favorite_circle').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.favorite_circle_id = $(this).data('circleid');
+                data.product_id = product_id;
+                data.mode = 'regist_circle_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResult(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+            $('.favorite_circle_short').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.favorite_circle_id = $(this).data('circleid');
+                data.product_id = product_id;
+                data.mode = 'regist_circle_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResultShort(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+            $('.favorite_coupling').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.favorite_seme = $(this).data('seme');
+                data.favorite_uke = $(this).data('uke');
+                data.favorite_genre_id = $(this).data('genreid');
+                data.product_id = product_id;
+                data.mode = 'regist_coupling_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResultShort(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+            $('.favorite_label').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.favorite_label_id = $(this).data('labelid');
+                data.product_id = product_id;
+                data.mode = 'regist_label_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResult(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+            $('.favorite_label_short').click(function(){
+                if(doubleClick){
+                    return false;
+                }
+                doubleClick = true;
+                var data = {};
+                var parent = $(this).closest('td');
+                var target = $(this);
+                data.favorite_label_id = $(this).data('labelid');
+                data.product_id = product_id;
+                data.mode = 'regist_label_ajax';
+                $.ajax({
+                    type: "GET",
+                    url: "?",
+                    data: data,
+                    success: function (data) {
+                        displayResultShort(data,target,parent);
+                        doubleClick = false;
+                    }
+                });
+                return false;
+            });
+        });
+    </script>
+        <a href="http://www.tenso.com/en/static/lp_shop_index?bn_code=melonbooks" target="_blank" style="line-height:0;"><img src="//www2.tenso.com/ext/banner.php?f=ipb_melonbooks_1400x200.png" alt="海外発送/国際配送サービスの転送コム" style="max-width: 100%; display: block;margin-bottom: 3px;"></a>
+    <a href="https://promotion.leyifan.com/adv/link/melonbooks" target="_blank" style="line-height:0;"><img src="https://promotion.leyifan.com/adv/banner/melonbooks" style="max-width: 100%; display: block;margin-bottom: 3px;"></a>
+    <script defer src="https://overseas-ship.wre.jp/melonbooks"></script>
+    <div class="whiterabbit-banner"></div>
+        <div class="item-page">
+        <div class="item-header">
+                            <span class="item-notes notes-analog">一般同人誌</span><span class="item-notes notes-red">同人</span><span class="item-notes notes-red">一般</span><span class="item-notes notes-red">発売開始</span><span class="item-notes notes-red">専売</span>
+            <h1 class="page-header">めいど・で・ろっく!</h1>
+                            <p class="author-name">
+                    <a href="https://www.melonbooks.co.jp/circle/index.php?circle_id=5624">MIX-ISM</a>
+                </p>
+                        
+        </div>
+        <div class="item-body-wrap">
+            <div class="item-img">
+                                    <p class="label-monopoly"></p>
+                                <div class="slider my-gallery">
+                                                                    <figure>
+                                                            <a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384.jpg">
+                                    <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384.jpg" alt="めいど・で・ろっく!" height="250"/>
+                                </a>
+                                                    </figure>
+                                                                                    <figure>
+                            <a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384a.jpg&sp=1">
+                                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384a.jpg&sp=1" alt="めいど・で・ろっく!" height="250"/>
+                            </a>
+                        </figure>
+                                            <figure>
+                            <a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384b.jpg&sp=1">
+                                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384b.jpg&sp=1" alt="めいど・で・ろっく!" height="250"/>
+                            </a>
+                        </figure>
+                                            <figure>
+                            <a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384c.jpg&sp=1">
+                                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384c.jpg&sp=1" alt="めいど・で・ろっく!" height="250"/>
+                            </a>
+                        </figure>
+                                            <figure>
+                            <a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384d.jpg&sp=1">
+                                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384d.jpg&sp=1" alt="めいど・で・ろっく!" height="250"/>
+                            </a>
+                        </figure>
+                                            <figure>
+                            <a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384e.jpg&sp=1">
+                                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001385384e.jpg&sp=1" alt="めいど・で・ろっく!" height="250"/>
+                            </a>
+                        </figure>
+                                    </div>
+                <div class="item-img-nav">
+                </div>
+            </div>
+
+            <div class="item-metas-wrap">
+
+                <div class="item-meta3">
+                    <p class="price">
+                        価格（税込み）
+                                                                                    <span class="yen __discount">
+                                    &yen;770
+                                </span>
+                                                                        </p>
+                                            <p class="point">3%（21ポイント）還元</p>
+                                        <div class="state mt12">
+                        販売状況
+                        <span class="state-instock">在庫あり</span>
+                    </div>
+                                            <p class="mt6">
+                            ※こちらは通販の在庫状態になります。
+                        </p>
+                        <p id="zaiko_open" data-lity="data-lity" href="#zaiko_wrapper">店舗在庫はこちらをご確認お願いいたします</p>
+                        
+                                                        </div>
+                
+                <form data-page="detail" name="form1" id="form_product" method="POST" action="?">
+                                        <div class="item-cart" id="cart_anchor">
+                        <input type="hidden" name="transactionid" value="af152ac9f6db2e6492eb8d591a03cf1f821a354a"/>
+                        <input type="hidden" id="mode" name="mode" value="cart_ajax"/>
+                        <input type="hidden" name="product_id" value="1836264"/>
+                        <input type="hidden" name="product_class_id" value="" id="product_class_id"/>
+                        <input type="hidden" name="favorite_product_id" value=""/>
+                        <input type="hidden" name="favorite_author_name" value=""/>
+                                                                                    <div class="select">
+                                    <div>個数
+                                        <select name="quantity" id="prouct_quantity">
+<option label="1" value="1">1</option>
+<option label="2" value="2">2</option>
+<option label="3" value="3">3</option>
+<option label="4" value="4">4</option>
+<option label="5" value="5">5</option>
+<option label="6" value="6">6</option>
+<option label="7" value="7">7</option>
+<option label="8" value="8">8</option>
+<option label="9" value="9">9</option>
+<option label="10" value="10">10</option>
+</select>
+
+                                    </div>
+                                </div>
+                                <div class="btn-cart">
+                                    <i class="fa fa-shopping-cart fa-2x" aria-hidden="true"></i>カートに入れる
+                                    <input class="submit cart tag_cart_main2" type="submit" value="&#xf07a; カートに入れる"/>
+                                </div>
+                                                                                                    <!--/.item-cart-->
+                    </div>
+                                                                            </form>
+                                <div class="view-environment">
+                                        <div class="headline_noline">配送方法</div>
+                    <div class="row_product_set">
+                        宅配便
+                                                                                    <a href="https://www.melonbooks.co.jp/special/service/mail-bin/" title="メール便" target="_blank">
+                                    / メール便OK！ (<i class="fa fa-archive fa-fw" aria-hidden="true"></i>容量 : 18%)
+                                </a>
+                                                                                                                                        <a href="https://www.melonbooks.co.jp/special/service/c_uketori/" title="コンビニ受取" target="_blank">
+                                    / コンビニ受取OK！
+                                </a>
+                                                                                                        / ＠店舗受取り
+                                                                                                    / さくっと注文
+                                                                    </div>
+                    <div class="headline_noline">お支払方法</div>
+                    <div class="row_product_set">
+                                                    クレジット / コンビニ前払い / コンビニ後払い / 代金引換 / atone 翌月後払い(コンビニ)
+                                            </div>
+                    <div class="row_sale_date">
+                                                                        発売日：2023年02月12日
+                                                                                                                    </div>
+                </div>
+                                                <div class="item-favorite mt24">
+                                            <a href="#" class="btn-favorite-circle favorite_circle"  data-circleid="5624">
+                            <i class="fa-regular fa-circle favorite" aria-hidden="true"></i>
+                            <span>お気に入り<br>サークルに追加</span>
+                        </a>
+                    
+                    <a href="#" class="btn-favorite-item add_wish"> <i class="fa-regular fa-heart favorite"></i><span>ほしいもの<br>リストに追加</span></a>
+                </div>
+
+                <div class="item-share mt24">
+                    <a class="btn-share-twitter" alt="Tweet" href="http://twitter.com/share?text=%E3%82%81%E3%81%84%E3%81%A9%E3%83%BB%E3%81%A7%E3%83%BB%E3%82%8D%E3%81%A3%E3%81%8F%21%EF%BC%88MIX-ISM%EF%BC%89%E3%81%AE%E9%80%9A%E8%B2%A9%E3%83%BB%E8%B3%BC%E5%85%A5%E3%81%AF%E3%83%A1%E3%83%AD%E3%83%B3%E3%83%96%E3%83%83%E3%82%AF%E3%82%B9%20%7C%20&amp;url=https%3A%2F%2Fwww.melonbooks.co.jp%2Fdetail%2Fdetail.php%3Fproduct_id%3D1836264" target="_blank">
+                        <i class="fa-brands fa-twitter"></i>
+                    </a>
+                    <a class="btn-share-line" alt="LINEで送る" href="http://line.me/R/msg/text/?%E3%82%81%E3%81%84%E3%81%A9%E3%83%BB%E3%81%A7%E3%83%BB%E3%82%8D%E3%81%A3%E3%81%8F%21%EF%BC%88MIX-ISM%EF%BC%89%E3%81%AE%E9%80%9A%E8%B2%A9%E3%83%BB%E8%B3%BC%E5%85%A5%E3%81%AF%E3%83%A1%E3%83%AD%E3%83%B3%E3%83%96%E3%83%83%E3%82%AF%E3%82%B9%0D%0Ahttps%3A%2F%2Fwww.melonbooks.co.jp%2Fdetail%2Fdetail.php%3Fproduct_id%3D1836264" target="_blank">
+                        <i class="fa-brands fa-line"></i>
+                    </a>
+                    <a class="btn-share-facebook" alt="Facebookで送る" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.melonbooks.co.jp%2Fdetail%2Fdetail.php%3Fproduct_id%3D1836264" target="_blank">
+                        <i class="fa-brands fa-facebook-f"></i>
+                    </a>
+                </div>
+                <div class="item-detail2">
+                    <p class="mt6">
+                                                                            <a href="https://www.melonbooks.co.jp/tags/index.php?genre=%E3%81%BC%E3%81%A3%E3%81%A1%E3%83%BB%E3%81%96%E3%83%BB%E3%82%8D%E3%81%A3%E3%81%8F%21">#ぼっち・ざ・ろっく!</a> 
+                                                                            <a href="https://www.melonbooks.co.jp/tags/index.php?chara=%E5%BE%8C%E8%97%A4%E3%81%B2%E3%81%A8%E3%82%8A" title="">#後藤ひとり</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?chara=%E5%96%9C%E5%A4%9A%E9%83%81%E4%BB%A3" title="">#喜多郁代</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?chara=%E5%B1%B1%E7%94%B0%E3%83%AA%E3%83%A7%E3%82%A6" title="">#山田リョウ</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?chara=%E4%BC%8A%E5%9C%B0%E7%9F%A5%E8%99%B9%E5%A4%8F" title="">#伊地知虹夏</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?chara=%E6%BC%AB%E7%94%BB" title="">#漫画</a> 
+                                                                            <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E3%82%AE%E3%83%A3%E3%82%B0%E3%83%BB%E3%82%B3%E3%83%A1%E3%83%87%E3%82%A3" title="">#ギャグ・コメディ</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E3%81%BB%E3%81%AE%E3%81%BC%E3%81%AE" title="">#ほのぼの</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E3%83%A1%E3%82%A4%E3%83%89" title="">#メイド</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E3%83%A1%E3%82%A4%E3%83%89%E6%9C%8D" title="">#メイド服</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E5%B0%82%E5%A3%B2" title="">#専売</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=%E5%B0%82%E5%A3%B2%E3%80%90%E4%B8%80%E8%88%AC%E5%90%8C%E4%BA%BA%E8%AA%8C%E3%80%91" title="">#専売【一般同人誌】</a> 
+                                                    <a href="https://www.melonbooks.co.jp/tags/index.php?tag=2023%E5%B9%B42%E6%9C%88%E6%96%B0%E5%88%8A%E5%90%8C%E4%BA%BA%E4%BD%9C%E5%93%81%E7%89%B9%E9%9B%86" title="">#2023年2月新刊同人作品特集</a> 
+                                            </p>
+                </div>
+            </div>
+        </div>
+                                        <div class="item-detail __light mt24" style="background-color: white;">
+                                                <h3 class="page-headline mb12">サークル(先生)からのコメント/作品詳細</h3>
+                                        <div>
+                <p>
+                    サークルMIX-ISM「ぼっち・ざ・ろっく!」本 第2弾!<br />
+ワンマンライブのチケットが売れていない結束バンドは<br />
+ライブハウスでメイドカフェ&ライブをやることに。<br />
+<br />
+SNSで宣伝したりオリジナルフードメニューを考えたり<br />
+星歌、きくり、PAさん大人チームもメイド服でお手伝い。<br />
+<br />
+メインキャラ総出演のドタバタギャグコメディ!<br />
+はたしてライブは成功するのか…?
+                </p>
+            </div>
+        </div>
+                        <div class="item-detail __light mt24" style="background-color: white;">
+                                                <h3 class="page-headline mb12">スタッフのオススメポイント</h3>
+                                        <div>
+                <p>
+                    犬威赤彦先生がお贈りする、ぼ〇ろのハイテンションメイドコメディ本の登場です☆<br />
+チケットノルマが足りないならメイド服になればいいじゃないと言う流れがすでに面白い♪<br />
+ぼっちちゃんの写真を撮っている時の奇跡の一枚が素材の良さを存分に発揮していて可愛い☆<br />
+可愛いメイド姿でカッコいいライブもこなす結束バンドが最高な、極上の一冊をお楽しみ下さい♪
+                </p>
+            </div>
+        </div>
+                                <div class="item-detail __light">
+            <div>
+                <div class="table-wrapper">
+                    <table>
+                        <tr>
+                            <th>サークル名</th>
+                                                            <td class="product_info">
+                                    <a href="https://www.melonbooks.co.jp/circle/index.php?circle_id=5624">MIX-ISM&nbsp;(作品数:60)</a>
+                                                            <a href="#" class="favorite fa-regular fa-heart favorite_circle_short" aria-hidden="true" data-circleid="5624"></a>
+                                                                    </td>
+                                                    </tr>
+                                                                            <tr>
+                                <th>作家名</th>
+                                <td class="product_info">
+                                                               <a href="https://www.melonbooks.co.jp/search/search.php?name=%E7%8A%AC%E5%A8%81%E8%B5%A4%E5%BD%A6&text_type=author">犬威赤彦</a>                           <a href="#" class="favorite fa-regular fa-heart favorite_author" aria-hidden="true" data-authorName="犬威赤彦"></a>
+                                </td>
+                            </tr>
+                                                                            <tr>
+                                <th>ジャンル</th>
+                                <td>
+                                                                            <a href="https://www.melonbooks.co.jp/tags/index.php?genre=%E3%81%BC%E3%81%A3%E3%81%A1%E3%83%BB%E3%81%96%E3%83%BB%E3%82%8D%E3%81%A3%E3%81%8F%21">ぼっち・ざ・ろっく!</a>
+                                                                                                            </td>
+                            </tr>
+                                                                                                    <tr>
+                                <th>発行日</th>
+                                <td>2023/02/10</td>
+                            </tr>
+                                                                            <tr>
+                                <th>版型・メディア</th>
+                                <td>B5</td>
+                            </tr>
+                                                                            <tr>
+                                <th>総ページ数・CG数・曲数</th>
+                                <td>28</td>
+                            </tr>
+                                                                        <tr>
+                            <th>作品種別</th>
+                            <td>
+                                                                    一般向け
+                                                            </td>
+                        </tr>
+                                                                                            </table>
+                </div>
+            </div>
+        </div>
+    </div>
+                <div class="main-section top-recent green_belt">
+            <h3 class="section-find">
+                このサークルのほかの作品
+            </h3>
+            <a class="more-link" href="https://www.melonbooks.co.jp/circle/index.php?circle_id=5624" title="もっと見る">もっと見る</a>
+            <div class="item-list">
+                <ul>
+                                                    <li class="product_1830901">
+            
+            <div class="item-info">
+                <p class="item-state item-state-analog">一般同人誌</p>
+                
+            </div>
+            <div class="item-image">
+                <a href="/detail/detail.php?product_id=1830901" title="【2023年02月新刊+既刊まとめ買い】MIX-ISM「ぼざろ本」セット">
+                    <span class="label-monopoly"></span>
+                    
+                    <div class="item-thumbnail">
+                                    <img class="lazyload lazyload_product" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=218001020800.jpg&amp;c=0&amp;aa=1" alt="【2023年02月新刊+既刊まとめ買い】MIX-ISM「ぼざろ本」セット" />
+            <noscript>
+                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=218001020800.jpg&amp;c=0&amp;aa=1"  alt="【2023年02月新刊+既刊まとめ買い】MIX-ISM「ぼざろ本」セット">
+            </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                
+                    <a class="pop_link" href="https://www.melonbooks.co.jp/tags/index.php?tag=%E5%90%8C%E4%BA%BA%E4%BD%9C%E5%93%81%E3%81%BE%E3%81%A8%E3%82%81%E8%B2%B7%E3%81%84%E3%82%BB%E3%83%83%E3%83%88"  style=" color:white;  background-color:white; " >
+                        <p class='item-ttl pop'><img src="//melonbooks.akamaized.net/special/a/2/tokusyu/matomeset/pop/matome_red_4.png"></p>
+                    </a>
+                <a href="/detail/detail.php?product_id=1830901">
+                    <p class="item-ttl product_title">【2023年02月新刊+既刊まとめ買い】MIX-ISM「ぼざろ本」セット</p>
+                </a>
+                <p class="search-item-author-author ancillary_info">
+                        <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                        <a href="/circle/index.php?circle_id=5624" title="MIX-ISM">MIX-ISM</a>
+                    </p>
+                <p class="search-item-author-author ancillary_info"><i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i><a href="/search/search.php?mode=search&text_type=author&name=%E7%8A%AC%E5%A8%81%E8%B5%A4%E5%BD%A6" title="犬威赤彦">犬威赤彦</a></p>
+                <p class="search-item-author-author ancillary_info coupling_info"><a href="/tags/index.php?genre=%E3%81%BC%E3%81%A3%E3%81%A1%E3%83%BB%E3%81%96%E3%83%BB%E3%82%8D%E3%81%A3%E3%81%8F%21" title="ぼっち・ざ・ろっく!">#ぼっち・ざ・ろっく!</a></p>
+                <p class="item-state item-state-new">発売開始</p>
+                <p class="item-price">&yen;1,540</p>
+                <div  class="search-item-detail-btn-list">
+                            <a class="open_sample" href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=218001020800.jpg&amp;c=0&amp;aa=1"><i class="fa-solid fa-image" aria-hidden="true"></i> サンプル</a> <a class="to_cart cart" href="/detail/detail.php?product_id=1830901" data-product_id="1830901" data-product_class_id="1349891" data-quantity="1"><i style="color: white;" class="fa fa-shopping-cart" aria-hidden="true"></i> カート</a>
+                        </div>
+                        <div class="sample_data sample_data_1830901">
+                            <figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=218001020800.jpg&amp;c=0&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=218001020800.jpg&amp;c=0&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=218001020800a.jpg&amp;c=0&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=218001020800a.jpg&amp;c=0&amp;aa=1" /></img></a></figure>
+                        </div>
+            </div>
+        </li>
+                                                    <li class="product_1788785">
+            
+            <div class="item-info">
+                <p class="item-state item-state-analog">一般同人誌</p>
+                
+            </div>
+            <div class="item-image">
+                <a href="/detail/detail.php?product_id=1788785" title="ぼっち・と・でーと!">
+                    <span class="label-monopoly"></span>
+                    
+                    <div class="item-thumbnail">
+                                    <img class="lazyload lazyload_product" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001380490.jpg&amp;c=0&amp;aa=1" alt="ぼっち・と・でーと!" />
+            <noscript>
+                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001380490.jpg&amp;c=0&amp;aa=1"  alt="ぼっち・と・でーと!">
+            </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <p style="opacity: 0;">.</p>
+                <a href="/detail/detail.php?product_id=1788785">
+                    <p class="item-ttl product_title">ぼっち・と・でーと!</p>
+                </a>
+                <p class="search-item-author-author ancillary_info">
+                        <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                        <a href="/circle/index.php?circle_id=5624" title="MIX-ISM">MIX-ISM</a>
+                    </p>
+                <p class="search-item-author-author ancillary_info"><i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i><a href="/search/search.php?mode=search&text_type=author&name=%E7%8A%AC%E5%A8%81%E8%B5%A4%E5%BD%A6" title="犬威赤彦">犬威赤彦</a></p>
+                <p class="search-item-author-author ancillary_info coupling_info"><a href="/tags/index.php?genre=%E3%81%BC%E3%81%A3%E3%81%A1%E3%83%BB%E3%81%96%E3%83%BB%E3%82%8D%E3%81%A3%E3%81%8F%21" title="ぼっち・ざ・ろっく!">#ぼっち・ざ・ろっく!</a></p>
+                
+                <p class="item-price">&yen;770</p>
+                <div  class="search-item-detail-btn-list">
+                            <a class="open_sample" href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001380490.jpg&amp;c=0&amp;aa=1"><i class="fa-solid fa-image" aria-hidden="true"></i> サンプル</a> <a class="to_cart cart" href="/detail/detail.php?product_id=1788785" data-product_id="1788785" data-product_class_id="1315995" data-quantity="1"><i style="color: white;" class="fa fa-shopping-cart" aria-hidden="true"></i> カート</a>
+                        </div>
+                        <div class="sample_data sample_data_1788785">
+                            <figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380490.jpg&amp;c=0&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380490.jpg&amp;c=0&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380490a.jpg&amp;c=0&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380490a.jpg&amp;c=0&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380490b.jpg&amp;c=0&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380490b.jpg&amp;c=0&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380490c.jpg&amp;c=0&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380490c.jpg&amp;c=0&amp;aa=1" /></img></a></figure><figure><a href="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380490d.jpg&amp;c=0&amp;aa=1"><img class="lazyload" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?image=212001380490d.jpg&amp;c=0&amp;aa=1" /></img></a></figure>
+                        </div>
+            </div>
+        </li>
+                                                    <li class="product_1665468">
+            
+            <div class="item-info">
+                <p class="item-state item-state-analog">一般同人誌</p>
+                
+            </div>
+            <div class="item-image">
+                <a href="/detail/detail.php?product_id=1665468" title="【サイン本】クゥすみがイチャイチャするまで外れません!">
+                    
+                    
+                    <div class="item-thumbnail">
+                                    <img class="lazyload lazyload_product" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001369731.jpg&amp;c=0&amp;aa=1" alt="【サイン本】クゥすみがイチャイチャするまで外れません!" />
+            <noscript>
+                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001369731.jpg&amp;c=0&amp;aa=1"  alt="【サイン本】クゥすみがイチャイチャするまで外れません!">
+            </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <p style="opacity: 0;">.</p>
+                <a href="/detail/detail.php?product_id=1665468">
+                    <p class="item-ttl product_title">【サイン本】クゥすみがイチャイチャするまで外れません!</p>
+                </a>
+                <p class="search-item-author-author ancillary_info">
+                        <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                        <a href="/circle/index.php?circle_id=5624" title="MIX-ISM">MIX-ISM</a>
+                    </p>
+                <p class="search-item-author-author ancillary_info"><i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i><a href="/search/search.php?mode=search&text_type=author&name=%E7%8A%AC%E5%A8%81%E8%B5%A4%E5%BD%A6" title="犬威赤彦">犬威赤彦</a></p>
+                <p class="search-item-author-author ancillary_info coupling_info"><a href="/tags/index.php?genre=%E3%83%A9%E3%83%96%E3%83%A9%E3%82%A4%E3%83%96%21frm_spc%E3%82%B9%E3%83%BC%E3%83%91%E3%83%BC%E3%82%B9%E3%82%BF%E3%83%BC%21%21" title="ラブライブ! スーパースター!!">#ラブライブ! スーパースター!!</a></p>
+                <p class="item-state item-state-cation">売り切れ</p>
+                <p class="item-price">&yen;759</p>
+                <div class="search-item-detail-btn-list">※こちらは通販在庫です。</div>
+            </div>
+        </li>
+                                                    <li class="product_1665466">
+            
+            <div class="item-info">
+                <p class="item-state item-state-analog">一般同人誌</p>
+                
+            </div>
+            <div class="item-image">
+                <a href="/detail/detail.php?product_id=1665466" title="【サイン本】平安名すみれは看病したい。">
+                    
+                    
+                    <div class="item-thumbnail">
+                                    <img class="lazyload lazyload_product" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001369729.jpg&amp;c=0&amp;aa=1" alt="【サイン本】平安名すみれは看病したい。" />
+            <noscript>
+                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001369729.jpg&amp;c=0&amp;aa=1"  alt="【サイン本】平安名すみれは看病したい。">
+            </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <p style="opacity: 0;">.</p>
+                <a href="/detail/detail.php?product_id=1665466">
+                    <p class="item-ttl product_title">【サイン本】平安名すみれは看病したい。</p>
+                </a>
+                <p class="search-item-author-author ancillary_info">
+                        <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                        <a href="/circle/index.php?circle_id=5624" title="MIX-ISM">MIX-ISM</a>
+                    </p>
+                <p class="search-item-author-author ancillary_info"><i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i><a href="/search/search.php?mode=search&text_type=author&name=%E7%8A%AC%E5%A8%81%E8%B5%A4%E5%BD%A6" title="犬威赤彦">犬威赤彦</a></p>
+                <p class="search-item-author-author ancillary_info coupling_info"><a href="/tags/index.php?genre=%E3%83%A9%E3%83%96%E3%83%A9%E3%82%A4%E3%83%96%21frm_spc%E3%82%B9%E3%83%BC%E3%83%91%E3%83%BC%E3%82%B9%E3%82%BF%E3%83%BC%21%21" title="ラブライブ! スーパースター!!">#ラブライブ! スーパースター!!</a> <a href="/tags/index.php?genre=%E3%83%A9%E3%83%96%E3%83%A9%E3%82%A4%E3%83%96%21" title="ラブライブ!">#ラブライブ!</a></p>
+                <p class="item-state item-state-cation">売り切れ</p>
+                <p class="item-price">&yen;759</p>
+                <div class="search-item-detail-btn-list">※こちらは通販在庫です。</div>
+            </div>
+        </li>
+                                                    <li class="product_1665465">
+            
+            <div class="item-info">
+                <p class="item-state item-state-analog">一般同人誌</p>
+                
+            </div>
+            <div class="item-image">
+                <a href="/detail/detail.php?product_id=1665465" title="【サイン本】Heartful Bash!!">
+                    
+                    
+                    <div class="item-thumbnail">
+                                    <img class="lazyload lazyload_product" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001369728.jpg&amp;c=0&amp;aa=1" alt="【サイン本】Heartful Bash!!" />
+            <noscript>
+                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001369728.jpg&amp;c=0&amp;aa=1"  alt="【サイン本】Heartful Bash!!">
+            </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <p style="opacity: 0;">.</p>
+                <a href="/detail/detail.php?product_id=1665465">
+                    <p class="item-ttl product_title">【サイン本】Heartful Bash!!</p>
+                </a>
+                <p class="search-item-author-author ancillary_info">
+                        <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                        <a href="/circle/index.php?circle_id=5624" title="MIX-ISM">MIX-ISM</a>
+                    </p>
+                <p class="search-item-author-author ancillary_info"><i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i><a href="/search/search.php?mode=search&text_type=author&name=%E7%8A%AC%E5%A8%81%E8%B5%A4%E5%BD%A6" title="犬威赤彦">犬威赤彦</a></p>
+                <p class="search-item-author-author ancillary_info coupling_info"><a href="/tags/index.php?genre=%E3%83%A9%E3%83%96%E3%83%A9%E3%82%A4%E3%83%96%21" title="ラブライブ!">#ラブライブ!</a> <a href="/tags/index.php?genre=%E3%83%A9%E3%83%96%E3%83%A9%E3%82%A4%E3%83%96%21frm_spc%E3%82%B5%E3%83%B3%E3%82%B7%E3%83%A3%E3%82%A4%E3%83%B3%21%21" title="ラブライブ! サンシャイン!!">#ラブライブ! サンシャイン!!</a></p>
+                <p class="item-state item-state-cation">売り切れ</p>
+                <p class="item-price">&yen;1,870</p>
+                <div class="search-item-detail-btn-list">※こちらは通販在庫です。</div>
+            </div>
+        </li>
+                                                    <li class="product_1618399">
+            
+            <div class="item-info">
+                <p class="item-state item-state-analog">一般同人誌</p>
+                <p class="item-state item-state-special">特典</p>
+            </div>
+            <div class="item-image">
+                <a href="/detail/detail.php?product_id=1618399" title="【同人祭サイン本】平安名すみれは看病したい。【特典付き②】">
+                    <span class="label-monopoly"></span>
+                    
+                    <div class="item-thumbnail">
+                                    <img class="lazyload lazyload_product" src="//melonbooks.akamaized.net/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001365185.jpg&amp;c=0&amp;aa=1" alt="【同人祭サイン本】平安名すみれは看病したい。【特典付き②】" />
+            <noscript>
+                <img src="//melonbooks.akamaized.net/user_data/packages/resize_image.php?width=450&amp;height=450&amp;image=212001365185.jpg&amp;c=0&amp;aa=1"  alt="【同人祭サイン本】平安名すみれは看病したい。【特典付き②】">
+            </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <p style="opacity: 0;">.</p>
+                <a href="/detail/detail.php?product_id=1618399">
+                    <p class="item-ttl product_title">【同人祭サイン本】平安名すみれは看病したい。【特典付き②】</p>
+                </a>
+                <p class="search-item-author-author ancillary_info">
+                        <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                        <a href="/circle/index.php?circle_id=5624" title="MIX-ISM">MIX-ISM</a>
+                    </p>
+                <p class="search-item-author-author ancillary_info"><i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i><a href="/search/search.php?mode=search&text_type=author&name=%E7%8A%AC%E5%A8%81%E8%B5%A4%E5%BD%A6" title="犬威赤彦">犬威赤彦</a></p>
+                <p class="search-item-author-author ancillary_info coupling_info"><a href="/tags/index.php?genre=%E3%83%A9%E3%83%96%E3%83%A9%E3%82%A4%E3%83%96%21frm_spc%E3%82%B9%E3%83%BC%E3%83%91%E3%83%BC%E3%82%B9%E3%82%BF%E3%83%BC%21%21" title="ラブライブ! スーパースター!!">#ラブライブ! スーパースター!!</a> <a href="/tags/index.php?genre=%E3%83%A9%E3%83%96%E3%83%A9%E3%82%A4%E3%83%96%21" title="ラブライブ!">#ラブライブ!</a></p>
+                <p class="item-state item-state-cation">売り切れ</p>
+                <p class="item-price">&yen;759</p>
+                <div class="search-item-detail-btn-list">※こちらは通販在庫です。</div>
+            </div>
+        </li>
+                                    </ul>
+            </div>
+        </div>
+            
+    <div class="main-section top-recent green_belt" style="display: none;">
+        <h3 class="section-find">よく一緒に買われている商品</h3>
+        <div class="item-list buy-together">
+            <ul class="rt-recommend" id="rt_rwd_detail_auto2"
+                data-auth-adult="1"
+                data-transactionid="af152ac9f6db2e6492eb8d591a03cf1f821a354a">
+                <form data-page="detail" name="form_999_product" id="form_999_product" method="POST" action="https://www.melonbooks.co.jp/bulk/bulk_purchase_detail.php">
+                    <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto2_1"></li>
+                    <li class="product buy-together-product clearfix">
+                        <input type="hidden" name="transactionid" value="af152ac9f6db2e6492eb8d591a03cf1f821a354a" />
+                        <input type="hidden" id="mode" name="mode" value="cart_ajax" />
+                        <input type="hidden" name="product_ids[]" value="1836264" />
+                        <input type="hidden" id="buy-together-product-id" name="product_ids[]" value="" />
+                        <div class="item-meta">
+                            <p class="item-ttl">2つの商品を同時に</p>
+                            <div class="search-item-detail-btn-list">
+                                <a href="" onClick="
+                                        if(Rtoaster){
+                                            Rtoaster.click('rt_rwd_detail_auto2_1');
+                                        }
+                                        $('#form_999_product').submit();
+                                        return false;">
+                                    <i class="fa fa-shopping-cart" aria-hidden="true"></i> カートに入れる
+                                </a>
+                            </div>
+                        </div>
+                    </li>
+                </form>
+            </ul>
+        </div>
+        <script>
+            $(function () {
+                Recommend.registerPostProcessBoxed($('#rt_rwd_detail_auto2'));
+                var buyTogether = $("[id^='form_999_product']");
+                if (typeof buyTogether !== "undefined") {
+                    Recommend.setTrackingBuyTogether(buyTogether);
+                }
+            });
+        </script>
+    </div>
+    
+    
+    
+    <div class="main-section top-recent green_belt" style="display: none">
+        <h3 class="section-find">ほかの人はこんな商品もチェックしています</h3>
+        <div class="item-list">
+            <ul class="rt-recommend" id="rt_rwd_detail_auto1" data-auth-adult="1" data-transactionid="af152ac9f6db2e6492eb8d591a03cf1f821a354a">
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_1"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_2"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_3"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_4"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_5"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_6"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_7"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_8"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_9"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_detail_auto1_10"></li>
+                            </ul>
+        </div>
+        <script>
+            $(function () {
+                Recommend.registerPostProcessBoxed($('#rt_rwd_detail_auto1'));
+            });
+        </script>
+    </div>
+
+    
+    
+    
+    <div class="main-section top-recent green_belt" style="display: none">
+        <h3 class="section-find">最近チェックした商品</h3>
+        <div class="item-list">
+            <ul class="rt-recommend" id="rt_rwd_history_auto1" data-auth-adult="1" data-transactionid="af152ac9f6db2e6492eb8d591a03cf1f821a354a">
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_1"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_2"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_3"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_4"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_5"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_6"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_7"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_8"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_9"></li>
+                                                        <li class="rt-recommend-element product clearfix" id="rt_rwd_history_auto1_10"></li>
+                            </ul>
+        </div>
+        <script>
+            $(function () {
+                Recommend.registerPostProcessBoxed($('#rt_rwd_history_auto1'));
+            });
+        </script>
+    </div>
+
+
+        <!--/.item-page-->
+            <script type="text/javascript" src="/user_data/packages/responsive/js/shoptech.js?d=1674446597"></script>
+        <script type="text/javascript">
+            $(function () {
+                zaiko({
+                    product_code:'2120013853849',
+                    product_name:'めいど・で・ろっく!',
+                    product_code_for_cart:'',
+                    is_sp:false
+                });
+            });
+        </script>
+    
+<script>
+    $(function(){
+        var fl_targets = $('#movie a.opacity.pop');
+        if(fl_targets.length > 0){
+            fl_targets.css('visibility','hidden');
+
+            var fl_base = $('<div>').addClass('feather_lightbox');
+            var fl_base_post = $('<div>').addClass('fl_post');
+            var fl_base_image = $('<div>').addClass('fl_image');
+            fl_base_post.append(fl_base_image);
+            fl_base.append(fl_base_post);
+            fl_targets.each(function(index,element){
+                $(this).attr('data-featherlight','#fl'+index).addClass('gallery');
+
+                var fl_box = fl_base.clone();
+                fl_box.attr('id','fl'+index);
+
+                var image = $(this).find('img').clone();
+                image.attr('width','').attr('height','');
+                fl_box.find('.fl_image').append(image);
+
+                var fl_count = $('<span>').addClass('fl_count');
+                fl_count.text( (index+1) + '/' + $('a.opacity.pop').length );
+                fl_box.find('.fl_post').append(fl_count);
+
+                $('#fl_wrapper').append(fl_box);
+            })
+
+            $('.gallery').featherlightGallery({
+                galleryFadeIn: 300,
+                previousIcon: '<i class="fa fa-angle-left"></i>',
+                nextIcon: '<i class="fa fa-angle-right"></i>',
+                openSpeed: 300,
+                variant:'melonbooks_fl melonbooks_fl--pc melonbooks_fl--product',
+                afterContent:function(){
+
+                }
+            });
+
+            fl_targets.css('visibility','visible');
+        }
+    })
+</script>
+<div id="fl_wrapper">
+
+</div>
+<div id="fl_mask">
+
+</div>
+<div id="zaiko_lity">
+    <div id="zaiko">
+        <div id="zaiko_wrapper">
+            <div id="zaiko_overlay"><i class="fas fa-spinner fa-spin"></i></div>
+            <h3 id="zaiko_title" class="page-headline"></h3>
+            <div id="zaiko_info"></div>
+            <div id="zaiko_notice"></div>
+            <div id="zaiko_shop">
+                <div class="simple-buttons simple-buttons--center-one">
+                    <p class="simple-buttons__button simple-buttons__button--yellow">
+                        <a class="" href="https://www.melonbooks.co.jp/shop/#kensaku" target="_blank" title="">店舗一覧</a>
+                    </p>
+                </div>
+            </div>
+            <div id="zaiko_data">読み込み中です...</div>
+            <div id="zaiko_notice2">
+                <div class="simple-buttons simple-buttons--center-one">
+                    <p class="simple-buttons__button simple-buttons__button--yellow">
+                        <a class="" href="#" title="">店舗取り寄せ「さくっと注文」で購入する</a>
+                    </p>
+                </div>
+            </div>
+            <div id="zaiko_close_box" style="">
+                <div class="simple-buttons simple-buttons--center-one">
+                    <p class="simple-buttons__button simple-buttons__button--return">
+                        <a class="" href="#" title="">とじる</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<link href="//cdn.rawgit.com/noelboss/featherlight/1.7.13/release/featherlight.min.css" type="text/css" rel="stylesheet" />
+<link href="//cdn.rawgit.com/noelboss/featherlight/1.7.13/release/featherlight.gallery.min.css" type="text/css" rel="stylesheet" />
+
+<script src="//cdn.rawgit.com/noelboss/featherlight/1.7.13/release/featherlight.min.js" type="text/javascript" charset="utf-8"></script>
+<script src="//cdn.rawgit.com/noelboss/featherlight/1.7.13/release/featherlight.gallery.min.js" type="text/javascript" charset="utf-8"></script>                                                        </div>
+    </div>
+            </div>
+
+    <!-- ▼ボトムナビ -->
+<!-- ▲ボトムナビ --></div>
+<script type="text/javascript" src="//js.rtoaster.jp/Rtoaster.Popup.js"></script>
+<script type="text/javascript">
+Rtoaster.Popup.register("top_oversea_bnr");
+$('body').append('<div class="rt-recommend" id="top_oversea_bnr"></div>');
+</script>
+
+<footer class="global_footer">
+    <nav class="f-u-nav">
+        <ul>
+            <li><a href="/special/service/start/">初めての方へ</a></li>
+            <li><a href="/help/index.php">よくある質問</a></li>
+            <!--
+                        <li><a href="https://www.melonbooks.co.jp/contact/index.php">お問い合わせ</a></li>
+            -->
+            <li><a href="/entry/kiyaku.php">利用規約</a></li>
+            <li><a href="/guide/privacy.php">プライバシーポリシー</a></li>
+            <li><a href="/guide/security.php">セキュリティポリシー</a></li>
+            <li><a href="/user_data/point_rule.php">ポイント規約</a></li>
+            <li><a href="/order/index.php">特定商法取引法</a></li>
+            <li><a href="/help/tpl.php?cid=413#1452">推奨環境</a></li>
+            <li><a href="/abouts/index.php">会社概要</a></li>
+            <li><a href="https://www.melonbooks.co.jp/special/b/0/special/melonbooks_flomagee_staff/recruit.html">求人案内</a></li>
+        </ul>
+        <!--
+                <ul>
+                    <li><a href="https://www.melonbooks.co.jp/help/tpl.php?cid=413#1452">スマートフォン推奨環境</a></li>
+                </ul>
+        -->
+    </nav>
+        <div class="f-u-nav" style="padding: 0;padding-bottom:10px;text-align: center;">
+        <div id="google_translate_element" style="display: inline-block;"></div><script type="text/javascript">
+            function googleTranslateElementInit() {
+                new google.translate.TranslateElement({pageLanguage: 'ja', includedLanguages: 'en,ja,ko,zh-CN,zh-TW', layout: google.translate.TranslateElement.InlineLayout.SIMPLE}, 'google_translate_element');
+            }
+        </script><script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+    </div>
+    <small class="copyright">Copyright © MELONBOOKS Inc. All Rights Reserved.
+    </small>
+</footer>
+<div id="cookie_agree" class="ca_sp" style="display:none;">
+    <p >当サイトでは、サイトの利便性向上のため、クッキー(Cookie)を使用しています。
+    サイトのクッキー(Cookie)の使用に関しては、<a href ="/guide/privacy.php" target="_blank">「プライバシーポリシー」</a>をお読みください。</p>
+    <button>同意する</button>
+</div>
+<script type="text/javascript" src = "//melonbooks.akamaized.net/user_data/packages/responsive/js/jquery.cookie.js"></script>
+<script type="text/javascript" src = "//melonbooks.akamaized.net/user_data/packages/responsive/js/coag.js"></script><!--▲ FOOTER-->
+
+<p class="general-fab-btn cart-fab-btn circular-button" style="right: 15px;">
+            <a href="/clipboard/"><i class="fa fa-shopping-cart"></i></a>
+    </p>
+<p class="general-fab-btn top-fab-btn circular-button" style="right: 20px;">
+    <a href="#"><i class="fa fa-chevron-up"></i></a>
+</p>
+
+<form id="form_for_product_parts" action="/detail/detail.php" method="post">
+    <input type="hidden" name="transactionid" value="af152ac9f6db2e6492eb8d591a03cf1f821a354a" />
+    <input type="hidden" name="mode" value="" />
+    <input type="hidden" name="product_id" value="" />
+    <input type="hidden" name="product_class_id" value="" />
+    <input type="hidden" name="quantity" value="1" />
+    <input type="hidden" name="text_type" />
+</form>
+
+<div class="lity-hide" id="lity-image-overlay">
+    <img src="" alt="">
+</div>
+
+
+<!-- Root element of PhotoSwipe. Must have class pswp. -->
+<div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
+
+    <!-- Background of PhotoSwipe.
+         It's a separate element as animating opacity is faster than rgba(). -->
+    <div class="pswp__bg"></div>
+
+    <!-- Slides wrapper with overflow:hidden. -->
+    <div class="pswp__scroll-wrap">
+
+        <!-- Container that holds slides.
+            PhotoSwipe keeps only 3 of them in the DOM to save memory.
+            Don't modify these 3 pswp__item elements, data is added later on. -->
+        <div class="pswp__container">
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+        </div>
+
+        <!-- Default (PhotoSwipeUI_Default) interface on top of sliding area. Can be changed. -->
+        <div class="pswp__ui pswp__ui--hidden">
+
+            <div class="pswp__top-bar">
+
+                <!--  Controls are self-explanatory. Order can be changed. -->
+
+                <div class="pswp__counter"></div>
+
+                <button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
+
+                <button class="pswp__button pswp__button--share" title="Share"></button>
+
+                <button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
+
+                <button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+
+                <!-- Preloader demo http://codepen.io/dimsemenov/pen/yyBWoR -->
+                <!-- element will get class pswp__preloader--active when preloader is running -->
+                <div class="pswp__preloader">
+                    <div class="pswp__preloader__icn">
+                        <div class="pswp__preloader__cut">
+                            <div class="pswp__preloader__donut"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap">
+                <div class="pswp__share-tooltip"></div>
+            </div>
+
+            <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)">
+            </button>
+
+            <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)">
+            </button>
+
+            <div class="pswp__caption">
+                <div class="pswp__caption__center"></div>
+            </div>
+        </div>
+    </div>
+</div>
+<div id="rtoaster-template">
+    <ul>
+        <li class="product">
+            <div class="item-info">
+                <p class="item-state category"></p>
+                <p class="item-state item-state-special"></p>
+            </div>
+            <div class="item-image">
+                <a href="" title="">
+                    <div class="item-thumbnail">
+                        <p class="label-monopoly"></p>
+                                                    <img class="lazyload lazyload_product" src="/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="" alt="" />
+                                                <noscript>
+                            <img src=""  alt="">
+                        </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <a class="item-link" href="">
+                    <p class="item-ttl"></p>
+                </a>
+                <p class="search-item-author-author circle">
+                    <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                </p>
+                <p class="search-item-author-author author">
+                    <i class="fa fa-paint-brush fa-fw" aria-hidden="true"></i>
+                </p>
+                <p class="search-item-author-author genre">
+                    <i class="fa fa-tags fa-fw" aria-hidden="true"></i>
+
+                </p>
+                <p class="item-price">
+
+                </p>
+                <div class="search-item-detail-btn-list">
+                </div>
+            </div>
+        </li>
+        <li class="circle">
+            <div class="item-image">
+                <a href="" title="">
+                    <div class="item-thumbnail">
+                                                <img class="lazyload lazyload_product" src="/user_data/packages/responsive/img/pic/now_printing.jpeg" data-src="" alt="" />
+                                                <noscript>
+                            <img src=""  alt="">
+                        </noscript>
+                    </div>
+                </a>
+            </div>
+            <div class="item-meta">
+                <p class="search-item-author-author circle">
+                    <i class="fa-regular fa-circle fa-fw" aria-hidden="true"></i>
+                    <a href="" title=""></a>
+                </p>
+            </div>
+        </li>
+    </ul>
+</div>
+</body>
+<!-- ▲BODY部 エンド -->
+</html>


### PR DESCRIPTION
fix #903, #1009

- ページタイトルのフォーマットが変わってパースに失敗していたので、正規表現を修正しました。
- サイトリニューアルでDOM構造も変わっていて作品詳細が取れなくなっていたので、XPathを修正しました。かなりナイーブなのですぐ壊れそうな気がします。
- テストがなかったので、簡単にスナップショットテストを入れておきました。