### PR TITLE
docker/production: tissue-phpの起動時にキャッシュを作成する

### DIFF
--- a/docker/production/bin/tissue-php-entrypoint
+++ b/docker/production/bin/tissue-php-entrypoint
@@ -9,4 +9,9 @@ install -o www-data -g www-data -m 0755 -d \
     $STORAGE/framework{,/cache,/cache/data,/sessions,/views} \
     $STORAGE/logs
 
+# optimize
+php artisan config:cache
+#php artisan route:cache
+php artisan view:cache
+
 exec docker-php-entrypoint "$@"

--- a/docker/production/php.dockerfile
+++ b/docker/production/php.dockerfile
@@ -14,5 +14,6 @@ COPY --from=foundation --chown=www-data:www-data /app /app
 COPY ./docker/production/bin/tissue-php-entrypoint /usr/local/bin/
 COPY ./docker/production/config/php.ini "$PHP_INI_DIR/php.ini"
 
+WORKDIR /app
 ENTRYPOINT ["tissue-php-entrypoint"]
 CMD ["php-fpm"]


### PR DESCRIPTION
fix #1110 

tissue-phpの起動時に `config:cache` と `view:cache` を実行するようにしました。

コンテナビルド時にやってしまうと必要な環境変数が読めない (config)、出力先に意味が無い (view) などの問題があるため、たぶんここにしか入れられないはず?