### PR TITLE
PixivResolver: 画像取れない問題を修正

### DIFF
--- a/app/MetadataResolver/PixivResolver.php
+++ b/app/MetadataResolver/PixivResolver.php
@@ -64,7 +64,7 @@ class PixivResolver implements Resolver
         $metadata->title = $json['body']['illustTitle'] ?? '';
         $metadata->description = '投稿者: ' . $json['body']['userName'] . PHP_EOL . strip_tags(str_replace('<br />', PHP_EOL, $json['body']['illustComment'] ?? ''));
         $metadata->image = $this->proxize(
-            str_replace("/c/250x250_80_a2", "", $json['body']['userIllusts'][$illustId]['url'])
+            str_replace(['/c/250x250_80_a2', '_square1200'], ['', '_master1200'], $json['body']['userIllusts'][$illustId]['url'])
                 ?? ''
         );
 

--- a/app/MetadataResolver/PixivResolver.php
+++ b/app/MetadataResolver/PixivResolver.php
@@ -63,7 +63,10 @@ class PixivResolver implements Resolver
 
         $metadata->title = $json['body']['illustTitle'] ?? '';
         $metadata->description = '投稿者: ' . $json['body']['userName'] . PHP_EOL . strip_tags(str_replace('<br />', PHP_EOL, $json['body']['illustComment'] ?? ''));
-        $metadata->image = $this->proxize($json['body']['urls']['regular'] ?? '');
+        $metadata->image = $this->proxize(
+            str_replace("/c/250x250_80_a2", "", $json['body']['userIllusts'][$illustId]['url'])
+                ?? ''
+        );
 
         // ページ数の指定がある場合は画像URLをそのページにする
         if ($page != 0) {

--- a/app/MetadataResolver/PixivResolver.php
+++ b/app/MetadataResolver/PixivResolver.php
@@ -64,7 +64,11 @@ class PixivResolver implements Resolver
         $metadata->title = $json['body']['illustTitle'] ?? '';
         $metadata->description = '投稿者: ' . $json['body']['userName'] . PHP_EOL . strip_tags(str_replace('<br />', PHP_EOL, $json['body']['illustComment'] ?? ''));
         $metadata->image = $this->proxize(
-            str_replace(['/c/250x250_80_a2', '_square1200'], ['', '_master1200'], $json['body']['userIllusts'][$illustId]['url'])
+            str_replace(
+                ['/c/250x250_80_a2/', '/custom-thumb/', '_square1200', '_custom1200'],
+                ['/', '/img-master/', '_master1200', '_master1200'],
+                $json['body']['userIllusts'][$illustId]['url']
+            )
                 ?? ''
         );
 


### PR DESCRIPTION
コードの通り、非ログイン時に表示できない（R18やセンシティブが設定されている）投稿だとurlが出てこなくなったので解決できてなかったが、userIllustsには入っていることがわかったのでそれを使うようにして修正

指定した投稿の情報が必ずしもuserIllustsに含まれているかは解らないがいくつか試した限りでは取れていそうだった

問題が起きても空文字列になるだけなら困ることもなさそう（そうするにはtry-catchが必要？）

---
56ffa1b で直したcustom-thumbは詳細不明。いくつかの投稿で使われていた

例
- `https://www.pixiv.net/artworks/78644857`
- `https://www.pixiv.net/artworks/77561578`