### PR TITLE
Open IconicからTabler Iconsに入れ替え

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "laravel-mix": "^6.0.49",
     "laravel-mix-bundle-analyzer": "^1.0.2",
     "lint-staged": "^10.5.3",
-    "open-iconic": "^1.1.1",
     "popper.js": "^1.14.7",
     "postcss": "^8.4.38",
     "postcss-scss": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@babel/preset-react": "^7.24.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
+    "@tabler/icons-webfont": "^2.44.0",
     "@tanstack/react-query": "^4.0.0",
     "@tanstack/react-query-devtools": "^4.0.0",
     "@types/bootstrap": "^4.5.0",

--- a/resources/assets/js/app.ts
+++ b/resources/assets/js/app.ts
@@ -57,7 +57,7 @@ $(() => {
                 })
                 .then((data) => {
                     $this.data('liked', false);
-                    $this.find('.oi-heart').removeClass('text-danger');
+                    $this.find('.ti-heart-filled').removeClass('text-danger');
 
                     const count = data.ejaculation ? data.ejaculation.likes_count : 0;
                     $this.find('.like-count').text(count ? count : '');
@@ -76,7 +76,7 @@ $(() => {
                 })
                 .then((data) => {
                     $this.data('liked', true);
-                    $this.find('.oi-heart').addClass('text-danger');
+                    $this.find('.ti-heart-filled').addClass('text-danger');
 
                     const count = data.ejaculation ? data.ejaculation.likes_count : 0;
                     $this.find('.like-count').text(count ? count : '');

--- a/resources/assets/js/collect.tsx
+++ b/resources/assets/js/collect.tsx
@@ -128,7 +128,7 @@ const CollectForm = () => {
                 <div className="form-group col-sm-12">
                     <div className="d-flex justify-content-between">
                         <label htmlFor="collection">
-                            <span className="oi oi-folder" /> 追加先
+                            <i className="ti ti-folder" /> 追加先
                         </label>
                         <button
                             className="btn btn-link p-0 mb-2"
@@ -157,7 +157,7 @@ const CollectForm = () => {
             <div className="form-row">
                 <div className="form-group col-sm-12">
                     <label htmlFor="link">
-                        <span className="oi oi-link-intact" /> オカズリンク
+                        <i className="ti ti-link" /> オカズリンク
                     </label>
                     <input
                         type="text"
@@ -183,7 +183,7 @@ const CollectForm = () => {
             <div className="form-row">
                 <div className="form-group col-sm-12">
                     <label htmlFor="tagInput">
-                        <span className="oi oi-tags" /> タグ
+                        <i className="ti ti-tags" /> タグ
                     </label>
                     <TagInput
                         id="tagInput"
@@ -199,7 +199,7 @@ const CollectForm = () => {
             <div className="form-row">
                 <div className="form-group col-sm-12">
                     <label htmlFor="note">
-                        <span className="oi oi-comment-square" /> ノート
+                        <i className="ti ti-message-circle" /> ノート
                     </label>
                     <textarea
                         id="note"

--- a/resources/assets/js/components/CheckinForm.tsx
+++ b/resources/assets/js/components/CheckinForm.tsx
@@ -50,7 +50,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
                 )}
                 <div className="form-group col-sm-6">
                     <label htmlFor="date">
-                        <span className="oi oi-calendar" /> 日付
+                        <i className="ti ti-calendar-event" /> 日付
                     </label>
                     <input
                         type="text"
@@ -70,7 +70,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
                 </div>
                 <div className="form-group col-sm-6">
                     <label htmlFor="time">
-                        <span className="oi oi-clock" /> 時刻
+                        <i className="ti ti-clock" /> 時刻
                     </label>
                     <input
                         type="text"
@@ -93,7 +93,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
             <div className="form-row">
                 <div className="form-group col-sm-12">
                     <label htmlFor="tagInput">
-                        <span className="oi oi-tags" /> タグ
+                        <i className="ti ti-tags" /> タグ
                     </label>
                     <TagInput
                         id="tagInput"
@@ -109,7 +109,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
             <div className="form-row">
                 <div className="form-group col-sm-12">
                     <label htmlFor="link">
-                        <span className="oi oi-link-intact" /> オカズリンク
+                        <span className="ti ti-link" /> オカズリンク
                     </label>
                     <input
                         type="text"
@@ -130,7 +130,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
             <div className="form-row">
                 <div className="form-group col-sm-12">
                     <label htmlFor="note">
-                        <span className="oi oi-comment-square" /> ノート
+                        <span className="ti ti-message-circle" /> ノート
                     </label>
                     <textarea
                         id="note"
@@ -154,7 +154,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
                         checked={isPrivate}
                         onChange={(v) => setPrivate(v)}
                     >
-                        <span className="oi oi-lock-locked" /> このチェックインを非公開にする
+                        <span className="ti ti-lock" /> このチェックインを非公開にする
                     </CheckBox>
                     <CheckBox
                         id="isTooSensitive"
@@ -163,7 +163,8 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
                         checked={isTooSensitive}
                         onChange={(v) => setTooSensitive(v)}
                     >
-                        <span className="oi oi-warning" /> チェックイン対象のオカズをより過激なオカズとして設定する
+                        <span className="ti ti-alert-triangle" />{' '}
+                        チェックイン対象のオカズをより過激なオカズとして設定する
                     </CheckBox>
                     <CheckBox
                         id="discardElapsedTime"
@@ -172,7 +173,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
                         checked={discardElapsedTime}
                         onChange={(v) => setDiscardElapsedTime(v)}
                     >
-                        <span className="oi oi-timer" /> 前回チェックインからの経過時間を記録しない
+                        <span className="ti ti-clock-x" /> 前回チェックインからの経過時間を記録しない
                         <br />
                         <small className="form-text text-muted">
                             長期間お使いにならなかった場合など、経過時間に意味が無い時のリセット用オプションです。

--- a/resources/assets/js/components/CheckinForm.tsx
+++ b/resources/assets/js/components/CheckinForm.tsx
@@ -109,7 +109,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
             <div className="form-row">
                 <div className="form-group col-sm-12">
                     <label htmlFor="link">
-                        <span className="ti ti-link" /> オカズリンク
+                        <i className="ti ti-link" /> オカズリンク
                     </label>
                     <input
                         type="text"
@@ -130,7 +130,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
             <div className="form-row">
                 <div className="form-group col-sm-12">
                     <label htmlFor="note">
-                        <span className="ti ti-message-circle" /> ノート
+                        <i className="ti ti-message-circle" /> ノート
                     </label>
                     <textarea
                         id="note"
@@ -154,7 +154,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
                         checked={isPrivate}
                         onChange={(v) => setPrivate(v)}
                     >
-                        <span className="ti ti-lock" /> このチェックインを非公開にする
+                        <i className="ti ti-lock" /> このチェックインを非公開にする
                     </CheckBox>
                     <CheckBox
                         id="isTooSensitive"
@@ -163,8 +163,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
                         checked={isTooSensitive}
                         onChange={(v) => setTooSensitive(v)}
                     >
-                        <span className="ti ti-alert-triangle" />{' '}
-                        チェックイン対象のオカズをより過激なオカズとして設定する
+                        <i className="ti ti-alert-triangle" /> チェックイン対象のオカズをより過激なオカズとして設定する
                     </CheckBox>
                     <CheckBox
                         id="discardElapsedTime"
@@ -173,7 +172,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
                         checked={discardElapsedTime}
                         onChange={(v) => setDiscardElapsedTime(v)}
                     >
-                        <span className="ti ti-clock-x" /> 前回チェックインからの経過時間を記録しない
+                        <i className="ti ti-clock-x" /> 前回チェックインからの経過時間を記録しない
                         <br />
                         <small className="form-text text-muted">
                             長期間お使いにならなかった場合など、経過時間に意味が無い時のリセット用オプションです。

--- a/resources/assets/js/components/MetadataPreview.tsx
+++ b/resources/assets/js/components/MetadataPreview.tsx
@@ -36,7 +36,7 @@ const MetadataLoading = () => (
         <div className="col-12">
             <div className="card-body">
                 <h6 className="card-title text-center font-weight-bold text-info">
-                    <span className="oi oi-loop-circular" /> オカズの情報を読み込んでいます…
+                    <i className="ti ti-loader" /> オカズの情報を読み込んでいます…
                 </h6>
             </div>
         </div>
@@ -48,7 +48,7 @@ const MetadataLoadFailed = () => (
         <div className="col-12">
             <div className="card-body">
                 <h6 className="card-title text-center font-weight-bold text-danger">
-                    <span className="oi oi-circle-x" /> オカズの情報を読み込めませんでした
+                    <i className="ti ti-circle-x" /> オカズの情報を読み込めませんでした
                 </h6>
             </div>
         </div>
@@ -138,7 +138,7 @@ export const MetadataPreview: React.FC<MetadataPreviewProps> = ({ link, tags, on
                                                         className={tagClasses(tag)}
                                                         onClick={() => !tag.used && onClickTag(tag.name)}
                                                     >
-                                                        <span className="oi oi-tag" /> {tag.name}
+                                                        <i className="ti ti-tag" /> {tag.name}
                                                     </li>
                                                 ))}
                                             </ul>

--- a/resources/assets/js/components/TagInput.tsx
+++ b/resources/assets/js/components/TagInput.tsx
@@ -60,7 +60,7 @@ export const TagInput: React.FC<TagInputProps> = ({ id, name, values, isInvalid,
                         className={classNames('list-inline-item', 'badge', 'badge-primary', 'tis-tag-input-item')}
                         onClick={() => removeTag(i)}
                     >
-                        <span className="oi oi-tag" /> {tag} | x
+                        <i className="ti ti-tag" /> {tag} | x
                     </li>
                 ))}
                 <li className="list-inline-item">

--- a/resources/assets/js/components/collections/AddToCollectionButton.tsx
+++ b/resources/assets/js/components/collections/AddToCollectionButton.tsx
@@ -10,8 +10,8 @@ import {
 } from './CollectionEditModal';
 
 const ToggleButton = React.forwardRef<HTMLButtonElement>((props, ref) => (
-    <Button {...props} ref={ref} variant="link" className="text-secondary">
-        <span className="oi oi-plus" />
+    <Button {...props} ref={ref} variant="" className="text-secondary">
+        <i className="ti ti-folder-plus" />
     </Button>
 ));
 ToggleButton.displayName = 'ToggleButton';
@@ -110,7 +110,7 @@ export const AddToCollectionButton: React.FC<AddToCollectionButtonProps> = ({
                         ))}
                         <Dropdown.Divider />
                         <Dropdown.Item eventKey="new">
-                            <span className="oi oi-plus mr-2 text-secondary" />
+                            <i className="ti ti-plus mr-2 text-secondary" />
                             新しいコレクションに追加
                         </Dropdown.Item>
                     </>

--- a/resources/assets/js/components/collections/CollectionEditModal.tsx
+++ b/resources/assets/js/components/collections/CollectionEditModal.tsx
@@ -88,7 +88,7 @@ export const CollectionEditModal: React.FC<CollectionEditModalProps> = ({
                     <div className="form-row">
                         <div className="form-group col-sm-12">
                             <label htmlFor="title">
-                                <span className="oi oi-folder" /> タイトル
+                                <i className="ti ti-folder" /> タイトル
                             </label>
                             <input
                                 type="text"
@@ -105,7 +105,7 @@ export const CollectionEditModal: React.FC<CollectionEditModalProps> = ({
                     <div className="form-row">
                         <div className="form-group col-sm-12">
                             <p className="mb-1">
-                                <span className="oi oi-eye" /> 公開設定
+                                <i className="ti ti-eye" /> 公開設定
                             </p>
                             <Form.Check
                                 custom

--- a/resources/assets/js/user/collection.tsx
+++ b/resources/assets/js/user/collection.tsx
@@ -239,7 +239,7 @@ const CollectionItem: React.FC<CollectionItemProps> = ({ item, onUpdate }) => {
                         {item.tags.map((tag: string) => (
                             <a
                                 key={tag}
-                                className="tis-checkin-tag"
+                                className="badge badge-secondary"
                                 href={`/search/collection?q=${encodeURIComponent(tag)}`}
                             >
                                 {tag}

--- a/resources/assets/js/user/collection.tsx
+++ b/resources/assets/js/user/collection.tsx
@@ -237,8 +237,11 @@ const CollectionItem: React.FC<CollectionItemProps> = ({ item, onUpdate }) => {
                     <i className="ti ti-tag mr-1" style={{ marginTop: '0.25rem' }} />
                     <p className="tis-checkin-tags mb-0">
                         {item.tags.map((tag: string) => (
-                            <a key={tag} href={`/search/collection?q=${encodeURIComponent(tag)}`}>
-                                <span style={{ opacity: 0.7 }}>#</span>
+                            <a
+                                key={tag}
+                                className="tis-checkin-tag"
+                                href={`/search/collection?q=${encodeURIComponent(tag)}`}
+                            >
                                 {tag}
                             </a>
                         ))}

--- a/resources/assets/js/user/collection.tsx
+++ b/resources/assets/js/user/collection.tsx
@@ -112,7 +112,7 @@ const ItemEditModal: React.FC<ItemEditModalProps> = ({ item, onUpdate, show, onH
                     <div className="form-row">
                         <div className="form-group col-sm-12">
                             <label htmlFor="link">
-                                <span className="oi oi-link-intact" /> オカズリンク
+                                <i className="ti ti-link" /> オカズリンク
                             </label>
                             <input
                                 type="text"
@@ -133,7 +133,7 @@ const ItemEditModal: React.FC<ItemEditModalProps> = ({ item, onUpdate, show, onH
                     <div className="form-row">
                         <div className="form-group col-sm-12">
                             <label htmlFor="tagInput">
-                                <span className="oi oi-tags" /> タグ
+                                <i className="ti ti-tags" /> タグ
                             </label>
                             <TagInput
                                 id="tagInput"
@@ -151,7 +151,7 @@ const ItemEditModal: React.FC<ItemEditModalProps> = ({ item, onUpdate, show, onH
                     <div className="form-row">
                         <div className="form-group col-sm-12">
                             <label htmlFor="note">
-                                <span className="oi oi-comment-square" /> ノート
+                                <i className="ti ti-message-circle" /> ノート
                             </label>
                             <textarea
                                 id="note"
@@ -226,7 +226,7 @@ const CollectionItem: React.FC<CollectionItemProps> = ({ item, onUpdate }) => {
             <div className="row mx-0">
                 <LinkCard link={item.link} />
                 <p className="d-flex align-items-baseline mb-2 col-12 px-0">
-                    <span className="oi oi-link-intact mr-1" />
+                    <i className="ti ti-link mr-1" />
                     <a className="overflow-hidden" href={item.link} target="_blank" rel="noopener noreferrer">
                         {item.link}
                     </a>
@@ -240,7 +240,7 @@ const CollectionItem: React.FC<CollectionItemProps> = ({ item, onUpdate }) => {
                             className="badge badge-secondary"
                             href={`/search/collection?q=${encodeURIComponent(tag)}`}
                         >
-                            <span className="oi oi-tag" /> {tag}
+                            <i className="ti ti-tag" /> {tag}
                         </a>
                     ))}
                 </p>
@@ -255,10 +255,10 @@ const CollectionItem: React.FC<CollectionItemProps> = ({ item, onUpdate }) => {
                 >
                     <button
                         type="button"
-                        className="btn btn-link text-secondary"
+                        className="btn text-secondary"
                         onClick={() => (location.href = item.checkin_url)}
                     >
-                        <span className="oi oi-check" />
+                        <i className="ti ti-send" />
                     </button>
                 </OverlayTrigger>
                 {me && (
@@ -275,21 +275,17 @@ const CollectionItem: React.FC<CollectionItemProps> = ({ item, onUpdate }) => {
                 {username === me?.name && (
                     <>
                         <OverlayTrigger placement="bottom" overlay={<Tooltip id={`edit_${item.id}`}>編集</Tooltip>}>
-                            <button
-                                type="button"
-                                className="btn btn-link text-secondary"
-                                onClick={() => setShowEditModal(true)}
-                            >
-                                <span className="oi oi-pencil" />
+                            <button type="button" className="btn text-secondary" onClick={() => setShowEditModal(true)}>
+                                <i className="ti ti-edit" />
                             </button>
                         </OverlayTrigger>
                         <OverlayTrigger placement="bottom" overlay={<Tooltip id={`delete_${item.id}`}>削除</Tooltip>}>
                             <button
                                 type="button"
-                                className="btn btn-link text-secondary"
+                                className="btn text-secondary"
                                 onClick={() => setShowDeleteModal(true)}
                             >
-                                <span className="oi oi-trash" />
+                                <i className="ti ti-trash" />
                             </button>
                         </OverlayTrigger>
                     </>
@@ -390,12 +386,12 @@ const CollectionHeader: React.FC<CollectionHeaderProps> = ({ collection, onUpdat
                     <p className="mb-3">
                         {collection.is_private ? (
                             <small className="text-secondary">
-                                <span className="oi oi-lock-locked mr-1" />
+                                <i className="ti ti-lock mr-1" />
                                 非公開コレクション
                             </small>
                         ) : (
                             <small className="text-secondary">
-                                <span className="oi oi-lock-unlocked mr-1" />
+                                <i className="ti ti-lock-open mr-1" />
                                 公開コレクション
                             </small>
                         )}
@@ -409,7 +405,7 @@ const CollectionHeader: React.FC<CollectionHeaderProps> = ({ collection, onUpdat
                             size="sm"
                             href={`/collect?collection=${collection.id}`}
                         >
-                            <span className="oi oi-plus mr-2" />
+                            <i className="ti ti-plus mr-2" />
                             オカズを追加
                         </Button>
                         <Button
@@ -418,11 +414,11 @@ const CollectionHeader: React.FC<CollectionHeaderProps> = ({ collection, onUpdat
                             size="sm"
                             onClick={() => setShowEditModal(true)}
                         >
-                            <span className="oi oi-wrench mr-2" />
+                            <i className="ti ti-edit mr-2" />
                             設定
                         </Button>
                         <Button variant="outline-secondary" size="sm" onClick={() => setShowDeleteModal(true)}>
-                            <span className="oi oi-trash mr-2" />
+                            <i className="ti ti-trash mr-2" />
                             削除
                         </Button>
                     </div>

--- a/resources/assets/js/user/collection.tsx
+++ b/resources/assets/js/user/collection.tsx
@@ -234,14 +234,11 @@ const CollectionItem: React.FC<CollectionItemProps> = ({ item, onUpdate }) => {
             </div>
             {item.tags.length !== 0 && (
                 <p className="d-flex mb-2">
-                    <i className="ti ti-tag mr-1" style={{ marginTop: '0.2rem' }} />
+                    <i className="ti ti-tag mr-1" style={{ marginTop: '0.25rem' }} />
                     <p className="tis-checkin-tags mb-0">
                         {item.tags.map((tag: string) => (
-                            <a
-                                key={tag}
-                                className="badge badge-secondary"
-                                href={`/search/collection?q=${encodeURIComponent(tag)}`}
-                            >
+                            <a key={tag} href={`/search/collection?q=${encodeURIComponent(tag)}`}>
+                                <span style={{ opacity: 0.7 }}>#</span>
                                 {tag}
                             </a>
                         ))}

--- a/resources/assets/js/user/collection.tsx
+++ b/resources/assets/js/user/collection.tsx
@@ -233,16 +233,19 @@ const CollectionItem: React.FC<CollectionItemProps> = ({ item, onUpdate }) => {
                 </p>
             </div>
             {item.tags.length !== 0 && (
-                <p className="tis-checkin-tags mb-2">
-                    {item.tags.map((tag: string) => (
-                        <a
-                            key={tag}
-                            className="badge badge-secondary"
-                            href={`/search/collection?q=${encodeURIComponent(tag)}`}
-                        >
-                            <i className="ti ti-tag" /> {tag}
-                        </a>
-                    ))}
+                <p className="d-flex mb-2">
+                    <i className="ti ti-tag mr-1" style={{ marginTop: '0.2rem' }} />
+                    <p className="tis-checkin-tags mb-0">
+                        {item.tags.map((tag: string) => (
+                            <a
+                                key={tag}
+                                className="badge badge-secondary"
+                                href={`/search/collection?q=${encodeURIComponent(tag)}`}
+                            >
+                                {tag}
+                            </a>
+                        ))}
+                    </p>
                 </p>
             )}
             {item.note_html != '' && (

--- a/resources/assets/js/user/collections.tsx
+++ b/resources/assets/js/user/collections.tsx
@@ -106,7 +106,7 @@ const Sidebar: React.FC<SidebarProps> = ({ collections }) => {
                             title="追加"
                             onClick={() => setShowCreateModal(true)}
                         >
-                            <i className="ti ti-plus font-weight-normal text-large" />
+                            <i className="ti ti-plus text-large" />
                         </Button>
                     )}
                     <Button
@@ -117,9 +117,9 @@ const Sidebar: React.FC<SidebarProps> = ({ collections }) => {
                         onClick={() => setOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'))}
                     >
                         {order === 'asc' ? (
-                            <i className="ti ti-sort-ascending-letters font-weight-normal text-large"></i>
+                            <i className="ti ti-sort-ascending-letters text-large"></i>
                         ) : (
-                            <i className="ti ti-sort-descending-letters font-weight-normal text-large"></i>
+                            <i className="ti ti-sort-descending-letters text-large"></i>
                         )}
                     </Button>
                 </div>

--- a/resources/assets/js/user/collections.tsx
+++ b/resources/assets/js/user/collections.tsx
@@ -29,6 +29,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({ collection }) => {
             to={`/user/${collection.user_name}/collections/${collection.id}`}
             className={classNames(
                 'list-group-item',
+                'list-group-item-action',
                 'd-flex',
                 'justify-content-between',
                 'align-items-center',
@@ -36,7 +37,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({ collection }) => {
             )}
         >
             <div style={{ wordBreak: 'break-all' }}>
-                <span className={classNames('oi', 'oi-folder', 'mr-1', { 'text-secondary': !isSelected })} />
+                <i className={classNames('ti', 'ti-folder', 'mr-1', { 'text-secondary': !isSelected })} />
                 {collection.title}
             </div>
         </Link>
@@ -99,26 +100,26 @@ const Sidebar: React.FC<SidebarProps> = ({ collections }) => {
                 <div>
                     {username === me?.name && (
                         <Button
-                            variant="link"
+                            variant=""
                             className="text-secondary mr-2"
                             size="sm"
                             title="追加"
                             onClick={() => setShowCreateModal(true)}
                         >
-                            <span className="oi oi-plus" />
+                            <i className="ti ti-plus font-weight-normal text-large" />
                         </Button>
                     )}
                     <Button
-                        variant="link"
+                        variant=""
                         className="text-secondary"
                         size="sm"
                         title="並べ替え"
                         onClick={() => setOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'))}
                     >
                         {order === 'asc' ? (
-                            <span className="oi oi-sort-ascending"></span>
+                            <i className="ti ti-sort-ascending-letters font-weight-normal text-large"></i>
                         ) : (
-                            <span className="oi oi-sort-descending"></span>
+                            <i className="ti ti-sort-descending-letters font-weight-normal text-large"></i>
                         )}
                     </Button>
                 </div>
@@ -157,7 +158,7 @@ const Collections: React.FC = () => {
                 <div className="col-lg-8">
                     {collectionsQuery.error?.response?.status === 403 ? (
                         <p className="mt-4">
-                            <span className="oi oi-lock-locked" /> このユーザはチェックイン履歴を公開していません。
+                            <i className="ti ti-lock" /> このユーザはチェックイン履歴を公開していません。
                         </p>
                     ) : (
                         <Outlet />

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -4,9 +4,6 @@ $primary: #e53fb1;
 // Bootstrap
 @import "~bootstrap/scss/bootstrap";
 
-// Open Iconic
-@import "~open-iconic/font/css/open-iconic-bootstrap";
-
 // Tabler Icons
 @import "~@tabler/icons-webfont/tabler-icons";
 .ti {

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -7,6 +7,12 @@ $primary: #e53fb1;
 // Open Iconic
 @import "~open-iconic/font/css/open-iconic-bootstrap";
 
+// Tabler Icons
+@import "~@tabler/icons-webfont/tabler-icons";
+.ti {
+    font-weight: 700;
+}
+
 // Legacy app styles
 @import "tissue.css";
 

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -6,9 +6,6 @@ $primary: #e53fb1;
 
 // Tabler Icons
 @import "~@tabler/icons-webfont/tabler-icons";
-.ti {
-    font-weight: 700;
-}
 
 // Legacy app styles
 @import "tissue.css";

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,4 +1,4 @@
-// Bootstrap Variable Overlide
+// Bootstrap Variable Override
 $primary: #e53fb1;
 
 // Bootstrap
@@ -44,4 +44,8 @@ $primary: #e53fb1;
     color: #fff;
     background-color: #e53fb1;
     border-radius: 0.5rem;
+}
+
+.text-large {
+    font-size: large;
 }

--- a/resources/assets/sass/components/_ejaculation.scss
+++ b/resources/assets/sass/components/_ejaculation.scss
@@ -1,7 +1,15 @@
 .ejaculation-actions {
-  & > :not(:last-child) {
-    margin-right: 24px;
-  }
+    button {
+        font-size: 1.4em;
+
+        & > i {
+            font-weight: normal;
+        }
+    }
+
+    & > :not(:last-child) {
+        margin-right: 16px;
+    }
 }
 
 .like-button {
@@ -47,9 +55,5 @@
         text-align: left;
         word-break: break-all;
         white-space: normal;
-
-        & > .oi-flash {
-            top: 2px;
-        }
     }
 }

--- a/resources/assets/sass/components/_ejaculation.scss
+++ b/resources/assets/sass/components/_ejaculation.scss
@@ -1,8 +1,7 @@
 .ejaculation-actions {
     button {
-        font-size: 1.4em;
-
         & > i {
+            font-size: 1.4em;
             font-weight: normal;
         }
     }
@@ -18,6 +17,7 @@
 
 .like-count:not(:empty) {
   padding-left: 0.5rem;
+  vertical-align: top;
 }
 
 .like-users {

--- a/resources/assets/sass/components/_ejaculation.scss
+++ b/resources/assets/sass/components/_ejaculation.scss
@@ -45,7 +45,7 @@
 .tis-checkin-tags {
     display: flex;
     flex-wrap: wrap;
-    gap: .6ch 1ch;
+    gap: .6ch;
 
     & > .badge {
         max-width: 100%;
@@ -54,12 +54,5 @@
         text-align: left;
         word-break: break-all;
         white-space: normal;
-    }
-}
-
-.tis-checkin-tag {
-    &::before {
-        content: '#';
-        opacity: .6;
     }
 }

--- a/resources/assets/sass/components/_ejaculation.scss
+++ b/resources/assets/sass/components/_ejaculation.scss
@@ -2,7 +2,6 @@
     button {
         & > i {
             font-size: 1.4em;
-            font-weight: normal;
         }
     }
 

--- a/resources/assets/sass/components/_ejaculation.scss
+++ b/resources/assets/sass/components/_ejaculation.scss
@@ -45,7 +45,7 @@
 .tis-checkin-tags {
     display: flex;
     flex-wrap: wrap;
-    gap: .6ch;
+    gap: .6ch 1ch;
 
     & > .badge {
         max-width: 100%;
@@ -54,5 +54,12 @@
         text-align: left;
         word-break: break-all;
         white-space: normal;
+    }
+}
+
+.tis-checkin-tag {
+    &::before {
+        content: '#';
+        opacity: .6;
     }
 }

--- a/resources/views/admin/info/index.blade.php
+++ b/resources/views/admin/info/index.blade.php
@@ -22,7 +22,7 @@
                 <tr>
                     <td>
                         @if ($info->pinned)
-                            <span class="badge badge-secondary"><span class="oi oi-pin"></span>ピン留め</span>
+                            <span class="badge badge-secondary"><i class="ti ti-pinned-filled"></i>ピン留め</span>
                         @endif
                         <span class="badge {{ $categories[$info->category]['class'] }}">{{ $categories[$info->category]['label'] }}</span>
                     </td>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -12,7 +12,7 @@
                 {{ csrf_field() }}
 
                 <div class="form-group">
-                    <label for="email"><span class="oi oi-envelope-closed"></span> メールアドレス</label>
+                    <label for="email"><i class="ti ti-mail"></i> メールアドレス</label>
                     <input id="email" name="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" type="email" value="{{ old('email') }}" required autofocus>
 
                     @if ($errors->has('email'))
@@ -20,7 +20,7 @@
                     @endif
                 </div>
                 <div class="form-group">
-                    <label for="password"><span class="oi oi-key"></span> パスワード</label>
+                    <label for="password"><i class="ti ti-key"></i> パスワード</label>
                     <input id="password" name="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" type="password" required>
 
                     @if ($errors->has('password'))

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -15,7 +15,7 @@
                 {{ csrf_field() }}
 
                 <div class="form-group">
-                    <label for="email"><span class="oi oi-envelope-closed"></span> メールアドレス</label>
+                    <label for="email"><i class="ti ti-mail"></i> メールアドレス</label>
                     <input id="email" name="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" type="email" value="{{ old('email') }}" required autofocus>
 
                     @if ($errors->has('email'))

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -17,7 +17,7 @@
                 <input type="hidden" name="token" value="{{ $token }}">
 
                 <div class="form-group">
-                    <label for="email"><span class="oi oi-envelope-closed"></span> メールアドレス</label>
+                    <label for="email"><i class="ti ti-mail"></i> メールアドレス</label>
                     <input id="email" name="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" type="email" value="{{ old('email') }}" required>
 
                     @if ($errors->has('email'))
@@ -25,7 +25,7 @@
                     @endif
                 </div>
                 <div class="form-group">
-                    <label for="password"><span class="oi oi-key"></span> パスワード</label>
+                    <label for="password"><i class="ti ti-key"></i> パスワード</label>
                     <input id="password" name="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" type="password" required>
 
                     @if ($errors->has('password'))

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -22,7 +22,7 @@
                 {{ csrf_field() }}
 
                 <div class="form-group">
-                    <label for="name"><span class="oi oi-person"></span> ユーザー名</label>
+                    <label for="name"><i class="ti ti-user"></i> ユーザー名</label>
                     <input id="name" name="name" class="form-control{{ $errors->has('name') ? ' is-invalid' : '' }}" type="text" value="{{ old('name') }}" required>
                     <small class="form-text text-muted">半角英数字と一部記号が使用できます。一度決めたら変更できません。</small>
 
@@ -31,7 +31,7 @@
                     @endif
                 </div>
                 <div class="form-group">
-                    <label for="email"><span class="oi oi-envelope-closed"></span> メールアドレス</label>
+                    <label for="email"><i class="ti ti-mail"></i> メールアドレス</label>
                     <input id="email" name="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" type="email" value="{{ old('email') }}" required>
 
                     @if ($errors->has('email'))
@@ -39,7 +39,7 @@
                     @endif
                 </div>
                 <div class="form-group">
-                    <label for="password"><span class="oi oi-key"></span> パスワード</label>
+                    <label for="password"><i class="ti ti-key"></i> パスワード</label>
                     <input id="password" name="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" type="password" required>
 
                     @if ($errors->has('password'))

--- a/resources/views/components/ejaculation.blade.php
+++ b/resources/views/components/ejaculation.blade.php
@@ -17,13 +17,13 @@
 @if ($ejaculation->is_private || $ejaculation->source === 'csv' || $ejaculation->tags->isNotEmpty())
     <p class="tis-checkin-tags mb-2">
         @if ($ejaculation->is_private)
-            <span class="badge badge-warning"><span class="oi oi-lock-locked"></span> 非公開</span>
+            <span class="badge badge-warning"><i class="ti ti-lock"></i> 非公開</span>
         @endif
         @if ($ejaculation->source === 'csv')
-            <span class="badge badge-info"><span class="oi oi-cloud-upload"></span> インポート</span>
+            <span class="badge badge-info"><i class="ti ti-cloud-upload"></i> インポート</span>
         @endif
         @foreach ($ejaculation->tags as $tag)
-            <a class="badge badge-secondary" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag"></span> {{ $tag->name }}</a>
+            <a class="badge badge-secondary" href="{{ route('search', ['q' => $tag->name]) }}"><i class="ti ti-tag"></i> {{ $tag->name }}</a>
         @endforeach
     </p>
 @endif
@@ -34,7 +34,7 @@
             @component('components.link-card', ['link' => $ejaculation->link, 'is_too_sensitive' => $ejaculation->is_too_sensitive])
             @endcomponent
             <p class="d-flex align-items-baseline mb-2 col-12 px-0">
-                <span class="oi oi-link-intact mr-1"></span><a class="overflow-hidden" href="{{ $ejaculation->link }}" target="_blank" rel="noopener">{{ $ejaculation->link }}</a>
+                <i class="ti ti-link mr-1"></i><a class="overflow-hidden" href="{{ $ejaculation->link }}" target="_blank" rel="noopener">{{ $ejaculation->link }}</a>
             </p>
         </div>
     @endif
@@ -85,27 +85,27 @@
 @endif
 <!-- actions -->
 <div class="ejaculation-actions">
-    <button type="button" class="btn btn-link text-secondary"
+    <button type="button" class="btn text-secondary"
             data-toggle="tooltip" data-placement="bottom"
-            title="同じオカズでチェックイン" data-href="{{ $ejaculation->makeCheckinURL() }}"><span class="oi oi-reload"></span></button>
-    <button type="button" class="btn btn-link text-secondary like-button"
+            title="同じオカズでチェックイン" data-href="{{ $ejaculation->makeCheckinURL() }}"><i class="ti ti-reload"></i></button>
+    <button type="button" class="btn text-secondary like-button"
             data-toggle="tooltip" data-placement="bottom" data-trigger="hover"
-            title="いいね" data-id="{{ $ejaculation->id }}" data-liked="{{ (bool)$ejaculation->is_liked }}"><span class="oi oi-heart {{ $ejaculation->is_liked ? 'text-danger' : '' }}"></span><span class="like-count">{{ $ejaculation->likes_count ? $ejaculation->likes_count : '' }}</span></button>
+            title="いいね" data-id="{{ $ejaculation->id }}" data-liked="{{ (bool)$ejaculation->is_liked }}"><i class="ti ti-heart-filled {{ $ejaculation->is_liked ? 'text-danger' : '' }}"></i><span class="like-count">{{ $ejaculation->likes_count ? $ejaculation->likes_count : '' }}</span></button>
     @auth
         @if (!empty($ejaculation->link))
             <span class="add-to-collection-button" data-link="{{ $ejaculation->link }}" data-tags="{{ $ejaculation->textTags() }}">
-                <button type="button" class="btn btn-link text-secondary"
+                <button type="button" class="btn text-secondary"
                         data-toggle="tooltip" data-placement="bottom" data-trigger="hover"
-                        title="コレクションに追加"><span class="oi oi-plus"></span></button>
+                        title="コレクションに追加"><i class="ti ti-folder-plus"></i></button>
             </span>
         @endif
     @endauth
     @if ($ejaculation->user->isMe())
-        <button type="button" class="btn btn-link text-secondary"
+        <button type="button" class="btn text-secondary"
                 data-toggle="tooltip" data-placement="bottom"
-                title="修正" data-href="{{ route('checkin.edit', ['id' => $ejaculation->id]) }}"><span class="oi oi-pencil"></span></button>
-        <button type="button" class="btn btn-link text-secondary"
+                title="修正" data-href="{{ route('checkin.edit', ['id' => $ejaculation->id]) }}"><i class="ti ti-edit"></i></button>
+        <button type="button" class="btn text-secondary"
                 data-toggle="tooltip" data-placement="bottom"
-                title="削除" data-target="#deleteCheckinModal" data-id="{{ $ejaculation->id }}" data-date="{{ $ejaculation->ejaculated_date }}"><span class="oi oi-trash"></span></button>
+                title="削除" data-target="#deleteCheckinModal" data-id="{{ $ejaculation->id }}" data-date="{{ $ejaculation->ejaculated_date }}"><i class="ti ti-trash"></i></button>
     @endif
 </div>

--- a/resources/views/components/ejaculation.blade.php
+++ b/resources/views/components/ejaculation.blade.php
@@ -29,7 +29,7 @@
         <i class="ti ti-tag mr-1" style="margin-top: 0.25rem;"></i>
         <div class="tis-checkin-tags">
             @foreach ($ejaculation->tags as $tag)
-                <a href="{{ route('search', ['q' => $tag->name]) }}"><span style="opacity: 0.7;">#</span>{{ $tag->name }}</a>
+                <a class="tis-checkin-tag" href="{{ route('search', ['q' => $tag->name]) }}">{{ $tag->name }}</a>
             @endforeach
         </div>
     </div>

--- a/resources/views/components/ejaculation.blade.php
+++ b/resources/views/components/ejaculation.blade.php
@@ -14,7 +14,7 @@
     @endswitch
 </div>
 <!-- tags -->
-@if ($ejaculation->is_private || $ejaculation->source === 'csv' || $ejaculation->tags->isNotEmpty())
+@if ($ejaculation->is_private || $ejaculation->source === 'csv')
     <p class="tis-checkin-tags mb-2">
         @if ($ejaculation->is_private)
             <span class="badge badge-warning"><i class="ti ti-lock"></i> 非公開</span>
@@ -22,10 +22,17 @@
         @if ($ejaculation->source === 'csv')
             <span class="badge badge-info"><i class="ti ti-cloud-upload"></i> インポート</span>
         @endif
-        @foreach ($ejaculation->tags as $tag)
-            <a class="badge badge-secondary" href="{{ route('search', ['q' => $tag->name]) }}"><i class="ti ti-tag"></i> {{ $tag->name }}</a>
-        @endforeach
     </p>
+@endif
+@if ($ejaculation->tags->isNotEmpty())
+    <div class="d-flex mb-2">
+        <i class="ti ti-tag mr-1" style="margin-top: 0.25rem;"></i>
+        <div class="tis-checkin-tags">
+            @foreach ($ejaculation->tags as $tag)
+                <a href="{{ route('search', ['q' => $tag->name]) }}"><span style="opacity: 0.7;">#</span>{{ $tag->name }}</a>
+            @endforeach
+        </div>
+    </div>
 @endif
 <div class="{{ $ejaculation->isMuted() ? 'tis-checkin-muted' : '' }}">
     <!-- okazu link -->

--- a/resources/views/components/ejaculation.blade.php
+++ b/resources/views/components/ejaculation.blade.php
@@ -29,7 +29,7 @@
         <i class="ti ti-tag mr-1" style="margin-top: 0.25rem;"></i>
         <div class="tis-checkin-tags">
             @foreach ($ejaculation->tags as $tag)
-                <a class="tis-checkin-tag" href="{{ route('search', ['q' => $tag->name]) }}">{{ $tag->name }}</a>
+                <a class="badge badge-secondary" href="{{ route('search', ['q' => $tag->name]) }}">{{ $tag->name }}</a>
             @endforeach
         </div>
     </div>

--- a/resources/views/components/profile-bio.blade.php
+++ b/resources/views/components/profile-bio.blade.php
@@ -11,7 +11,7 @@
             {{-- URL --}}
             @if (!empty($user->url))
                 <p class="card-text d-flex mt-3">
-                    <span class="oi oi-link-intact mr-1 mt-1"></span>
+                    <i class="ti ti-link mr-1 mt-1"></i>
                     <a href="{{ $user->url }}" rel="me nofollow noopener" target="_blank" class="text-truncate">{{ preg_replace('~\Ahttps?://~', '', $user->url) }}</a>
                 </p>
             @endif

--- a/resources/views/components/profile-mini.blade.php
+++ b/resources/views/components/profile-mini.blade.php
@@ -7,7 +7,7 @@
         <div class="tis-profile-mini-name">
             <a class="text-muted" href="{{ route('user.profile', ['name' => $user->name]) }}">&commat;{{ $user->name }}</a>
             @if ($user->is_protected)
-                <span class="oi oi-lock-locked text-muted"></span>
+                <i class="ti ti-lock text-muted"></i>
             @endif
         </div>
     </div>

--- a/resources/views/components/profile-stats.blade.php
+++ b/resources/views/components/profile-stats.blade.php
@@ -1,4 +1,4 @@
-<h6 class="font-weight-bold"><span class="oi oi-timer"></span> 現在のセッション</h6>
+<h6 class="font-weight-bold"><i class="ti ti-clock-play"></i> 現在のセッション</h6>
 @if (isset($currentSession))
     <p class="card-text mb-0">{{ $currentSession }}経過</p>
     <p class="card-text">({{ $latestEjaculation->ejaculated_date->format('Y/m/d H:i') }} にリセット)</p>
@@ -7,7 +7,7 @@
     <p class="card-text">(一度チェックインすると始まります)</p>
 @endif
 
-<h6 class="font-weight-bold"><span class="oi oi-graph"></span> 概況</h6>
+<h6 class="font-weight-bold"><i class="ti ti-timeline"></i> 概況</h6>
 <table class="tis-profile-stats-table">
     <tr>
         <th>平均記録</th>

--- a/resources/views/components/profile.blade.php
+++ b/resources/views/components/profile.blade.php
@@ -7,7 +7,7 @@
         <h6 class="card-subtitle">
             <a class="text-muted font-weight-normal" href="{{ route('user.profile', ['name' => $user->name]) }}">&commat;{{ $user->name }}</a>
             @if ($user->is_protected)
-                <span class="oi oi-lock-locked text-muted"></span>
+                <i class="ti ti-lock text-muted"></i>
             @endif
         </h6>
 
@@ -21,7 +21,7 @@
         {{-- URL --}}
         @if (!empty($user->url))
             <p class="card-text d-flex mt-3">
-                <span class="oi oi-link-intact mr-1 mt-1"></span>
+                <i class="ti ti-link mr-1 mt-1"></i>
                 <a href="{{ $user->url }}" rel="me nofollow noopener" target="_blank" class="text-truncate">{{ preg_replace('~\Ahttps?://~', '', $user->url) }}</a>
             </p>
         @endif

--- a/resources/views/components/profile.blade.php
+++ b/resources/views/components/profile.blade.php
@@ -5,7 +5,7 @@
             <a class="text-dark" href="{{ route('user.profile', ['name' => $user->name]) }}">{{ $user->display_name }}</a>
         </h4>
         <h6 class="card-subtitle">
-            <a class="text-muted font-weight-normal" href="{{ route('user.profile', ['name' => $user->name]) }}">&commat;{{ $user->name }}</a>
+            <a class="text-muted" href="{{ route('user.profile', ['name' => $user->name]) }}">&commat;{{ $user->name }}</a>
             @if ($user->is_protected)
                 <i class="ti ti-lock text-muted"></i>
             @endif

--- a/resources/views/ejaculation/show.blade.php
+++ b/resources/views/ejaculation/show.blade.php
@@ -17,13 +17,13 @@
             @if ($user->is_protected && !$user->isMe())
                 <div class="card">
                     <div class="card-body">
-                        <span class="oi oi-lock-locked"></span> このユーザはチェックイン履歴を公開していません。
+                        <i class="ti ti-lock"></i> このユーザはチェックイン履歴を公開していません。
                     </div>
                 </div>
             @elseif ($ejaculation->is_private && !$user->isMe())
                 <div class="card">
                     <div class="card-body">
-                        <span class="oi oi-lock-locked"></span> 非公開チェックインのため、表示できません
+                        <i class="ti ti-lock"></i> 非公開チェックインのため、表示できません
                     </div>
                 </div>
             @else

--- a/resources/views/guest.blade.php
+++ b/resources/views/guest.blade.php
@@ -12,7 +12,7 @@
 <div class="container">
     <div class="row py-4">
         <div class="col-lg-4">
-            <h1 class="text-center text-secondary display-1"><span class="oi oi-pencil"></span></h1>
+            <h1 class="text-center text-secondary display-1"><span class="ti ti-ballpen font-weight-normal"></span></h1>
         </div>
         <div class="col-lg-8">
             <h4 class="text-center text-lg-left mb-4">思い出を残す</h4>
@@ -21,7 +21,7 @@
     </div>
     <div class="row py-4">
         <div class="col-lg-4">
-            <h1 class="text-center text-secondary display-1"><span class="oi oi-graph"></span></h1>
+            <h1 class="text-center text-secondary display-1"><i class="ti ti-timeline font-weight-normal"></i></h1>
         </div>
         <div class="col-lg-8">
             <h4 class="text-center text-lg-left mb-4">自分を知る</h4>
@@ -37,7 +37,7 @@
         @foreach($informations as $info)
             <a class="list-group-item" href="{{ route('info.show', ['id' => $info->id]) }}">
             @if ($info->pinned)
-                <span class="badge badge-secondary"><span class="oi oi-pin"></span>ピン留め</span>
+                <span class="badge badge-secondary"><i class="ti ti-pinned-filled"></i>ピン留め</span>
             @endif
                 <span class="badge {{ $categories[$info->category]['class'] }}">{{ $categories[$info->category]['label'] }}</span> {{ $info->title }} <small class="text-secondary">- {{ $info->created_at->format('n月j日') }}</small>
             </a>

--- a/resources/views/guest.blade.php
+++ b/resources/views/guest.blade.php
@@ -12,7 +12,7 @@
 <div class="container">
     <div class="row py-4">
         <div class="col-lg-4">
-            <h1 class="text-center text-secondary display-1"><span class="ti ti-ballpen font-weight-normal"></span></h1>
+            <h1 class="text-center text-secondary display-1"><span class="ti ti-ballpen"></span></h1>
         </div>
         <div class="col-lg-8">
             <h4 class="text-center text-lg-left mb-4">思い出を残す</h4>
@@ -21,7 +21,7 @@
     </div>
     <div class="row py-4">
         <div class="col-lg-4">
-            <h1 class="text-center text-secondary display-1"><i class="ti ti-timeline font-weight-normal"></i></h1>
+            <h1 class="text-center text-secondary display-1"><i class="ti ti-timeline"></i></h1>
         </div>
         <div class="col-lg-8">
             <h4 class="text-center text-lg-left mb-4">自分を知る</h4>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -21,7 +21,7 @@
                     @foreach($informations as $info)
                         <a class="list-group-item" href="{{ route('info.show', ['id' => $info->id]) }}">
                             @if ($info->pinned)
-                                <span class="badge badge-secondary"><span class="oi oi-pin"></span>ピン留め</span>
+                                <span class="badge badge-secondary"><i class="ti ti-pinned-filled"></i>ピン留め</span>
                             @endif
                             <span class="badge {{ $categories[$info->category]['class'] }}">{{ $categories[$info->category]['label'] }}</span> {{ $info->title }} <small class="text-secondary">- {{ $info->created_at->format('n月j日') }}</small>
                         </a>

--- a/resources/views/info/index.blade.php
+++ b/resources/views/info/index.blade.php
@@ -10,7 +10,7 @@
         @foreach($informations as $info)
         <a class="list-group-item border-bottom-only pt-3 pb-3" href="{{ route('info.show', ['id' => $info->id]) }}">
             @if ($info->pinned)
-                <span class="badge badge-secondary"><span class="oi oi-pin"></span>ピン留め</span>
+                <span class="badge badge-secondary"><i class="ti ti-pinned-filled"></i>ピン留め</span>
             @endif
             <span class="badge {{ $categories[$info->category]['class'] }}">{{ $categories[$info->category]['label'] }}</span> {{ $info->title }} <small class="text-secondary">- {{ $info->created_at->format('n月j日') }}</small>
         </a>

--- a/resources/views/info/show.blade.php
+++ b/resources/views/info/show.blade.php
@@ -13,9 +13,9 @@
     <h2><span class="badge {{ $category['class'] }}">{{ $category['label'] }}</span> {{ $info->title }}</h2>
     <p class="text-secondary">
         @if ($info->pinned)
-            <span class="badge badge-secondary"><span class="oi oi-pin"></span>ピン留め</span>
+            <span class="badge badge-secondary"><i class="ti ti-pinned-filled"></i>ピン留め</span>
         @endif
-        <span class="oi oi-calendar"></span> {{ $info->created_at->format('Y年n月j日') }}
+        <i class="ti ti-calendar-event"></i> {{ $info->created_at->format('Y年n月j日') }}
     </p>
     @parsedown($info->content)
 </div>

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -7,9 +7,9 @@
                 <div class="list-group mb-4">
                     <div class="list-group-item disabled font-weight-bold">管理</div>
                     <a class="list-group-item list-group-item-action {{ Route::is('admin.dashboard') ? 'active' : '' }}"
-                       href="{{ route('admin.dashboard') }}"><span class="oi oi-dashboard mr-1"></span> ダッシュボード</a>
+                       href="{{ route('admin.dashboard') }}"><i class="ti ti-dashboard mr-1"></i> ダッシュボード</a>
                     <a class="list-group-item list-group-item-action {{ Route::is('admin.info*') ? 'active' : '' }}"
-                       href="{{ route('admin.info') }}"><span class="oi oi-bullhorn mr-1"></span> お知らせ</a>
+                       href="{{ route('admin.info') }}"><i class="ti ti-speakerphone mr-1"></i> お知らせ</a>
                 </div>
             </div>
             <div class="tab-content col-lg-9">

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -73,7 +73,7 @@
                         <div class="input-group">
                             <input type="search" name="q" class="form-control" placeholder="検索..." value="{{ stripos(Route::currentRouteName(), 'search') === 0 ? $inputs['q'] : '' }}" required>
                             <div class="input-group-append">
-                                <button class="btn btn-outline-secondary" type="submit"><span class="oi oi-magnifying-glass" aria-hidden="true"></span><span class="sr-only">検索</span></button>
+                                <button class="btn btn-outline-secondary" type="submit"><i class="ti ti-search" aria-hidden="true"></i><span class="sr-only">検索</span></button>
                             </div>
                         </div>
                     </form>

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -118,7 +118,7 @@
                             <div class="input-group">
                                 <input type="search" name="q" class="form-control" placeholder="検索..." value="{{ stripos(Route::currentRouteName(), 'search') === 0 ? $inputs['q'] : '' }}" required>
                                 <div class="input-group-append">
-                                    <button class="btn btn-outline-secondary" type="submit"><span class="oi oi-magnifying-glass" aria-hidden="true"></span><span class="sr-only">検索</span></button>
+                                    <button class="btn btn-outline-secondary" type="submit"><i class="ti ti-search" aria-hidden="true"></i><span class="sr-only">検索</span></button>
                                 </div>
                             </div>
                         </form>

--- a/resources/views/search/collection.blade.php
+++ b/resources/views/search/collection.blade.php
@@ -22,7 +22,7 @@
                         <i class="ti ti-tag mr-1" style="margin-top: 0.25rem;"></i>
                         <div class="tis-checkin-tags">
                             @foreach ($item->tags as $tag)
-                                <a class="tis-checkin-tag" href="{{ route('search.collection', ['q' => $tag->name]) }}">{{ $tag->name }}</a>
+                                <a class="badge badge-secondary" href="{{ route('search.collection', ['q' => $tag->name]) }}">{{ $tag->name }}</a>
                             @endforeach
                         </div>
                     </div>

--- a/resources/views/search/collection.blade.php
+++ b/resources/views/search/collection.blade.php
@@ -18,11 +18,14 @@
                     </p>
                 </div>
                 @if ($item->tags->isNotEmpty())
-                    <p class="tis-checkin-tags mb-2">
-                        @foreach ($item->tags as $tag)
-                            <a class="badge badge-secondary" href="{{ route('search.collection', ['q' => $tag->name]) }}"><i class="ti ti-tag"></i> {{ $tag->name }}</a>
-                        @endforeach
-                    </p>
+                    <div class="d-flex mb-2">
+                        <i class="ti ti-tag mr-1" style="margin-top: 0.25rem;"></i>
+                        <div class="tis-checkin-tags">
+                            @foreach ($item->tags as $tag)
+                                <a href="{{ route('search.collection', ['q' => $tag->name]) }}"><span style="opacity: 0.7;">#</span>{{ $tag->name }}</a>
+                            @endforeach
+                        </div>
+                    </div>
                 @endif
                 @if (!empty($item->note))
                     <p class="mb-2 text-break">

--- a/resources/views/search/collection.blade.php
+++ b/resources/views/search/collection.blade.php
@@ -22,7 +22,7 @@
                         <i class="ti ti-tag mr-1" style="margin-top: 0.25rem;"></i>
                         <div class="tis-checkin-tags">
                             @foreach ($item->tags as $tag)
-                                <a href="{{ route('search.collection', ['q' => $tag->name]) }}"><span style="opacity: 0.7;">#</span>{{ $tag->name }}</a>
+                                <a class="tis-checkin-tag" href="{{ route('search.collection', ['q' => $tag->name]) }}">{{ $tag->name }}</a>
                             @endforeach
                         </div>
                     </div>

--- a/resources/views/search/collection.blade.php
+++ b/resources/views/search/collection.blade.php
@@ -8,19 +8,19 @@
         @foreach($results as $item)
             <li class="list-group-item border-bottom-only pt-3 pb-3 text-break">
                 <h6>
-                    <a href="{{ route('user.collections.show', ['name' => $item->collection->user->name, 'id' => $item->collection_id]) }}" class="text-dark"><span class="oi oi-box text-secondary"></span> {{ $item->collection->title }}</a><span class="mx-1 text-muted">—</span><a href="{{ route('user.profile', ['name' => $item->collection->user->name]) }}" class="text-dark"><img src="{{ $item->collection->user->getProfileImageUrl(20) }}" srcset="{{ Formatter::profileImageSrcSet($item->collection->user, 20) }}" width="20" height="20" class="rounded d-inline-block align-bottom"> <bdi>{{ $item->collection->user->display_name }}</bdi> さんのコレクション</a>
+                    <a href="{{ route('user.collections.show', ['name' => $item->collection->user->name, 'id' => $item->collection_id]) }}" class="text-dark"><i class="ti ti-folder text-secondary"></i> {{ $item->collection->title }}</a><span class="mx-1 text-muted">—</span><a href="{{ route('user.profile', ['name' => $item->collection->user->name]) }}" class="text-dark"><img src="{{ $item->collection->user->getProfileImageUrl(20) }}" srcset="{{ Formatter::profileImageSrcSet($item->collection->user, 20) }}" width="20" height="20" class="rounded d-inline-block align-bottom"> <bdi>{{ $item->collection->user->display_name }}</bdi> さんのコレクション</a>
                 </h6>
                 <div class="row mx-0">
                     @component('components.link-card', ['link' => $item->link, 'is_too_sensitive' => false])
                     @endcomponent
                     <p class="d-flex align-items-baseline mb-2 col-12 px-0">
-                        <span class="oi oi-link-intact mr-1"></span><a class="overflow-hidden" href="{{ $item->link }}" target="_blank" rel="noopener">{{ $item->link }}</a>
+                        <i class="ti ti-link mr-1"></i><a class="overflow-hidden" href="{{ $item->link }}" target="_blank" rel="noopener">{{ $item->link }}</a>
                     </p>
                 </div>
                 @if ($item->tags->isNotEmpty())
                     <p class="tis-checkin-tags mb-2">
                         @foreach ($item->tags as $tag)
-                            <a class="badge badge-secondary" href="{{ route('search.collection', ['q' => $tag->name]) }}"><span class="oi oi-tag"></span> {{ $tag->name }}</a>
+                            <a class="badge badge-secondary" href="{{ route('search.collection', ['q' => $tag->name]) }}"><i class="ti ti-tag"></i> {{ $tag->name }}</a>
                         @endforeach
                     </p>
                 @endif
@@ -30,14 +30,14 @@
                     </p>
                 @endif
                 <div class="ejaculation-actions">
-                    <button type="button" class="btn btn-link text-secondary"
+                    <button type="button" class="btn text-secondary"
                             data-toggle="tooltip" data-placement="bottom"
-                            title="このオカズでチェックイン" data-href="{{ $item->makeCheckinURL() }}"><span class="oi oi-check"></span></button>
+                            title="このオカズでチェックイン" data-href="{{ $item->makeCheckinURL() }}"><i class="ti ti-send"></i></button>
                     @auth
                         <span class="add-to-collection-button" data-link="{{ $item->link }}" data-tags="{{ $item->textTags() }}">
-                            <button type="button" class="btn btn-link text-secondary"
+                            <button type="button" class="btn text-secondary"
                                     data-toggle="tooltip" data-placement="bottom" data-trigger="hover"
-                                    title="コレクションに追加"><span class="oi oi-plus"></span></button>
+                                    title="コレクションに追加"><i class="ti ti-folder-plus"></i></button>
                         </span>
                     @endauth
                 </div>

--- a/resources/views/setting/base.blade.php
+++ b/resources/views/setting/base.blade.php
@@ -7,29 +7,29 @@
                 <div class="list-group">
                     <div class="list-group-item disabled font-weight-bold">設定</div>
                     <a class="list-group-item list-group-item-action {{ Route::currentRouteName() === 'setting' ? 'active' : '' }}"
-                       href="{{ route('setting') }}"><span class="oi oi-person mr-1"></span> プロフィール</a>
+                       href="{{ route('setting') }}"><i class="ti ti-user mr-1"></i> プロフィール</a>
                     <a class="list-group-item list-group-item-action {{ Route::currentRouteName() === 'setting.privacy' ? 'active' : '' }}"
-                       href="{{ route('setting.privacy') }}"><span class="oi oi-shield mr-1"></span> プライバシー</a>
+                       href="{{ route('setting.privacy') }}"><i class="ti ti-shield-lock mr-1"></i> プライバシー</a>
                     <a class="list-group-item list-group-item-action {{ Route::currentRouteName() === 'setting.filter.tags' ? 'active' : '' }}"
-                       href="{{ route('setting.filter.tags') }}"><span class="oi oi-tags mr-1"></span> タグミュート</a>
+                       href="{{ route('setting.filter.tags') }}"><i class="ti ti-tag-off mr-1"></i> タグミュート</a>
                     <a class="list-group-item list-group-item-action {{ Route::currentRouteName() === 'setting.password' ? 'active' : '' }}"
-                       href="{{ route('setting.password') }}"><span class="oi oi-key mr-1"></span> パスワードの変更</a>
+                       href="{{ route('setting.password') }}"><i class="ti ti-password mr-1"></i> パスワードの変更</a>
                     <a class="list-group-item list-group-item-action {{ Route::currentRouteName() === 'setting.deactivate' ? 'active' : '' }}"
-                       href="{{ route('setting.deactivate') }}"><span class="oi oi-trash mr-1"></span> アカウントの削除</a>
+                       href="{{ route('setting.deactivate') }}"><i class="ti ti-trash mr-1"></i> アカウントの削除</a>
                 </div>
                 <div class="list-group mt-4">
                     <div class="list-group-item disabled font-weight-bold">アプリ連携</div>
                     <a class="list-group-item list-group-item-action {{ Route::currentRouteName() === 'setting.webhooks' ? 'active' : '' }}"
-                       href="{{ route('setting.webhooks') }}"><span class="oi oi-link-intact mr-1"></span> Webhook</a>
+                       href="{{ route('setting.webhooks') }}"><i class="ti ti-webhook mr-1"></i> Webhook</a>
                     <a class="list-group-item list-group-item-action {{ Route::currentRouteName() === 'setting.tokens' ? 'active' : '' }}"
-                       href="{{ route('setting.tokens') }}"><span class="oi oi-key mr-1"></span> 個人用アクセストークン</a>
+                       href="{{ route('setting.tokens') }}"><i class="ti ti-key mr-1"></i> 個人用アクセストークン</a>
                 </div>
                 <div class="list-group mt-4">
                     <div class="list-group-item disabled font-weight-bold">データ管理</div>
                     <a class="list-group-item list-group-item-action {{ Route::currentRouteName() === 'setting.import' ? 'active' : '' }}"
-                       href="{{ route('setting.import') }}"><span class="oi oi-data-transfer-upload mr-1"></span> データのインポート</a>
+                       href="{{ route('setting.import') }}"><i class="ti ti-upload mr-1"></i> データのインポート</a>
                     <a class="list-group-item list-group-item-action {{ Route::currentRouteName() === 'setting.export' ? 'active' : '' }}"
-                       href="{{ route('setting.export') }}"><span class="oi oi-data-transfer-download mr-1"></span> データのエクスポート</a>
+                       href="{{ route('setting.export') }}"><i class="ti ti-download mr-1"></i> データのエクスポート</a>
                 </div>
             </div>
             <div class="tab-content col-lg-8">

--- a/resources/views/setting/deactivate.blade.php
+++ b/resources/views/setting/deactivate.blade.php
@@ -7,7 +7,7 @@
     <hr>
     <p>Tissueからあなたのアカウントに関する情報を削除します。</p>
     <div class="alert alert-danger">
-        <h4 class="alert-heading"><span class="oi oi-warning"></span> 警告</h4>
+        <h4 class="alert-heading"><i class="ti ti-alert-triangle font-weight-normal"></i> 警告</h4>
         <p><strong>削除はすぐに実行され、取り消すことはできません！</strong></p>
         <p class="my-0">なりすましを防止するため、あなたのユーザー名はサーバーに記録されます。今後、同じユーザー名を使って再登録することはできません。</p>
     </div>

--- a/resources/views/setting/deactivate.blade.php
+++ b/resources/views/setting/deactivate.blade.php
@@ -7,7 +7,7 @@
     <hr>
     <p>Tissueからあなたのアカウントに関する情報を削除します。</p>
     <div class="alert alert-danger">
-        <h4 class="alert-heading"><i class="ti ti-alert-triangle font-weight-normal"></i> 警告</h4>
+        <h4 class="alert-heading"><i class="ti ti-alert-triangle"></i> 警告</h4>
         <p><strong>削除はすぐに実行され、取り消すことはできません！</strong></p>
         <p class="my-0">なりすましを防止するため、あなたのユーザー名はサーバーに記録されます。今後、同じユーザー名を使って再登録することはできません。</p>
     </div>

--- a/resources/views/setting/filter/tags.blade.php
+++ b/resources/views/setting/filter/tags.blade.php
@@ -57,7 +57,7 @@
             @foreach ($tagFilters as $tagFilter)
                 <div class="list-group-item d-flex justify-content-between align-items-center">
                     <div class="flex-grow-1 mr-2">
-                        <div><span class="oi oi-tag text-secondary"></span> {{ $tagFilter->tag_name }}</div>
+                        <div><i class="ti ti-tag text-secondary"></i> {{ $tagFilter->tag_name }}</div>
                         <small class="text-muted">
                             @switch ($tagFilter->mode)
                                 @case (\App\TagFilter::MODE_MASK)

--- a/resources/views/setting/import.blade.php
+++ b/resources/views/setting/import.blade.php
@@ -18,7 +18,7 @@
         </div>
         @if (session('import_errors'))
             <div class="alert alert-danger">
-                <p class="alert-heading"><span class="oi oi-warning"></span> <strong>インポートに失敗しました</strong></p>
+                <p class="alert-heading"><i class="ti ti-alert-triangle font-weight-normal"></i> <strong>インポートに失敗しました</strong></p>
                 @foreach (session('import_errors') as $err)
                     <p class="mb-0">{{ $err }}</p>
                 @endforeach

--- a/resources/views/setting/import.blade.php
+++ b/resources/views/setting/import.blade.php
@@ -18,7 +18,7 @@
         </div>
         @if (session('import_errors'))
             <div class="alert alert-danger">
-                <p class="alert-heading"><i class="ti ti-alert-triangle font-weight-normal"></i> <strong>インポートに失敗しました</strong></p>
+                <p class="alert-heading"><i class="ti ti-alert-triangle"></i> <strong>インポートに失敗しました</strong></p>
                 @foreach (session('import_errors') as $err)
                     <p class="mb-0">{{ $err }}</p>
                 @endforeach

--- a/resources/views/user/likes.blade.php
+++ b/resources/views/user/likes.blade.php
@@ -5,7 +5,7 @@
 @section('tab-content')
 @if (($user->is_protected || $user->private_likes) && !$user->isMe())
     <p class="mt-4">
-        <span class="oi oi-lock-locked"></span> このユーザはいいね一覧を公開していません。
+        <i class="ti ti-lock"></i> このユーザはいいね一覧を公開していません。
     </p>
 @else
     <ul class="list-group">

--- a/resources/views/user/okazu.blade.php
+++ b/resources/views/user/okazu.blade.php
@@ -5,7 +5,7 @@
 @section('tab-content')
 @if ($user->is_protected && !$user->isMe())
     <p class="mt-4">
-        <span class="oi oi-lock-locked"></span> このユーザはチェックイン履歴を公開していません。
+        <i class="ti ti-lock"></i> このユーザはチェックイン履歴を公開していません。
     </p>
 @else
 @endif

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -30,7 +30,7 @@
                 @foreach ($tags as $tag)
                     <a class="list-group-item d-flex justify-content-between align-items-center text-dark" href="{{ route('search', ['q' => $tag->name]) }}">
                         <div style="word-break: break-all;">
-                            <span class="oi oi-tag text-secondary"></span>
+                            <i class="ti ti-tag text-secondary"></i>
                             {{ $tag->name }}
                         </div>
                         <span class="badge badge-secondary badge-pill">{{ $tag->count }}</span>
@@ -45,7 +45,7 @@
 @section('tab-content')
 @if ($user->is_protected && !$user->isMe())
     <p class="mt-4">
-        <span class="oi oi-lock-locked"></span> このユーザはチェックイン履歴を公開していません。
+        <i class="ti ti-lock"></i> このユーザはチェックイン履歴を公開していません。
     </p>
 @else
     @if (Route::currentRouteName() === 'user.profile' && $ejaculations->count() !== 0 && $ejaculations->currentPage() === 1)

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -30,8 +30,7 @@
                 @foreach ($tags as $tag)
                     <a class="list-group-item d-flex justify-content-between align-items-center text-dark" href="{{ route('search', ['q' => $tag->name]) }}">
                         <div style="word-break: break-all;">
-                            <i class="ti ti-tag text-secondary"></i>
-                            {{ $tag->name }}
+                            <i class="ti ti-tag text-secondary mr-2 d-inline-block"></i>{{ $tag->name }}
                         </div>
                         <span class="badge badge-secondary badge-pill">{{ $tag->count }}</span>
                     </a>

--- a/resources/views/user/stats/base.blade.php
+++ b/resources/views/user/stats/base.blade.php
@@ -22,7 +22,7 @@
 @section('tab-content')
     @if ($user->is_protected && !$user->isMe())
         <p class="mt-4">
-            <span class="oi oi-lock-locked"></span> このユーザはチェックイン履歴を公開していません。
+            <i class="ti ti-lock"></i> このユーザはチェックイン履歴を公開していません。
         </p>
     @else
         <div class="row my-2 d-lg-none">

--- a/resources/views/user/stats/components/used-tags.blade.php
+++ b/resources/views/user/stats/components/used-tags.blade.php
@@ -13,7 +13,7 @@
                 @foreach ($tags as $tag)
                     <tr>
                         <td style="word-break: break-all;">
-                            <a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><i class="ti ti-tag text-secondary mr-2"></i>{{ $tag->name }}</a>
+                            <a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><i class="ti ti-tag text-secondary mr-2 d-inline-block"></i>{{ $tag->name }}</a>
                         </td>
                         <td class="text-right">
                             <a class="text-reset text-decoration-none" href="{{ route('search', ['q' => $tag->name]) }}">{{ number_format($tag->count) }}</a>
@@ -37,7 +37,7 @@
                 @foreach ($tagsIncludesMetadata as $tag)
                     <tr>
                         <td style="word-break: break-all;">
-                            <a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><i class="ti ti-tag text-secondary mr-2"></i>{{ $tag->name }}</a>
+                            <a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><i class="ti ti-tag text-secondary mr-2 d-inline-block"></i>{{ $tag->name }}</a>
                         </td>
                         <td class="text-right">
                             <a class="text-reset text-decoration-none" href="{{ route('search', ['q' => $tag->name]) }}">{{ number_format($tag->count) }}</a>

--- a/resources/views/user/stats/components/used-tags.blade.php
+++ b/resources/views/user/stats/components/used-tags.blade.php
@@ -13,7 +13,7 @@
                 @foreach ($tags as $tag)
                     <tr>
                         <td style="word-break: break-all;">
-                            <a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a>
+                            <a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><i class="ti ti-tag text-secondary mr-2"></i>{{ $tag->name }}</a>
                         </td>
                         <td class="text-right">
                             <a class="text-reset text-decoration-none" href="{{ route('search', ['q' => $tag->name]) }}">{{ number_format($tag->count) }}</a>
@@ -37,7 +37,7 @@
                 @foreach ($tagsIncludesMetadata as $tag)
                     <tr>
                         <td style="word-break: break-all;">
-                            <a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><span class="oi oi-tag text-secondary mr-2"></span>{{ $tag->name }}</a>
+                            <a class="text-reset" href="{{ route('search', ['q' => $tag->name]) }}"><i class="ti ti-tag text-secondary mr-2"></i>{{ $tag->name }}</a>
                         </td>
                         <td class="text-right">
                             <a class="text-reset text-decoration-none" href="{{ route('search', ['q' => $tag->name]) }}">{{ number_format($tag->count) }}</a>

--- a/resources/views/user/stats/yearly.blade.php
+++ b/resources/views/user/stats/yearly.blade.php
@@ -31,13 +31,13 @@
                     @component('components.link-card', ['link' => $item->normalized_link, 'is_too_sensitive' => false])
                     @endcomponent
                     <p class="d-flex align-items-baseline mb-2 col-12 px-0">
-                        <span class="oi oi-link-intact mr-1"></span><a class="overflow-hidden" href="{{ $item->normalized_link }}" target="_blank" rel="noopener">{{ $item->normalized_link }}</a>
+                        <i class="ti ti-link mr-1"></i><a class="overflow-hidden" href="{{ $item->normalized_link }}" target="_blank" rel="noopener">{{ $item->normalized_link }}</a>
                     </p>
                 </div>
                 <div class="ejaculation-actions">
-                    <button type="button" class="btn btn-link text-secondary"
+                    <button type="button" class="btn text-secondary"
                             data-toggle="tooltip" data-placement="bottom"
-                            title="同じオカズでチェックイン" data-href="{{ route('checkin', ['link' => $item->normalized_link]) }}"><span class="oi oi-reload"></span></button>
+                            title="同じオカズでチェックイン" data-href="{{ route('checkin', ['link' => $item->normalized_link]) }}"><i class="ti ti-reload"></i></button>
                 </div>
             </li>
         @empty

--- a/yarn.lock
+++ b/yarn.lock
@@ -6142,11 +6142,6 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-open-iconic@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/open-iconic/-/open-iconic-1.1.1.tgz#9dcfc8c7cd3c61cdb4a236b1a347894c97adc0c6"
-  integrity sha1-nc/Ix808Yc20ojaxo0eJTJetwMY=
-
 open@^8.0.9:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1493,6 +1493,18 @@
     "@tanstack/query-core" "4.36.1"
     use-sync-external-store "^1.2.0"
 
+"@tabler/icons-webfont@^2.44.0":
+  version "2.44.0"
+  resolved "https://registry.yarnpkg.com/@tabler/icons-webfont/-/icons-webfont-2.44.0.tgz#105024173bf89964ec0485292daec62f2a6c2e90"
+  integrity sha512-E5+CYnZXKTUGFhpb0KGiRR4s+Tylbsq6/CA88QKn44xaBfU3ui/zVwKc1vaTKBL9kxZIxNz7qLkne+lUd/Hvzw==
+  dependencies:
+    "@tabler/icons" "2.44.0"
+
+"@tabler/icons@2.44.0":
+  version "2.44.0"
+  resolved "https://registry.yarnpkg.com/@tabler/icons/-/icons-2.44.0.tgz#9f3cf86150b23e84a6eaf9d29ab2b2aaa8c7eed6"
+  integrity sha512-WPPtihDcAwEm1QZM9MXQw6+r/R2/qx7KMU1eegsi9DsqBLAb0W2kbt6e/syvd6j9c+6XNpRVBW1ziGqSWQAWOg==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"


### PR DESCRIPTION
fix #665 

とりあえず手軽に導入できる `@tabler/icons-webfont` でセットアップしてみた。

Open Iconicと比べて、aタグ内に置いた時にアイコンにもunderlineがかかる。場所によってはやや微妙な性質で、若干困っている。