### PR TITLE
Collection APIを公開API化

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,19 +109,19 @@ jobs:
       # Run unit test
       - run:
           command: |
-            mkdir -p /tmp/phpunit
-            ./vendor/bin/phpunit --log-junit /tmp/phpunit/phpunit.xml --coverage-clover=/tmp/phpunit/coverage.xml
+            mkdir -p /tmp/phpunit{,-coverage}
+            ./vendor/bin/phpunit --log-junit /tmp/phpunit/phpunit.xml --coverage-clover=/tmp/phpunit-coverage/coverage.xml
           when: always
           environment:
             XDEBUG_MODE: coverage
       - store_test_results:
           path: /tmp/phpunit
       - store_artifacts:
-          path: /tmp/phpunit/coverage.xml
+          path: /tmp/phpunit-coverage/coverage.xml
 
       # Upload coverage
       - run:
-          command: bash <(curl -s https://codecov.io/bash) -f /tmp/phpunit/coverage.xml
+          command: bash <(curl -s https://codecov.io/bash) -f /tmp/phpunit-coverage/coverage.xml
           when: always
 
   test_resolver:

--- a/app/Collection.php
+++ b/app/Collection.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Collection extends Model
 {
+    use HasFactory;
+
     /** @var int ユーザーごとの作成数制限 */
     const PER_USER_LIMIT = 100;
 

--- a/app/CollectionItem.php
+++ b/app/CollectionItem.php
@@ -3,10 +3,13 @@
 namespace App;
 
 use App\Utilities\Formatter;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class CollectionItem extends Model
 {
+    use HasFactory;
+
     const PER_COLLECTION_LIMIT = 1000;
 
     protected $fillable = [

--- a/app/Http/Controllers/Api/UserCollectionController.php
+++ b/app/Http/Controllers/Api/UserCollectionController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\CollectionResource;
+use App\User;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class UserCollectionController extends Controller
+{
+    public function index(User $user)
+    {
+        if (!$user->isMe() && $user->is_protected) {
+            throw new AccessDeniedHttpException('このユーザはチェックイン履歴を公開していません');
+        }
+
+        $collections = $user->collections();
+        if (!$user->isMe()) {
+            $collections = $collections->where('is_private', false);
+        }
+
+        return response()->json($collections->get()->map(fn ($collection) => new CollectionResource($collection)));
+    }
+}

--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Api;
+namespace App\Http\Controllers\Api\V1;
 
 use App\Collection;
 use App\CollectionItem;
@@ -20,7 +20,6 @@ class CollectionController extends Controller
 {
     public function __construct()
     {
-        $this->middleware('auth')->except('show');
         $this->middleware(function (Request $request, $next) {
             $collection = $request->route('collection');
             if ($collection instanceof Collection && !$collection->user->isMe()) {

--- a/app/Http/Controllers/Api/V1/CollectionItemController.php
+++ b/app/Http/Controllers/Api/V1/CollectionItemController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Api;
+namespace App\Http\Controllers\Api\V1;
 
 use App\Collection;
 use App\CollectionItem;
@@ -19,7 +19,6 @@ class CollectionItemController extends Controller
 {
     public function __construct()
     {
-        $this->middleware('auth')->except('index');
         $this->middleware(function (Request $request, $next) {
             $collection = $request->route('collection');
             if ($collection instanceof Collection && !$collection->user->isMe()) {

--- a/app/Http/Controllers/Api/V1/UserCollectionController.php
+++ b/app/Http/Controllers/Api/V1/UserCollectionController.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace App\Http\Controllers\Api;
+namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\CollectionResource;
 use App\User;
-use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class UserCollectionController extends Controller

--- a/app/Http/Controllers/Api/V1/UserCollectionController.php
+++ b/app/Http/Controllers/Api/V1/UserCollectionController.php
@@ -5,21 +5,28 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\CollectionResource;
 use App\User;
+use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class UserCollectionController extends Controller
 {
-    public function index(User $user)
+    public function index(Request $request, User $user)
     {
         if (!$user->isMe() && $user->is_protected) {
             throw new AccessDeniedHttpException('このユーザはチェックイン履歴を公開していません');
         }
 
-        $collections = $user->collections();
-        if (!$user->isMe()) {
-            $collections = $collections->where('is_private', false);
-        }
+        $inputs = $request->validate([
+            'per_page' => 'nullable|integer|between:10,100',
+        ]);
 
-        return response()->json($collections->get()->map(fn ($collection) => new CollectionResource($collection)));
+        $query = $user->collections();
+        if (!$user->isMe()) {
+            $query = $query->where('is_private', false);
+        }
+        $collections = $query->orderBy('id')
+            ->paginate($inputs['per_page'] ?? 20);
+
+        return response()->fromPaginator($collections, CollectionResource::class);
     }
 }

--- a/database/factories/CollectionFactory.php
+++ b/database/factories/CollectionFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Collection>
+ */
+class CollectionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'title' => 'collection',
+            'is_private' => false,
+        ];
+    }
+}

--- a/database/factories/CollectionItemFactory.php
+++ b/database/factories/CollectionItemFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\CollectionItem>
+ */
+class CollectionItemFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,10 @@ info:
   description: |
     夜のライフログサービス Tissue の公開API仕様です。
     全てのAPIのURLは `https://shikorism.net/api` から始まります。
-  version: 0.2.0
+
+    一部APIではドキュメントに無いプロパティを応答する場合がありますが、これは正式な仕様ではありません。
+    予告なく削除する可能性がありますので**使用しないでください**。
+  version: 0.3.0
 servers:
   - url: 'https://shikorism.net/api'
 tags:
@@ -14,6 +17,8 @@ tags:
     description: ユーザー情報に関する操作
   - name: checkin
     description: チェックインに関する操作
+  - name: collection
+    description: コレクションに関する操作
 paths:
   /webhooks/checkin/{id}:
     post:
@@ -200,6 +205,51 @@ paths:
           description: ユーザーがチェックイン履歴を公開していない場合
         404:
           description: 存在しないユーザー
+  /v1/users/{name}/collections:
+    get:
+      summary: コレクション一覧の取得
+      description: 指定したユーザーのコレクション一覧を取得します。
+      tags:
+        - users
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: ユーザー名
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: ページ番号
+          schema:
+            type: integer
+            default: 1
+        - name: per_page
+          in: query
+          description: 1ページあたりのアイテム数
+          schema:
+            type: integer
+            default: 20
+            minimum: 10
+            maximum: 100
+      responses:
+        200:
+          description: 成功
+          headers:
+            X-Total-Count:
+              description: 全体のアイテム数
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Collection'
+        403:
+          description: ユーザーがチェックイン履歴を公開していない場合
+        404:
+          description: 存在しないユーザー
   /v1/checkins:
     post:
       summary: チェックインの作成
@@ -339,6 +389,303 @@ paths:
           description: 成功、または既に存在しない場合
         403:
           description: 自分以外のチェックインに対して操作を試みた場合
+  /v1/collections:
+    post:
+      summary: コレクションの作成
+      description: 新規コレクションを作成します。
+      tags:
+        - collection
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCollection'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+        422:
+          description: バリデーションエラー
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - status
+                  - error
+                properties:
+                  status:
+                    type: number
+                    description: HTTPステータスコードと同じ値
+                    example: 422
+                  error:
+                    $ref: '#/components/schemas/ValidationError'
+  /v1/collections/{collection_id}:
+    get:
+      summary: コレクションの取得
+      description: 指定したIDのコレクションの情報を取得します。
+      tags:
+        - collection
+      parameters:
+        - name: collection_id
+          in: path
+          required: true
+          description: コレクションID
+          schema:
+            type: integer
+            format: int64
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+        404:
+          description: 存在しない、またはアクセス権の無いコレクションの場合 (ユーザーがチェックイン履歴を公開していない、またはコレクションが非公開設定)
+    put:
+      summary: コレクションの編集
+      description: 指定したIDのコレクションの情報を編集します。
+      tags:
+        - collection
+      parameters:
+        - name: collection_id
+          in: path
+          required: true
+          description: コレクションID
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCollection'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+        403:
+          description: 自分以外が作成したコレクションに対して操作を試みた場合
+        404:
+          description: 存在しない場合
+        422:
+          description: バリデーションエラー
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - status
+                  - error
+                properties:
+                  status:
+                    type: number
+                    description: HTTPステータスコードと同じ値
+                    example: 422
+                  error:
+                    $ref: '#/components/schemas/ValidationError'
+    delete:
+      summary: コレクションの削除
+      description: |
+        指定したIDのコレクションを削除します。
+
+        ### 注意
+        実装上の都合で、Checkin APIと異なり**応答がべき等ではありません**。既に削除されている場合は404エラーになりますので、ご注意ください。
+      tags:
+        - collection
+      parameters:
+        - name: collection_id
+          in: path
+          required: true
+          description: コレクションID
+          schema:
+            type: integer
+            format: int64
+      responses:
+        204:
+          description: 成功
+        403:
+          description: 自分以外が作成したコレクションに対して操作を試みた場合
+        404:
+          description: 存在しない場合
+  /v1/collections/{collection_id}/items:
+    get:
+      summary: コレクション内アイテム一覧の取得
+      description: 指定したコレクションに含まれるアイテムの一覧を取得します。
+      tags:
+        - collection
+      parameters:
+        - name: collection_id
+          in: path
+          required: true
+          description: コレクションID
+          schema:
+            type: integer
+            format: int64
+        - name: page
+          in: query
+          description: ページ番号
+          schema:
+            type: integer
+            default: 1
+        - name: per_page
+          in: query
+          description: 1ページあたりのアイテム数
+          schema:
+            type: integer
+            default: 20
+            minimum: 10
+            maximum: 100
+      responses:
+        200:
+          description: 成功
+          headers:
+            X-Total-Count:
+              description: 全体のアイテム数
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CollectionItem'
+        404:
+          description: コレクションが存在しない、またはアクセス権の無いコレクションの場合 (ユーザーがチェックイン履歴を公開していない、またはコレクションが非公開設定)
+    post:
+      summary: コレクションにアイテムを追加
+      description: 指定したコレクションに新しいアイテムを追加します。
+      tags:
+        - collection
+      parameters:
+        - name: collection_id
+          in: path
+          required: true
+          description: コレクションID
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCollectionItem'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectionItem'
+        422:
+          description: バリデーションエラー
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - status
+                  - error
+                properties:
+                  status:
+                    type: number
+                    description: HTTPステータスコードと同じ値
+                    example: 422
+                  error:
+                    $ref: '#/components/schemas/ValidationError'
+  /v1/collections/{collection_id}/items/{collection_item_id}:
+    patch:
+      summary: コレクションアイテムの更新
+      description: |
+        指定したIDのコレクションアイテムの情報を更新します。
+        リクエスト内の項目は全て省略可能であり、更新したい項目のみを送信することができます。
+      tags:
+        - collection
+      parameters:
+        - name: collection_id
+          in: path
+          required: true
+          description: コレクションID
+          schema:
+            type: integer
+            format: int64
+        - name: collection_item_id
+          in: path
+          required: true
+          description: コレクションアイテムID
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCollectionItem'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectionItem'
+        403:
+          description: 自分以外が作成したコレクションに対して操作を試みた場合
+        404:
+          description: 存在しない場合
+        422:
+          description: バリデーションエラー
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - status
+                  - error
+                properties:
+                  status:
+                    type: number
+                    description: HTTPステータスコードと同じ値
+                    example: 422
+                  error:
+                    $ref: '#/components/schemas/ValidationError'
+    delete:
+      summary: コレクションからアイテムを削除
+      description: |
+        コレクションから、指定したIDのコレクションアイテムを削除します。
+
+        ### 注意
+        実装上の都合で、Checkin APIと異なり**応答がべき等ではありません**。既に削除されている場合は404エラーになりますので、ご注意ください。
+      tags:
+        - collection
+      parameters:
+        - name: collection_id
+          in: path
+          required: true
+          description: コレクションID
+          schema:
+            type: integer
+            format: int64
+        - name: collection_item_id
+          in: path
+          required: true
+          description: コレクションアイテムID
+          schema:
+            type: integer
+            format: int64
+      responses:
+        204:
+          description: 成功
+        403:
+          description: 自分以外が作成したコレクションに対して操作を試みた場合
+        404:
+          description: 存在しない場合
 components:
   schemas:
     User:
@@ -508,6 +855,107 @@ components:
               default: false
             discard_elapsed_time:
               default: false
+    Collection:
+      type: object
+      description: コレクション
+      required:
+        - id
+        - user_name
+        - title
+        - is_private
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: コレクションID
+        title:
+          type: string
+          description: コレクションのタイトル
+          example: My collection
+        is_private:
+          type: boolean
+          description: 非公開コレクションとして設定
+          example: false
+    UpdateCollection:
+      type: object
+      required:
+        - title
+        - is_private
+      properties:
+        title:
+          type: string
+          maxLength: 255
+          description: コレクションのタイトル
+          example: My collection
+        is_private:
+          type: boolean
+          description: 非公開コレクションとして設定
+          example: false
+    CreateCollection:
+      $ref: '#/components/schemas/UpdateCollection'
+    CollectionItem:
+      type: object
+      required:
+        - id
+        - collection_id
+        - link
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: コレクションアイテムID
+        collection_id:
+          type: integer
+          format: int64
+          description: コレクションID
+        link:
+          type: string
+          maxLength: 2000
+          description: オカズリンク (http, https)
+          example: http://example.com
+        note:
+          type: string
+          maxLength: 500
+          description: ノート
+          example: すごく抜ける
+        tags:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+          description: タグ
+          example:
+            - Example
+            - Example_2
+    UpdateCollectionItem:
+      type: object
+      properties:
+        note:
+          type: string
+          maxLength: 500
+          description: ノート
+          example: すごく抜ける
+        tags:
+          type: array
+          maxItems: 40
+          items:
+            type: string
+            maxLength: 255
+          description: タグ
+          example:
+            - Example
+            - Example_2
+    CreateCollectionItem:
+      allOf:
+        - required:
+            - link
+          properties:
+            link:
+              type: string
+              maxLength: 2000
+              description: オカズリンク (http, https)
+              example: http://example.com
+        - $ref: '#/components/schemas/UpdateCollectionItem'
     ValidationError:
       type: object
       description: バリデーションエラー

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eslint": "eslint --ext .js,.ts,.tsx resources/",
     "stylelint": "stylelint resources/assets/sass/**/*",
     "doc": "redoc-cli bundle --options.pathInMiddlePanel -o public/apidoc.html openapi.yaml",
+    "doc-watch": "chokidar openapi.yaml -c \"npm run doc\"",
     "heroku-postbuild": "npm run production && npm run doc"
   },
   "devDependencies": {
@@ -31,6 +32,7 @@
     "bootstrap": "^4.5.0",
     "cal-heatmap": "^3.3.10",
     "chart.js": "^2.9.4",
+    "chokidar-cli": "^3.0.0",
     "classnames": "^2.3.1",
     "clipboard": "^2.0.11",
     "cross-env": "^7.0.3",

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,7 +26,7 @@ Route::middleware('stateful')->group(function () {
             Route::apiResource('collections.items', 'Api\\V1\\CollectionItemController')->only(['store', 'update', 'destroy']);
         });
 
-        Route::apiResource('users.collections', 'Api\\V1\\UserCollectionController')->only(['index']);
+        Route::apiResource('users.collections', 'Api\\UserCollectionController')->only(['index']);
         Route::apiResource('collections', 'Api\\V1\\CollectionController')->only(['show']);
         Route::apiResource('collections.items', 'Api\\V1\\CollectionItemController')->only(['index']);
     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,11 +22,13 @@ Route::middleware('stateful')->group(function () {
             Route::post('/likes', 'Api\\LikeController@store');
             Route::delete('/likes/{id}', 'Api\\LikeController@destroy');
             Route::apiResource('checkin', 'Api\\CheckinController')->only(['destroy']);
+            Route::apiResource('collections', 'Api\\V1\\CollectionController')->only(['index', 'store', 'update', 'destroy']);
+            Route::apiResource('collections.items', 'Api\\V1\\CollectionItemController')->only(['store', 'update', 'destroy']);
         });
 
-        Route::apiResource('users.collections', 'Api\\UserCollectionController')->only(['index']);
-        Route::apiResource('collections', 'Api\\CollectionController');
-        Route::apiResource('collections.items', 'Api\\CollectionItemController')->except(['show']);
+        Route::apiResource('users.collections', 'Api\\V1\\UserCollectionController')->only(['index']);
+        Route::apiResource('collections', 'Api\\V1\\CollectionController')->only(['show']);
+        Route::apiResource('collections.items', 'Api\\V1\\CollectionItemController')->only(['index']);
     });
 });
 
@@ -44,4 +46,7 @@ Route::middleware(['throttle:60,1', 'auth:api'])
         Route::apiResource('users', 'UserController')->only(['show']);
         Route::apiResource('users.checkins', 'UserCheckinController')->only(['index']);
         Route::apiResource('checkins', 'CheckinController')->except(['index']);
+        Route::apiResource('users.collections', 'UserCollectionController')->only(['index']);
+        Route::apiResource('collections', 'CollectionController')->except(['index']);
+        Route::apiResource('collections.items', 'CollectionItemController')->except(['show']);
     });

--- a/tests/Feature/Api/V1/CollectionItemTest.php
+++ b/tests/Feature/Api/V1/CollectionItemTest.php
@@ -1,0 +1,353 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Collection;
+use App\CollectionItem;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class CollectionItemTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function testGet()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+        $collectionItem = CollectionItem::factory()->create([
+            'collection_id' => $collection->id,
+            'link' => 'http://example.com',
+            'note' => 'big pi',
+        ]);
+
+        $response = $this->getJson('/api/v1/collections/' . $collection->id . '/items');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(1);
+        $response->assertJson([
+            [
+                'id' => $collectionItem->id,
+                'collection_id' => $collection->id,
+                'link' => 'http://example.com',
+                'note' => 'big pi',
+            ]
+        ], true);
+    }
+
+    public function testGetPagination()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+        CollectionItem::factory(11)
+            ->sequence(fn ($sequence) => ['link' => 'http://example.com/#' . $sequence->index])
+            ->create([
+                'collection_id' => $collection->id,
+            ]);
+        $first = $collection->items()->orderBy('id')->first();
+
+        $response = $this->getJson('/api/v1/collections/' . $collection->id . '/items?page=2&per_page=10');
+
+        $response->assertStatus(200);
+        $response->assertHeader('X-Total-Count', 11);
+        $response->assertJsonCount(1);
+        $response->assertJson([
+            [
+                'id' => $first->id,
+            ]
+        ], true);
+    }
+
+    public function testGetProtected()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $targetUser = factory(User::class)->state('protected')->create();
+        $collection = Collection::factory()->create([
+            'user_id' => $targetUser->id,
+            'title' => 'test collection',
+            'is_private' => true,
+        ]);
+        CollectionItem::factory()->create([
+            'collection_id' => $collection->id,
+            'link' => 'http://example.com',
+        ]);
+
+        $response = $this->getJson('/api/v1/collections/' . $collection->id . '/items');
+
+        $response->assertStatus(404);
+    }
+
+    public function testGetMyPrivate()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => true,
+        ]);
+        CollectionItem::factory()->create([
+            'collection_id' => $collection->id,
+            'link' => 'http://example.com',
+        ]);
+
+        $response = $this->getJson('/api/v1/collections/' . $collection->id . '/items');
+
+        $response->assertStatus(200);
+    }
+
+    public function testGetOthersPrivate()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $targetUser = factory(User::class)->create();
+        $collection = Collection::factory()->create([
+            'user_id' => $targetUser->id,
+            'title' => 'test collection',
+            'is_private' => true,
+        ]);
+        CollectionItem::factory()->create([
+            'collection_id' => $collection->id,
+            'link' => 'http://example.com',
+        ]);
+
+        $response = $this->getJson('/api/v1/collections/' . $collection->id . '/items');
+
+        $response->assertStatus(404);
+    }
+
+    public function testGetMissing()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $response = $this->getJson('/api/v1/collections/0/items');
+
+        $response->assertStatus(404);
+    }
+
+    public function testPost()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+
+        $response = $this->postJson('/api/v1/collections/' . $collection->id . '/items', [
+            'link' => 'http://example.com',
+            'note' => 'big pi',
+            'tags' => ['foo', 'bar'],
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJson([
+            'link' => 'http://example.com',
+            'note' => 'big pi',
+            'tags' => ['foo', 'bar'],
+        ]);
+
+        $collectionItemId = $response->json('id');
+        $collectionItem = $collection->items()->find($collectionItemId);
+        $this->assertSame('http://example.com', $collectionItem->link);
+        $this->assertSame('big pi', $collectionItem->note);
+        $this->assertCount(2, $collectionItem->tags);
+    }
+
+    public function testPostConflictLink()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+        CollectionItem::factory()->create([
+            'collection_id' => $collection->id,
+            'link' => 'http://example.com',
+        ]);
+
+        $response = $this->postJson('/api/v1/collections/' . $collection->id . '/items', [
+            'link' => 'http://example.com',
+            'note' => 'big pi',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('status', 422)
+            ->assertJsonPath('error.message', 'そのlinkはすでに使われています。')
+            ->assertJsonCount(1, 'error.violations')
+            ->assertJsonPath('error.violations.0.field', 'link')
+            ->assertJsonPath('error.violations.0.message', 'そのlinkはすでに使われています。');
+    }
+
+    public function testPostMissingCollection()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $response = $this->postJson('/api/v1/collections/0/items', [
+            'link' => 'http://example.com',
+            'note' => 'big pi',
+        ]);
+
+        $response->assertStatus(404);
+    }
+
+    public function testPatch()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+        $collectionItem = CollectionItem::factory()->create([
+            'collection_id' => $collection->id,
+            'link' => 'http://example.com',
+        ]);
+
+        $response = $this->patchJson('/api/v1/collections/' . $collection->id . '/items/' . $collectionItem->id, [
+            'note' => 'updated',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'note' => 'updated',
+        ]);
+
+        $collectionItem->refresh();
+        $this->assertSame('updated', $collectionItem->note);
+    }
+
+    public function testPatchMissing()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+
+        $response = $this->patchJson('/api/v1/collections/' . $collection->id . '/items/0', [
+            'note' => 'updated',
+        ]);
+
+        $response->assertStatus(404);
+    }
+
+    public function testPatchOthers()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $targetUser = factory(User::class)->create();
+        $collection = Collection::factory()->create([
+            'user_id' => $targetUser->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+        $collectionItem = CollectionItem::factory()->create([
+            'collection_id' => $collection->id,
+            'link' => 'http://example.com',
+        ]);
+
+        $response = $this->patchJson('/api/v1/collections/' . $collection->id . '/items/' . $collectionItem->id, [
+            'note' => 'updated',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function testDelete()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+        $collectionItem = CollectionItem::factory()->create([
+            'collection_id' => $collection->id,
+            'link' => 'http://example.com',
+        ]);
+
+        $response = $this->deleteJson('/api/v1/collections/' . $collection->id . '/items/' . $collectionItem->id);
+
+        $response->assertStatus(204);
+        $this->assertDatabaseMissing('collection_items', ['id' => $collectionItem->id]);
+    }
+
+    public function testDeleteMissing()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+
+        $response = $this->deleteJson('/api/v1/collections/' . $collection->id . '/items/0');
+
+        $response->assertStatus(404);
+    }
+
+    public function testDeleteOthers()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $targetUser = factory(User::class)->create();
+        $collection = Collection::factory()->create([
+            'user_id' => $targetUser->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+        $collectionItem = CollectionItem::factory()->create([
+            'collection_id' => $collection->id,
+            'link' => 'http://example.com',
+        ]);
+
+        $response = $this->deleteJson('/api/v1/collections/' . $collection->id . '/items/' . $collectionItem->id);
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('collection_items', ['id' => $collectionItem->id]);
+    }
+}

--- a/tests/Feature/Api/V1/CollectionTest.php
+++ b/tests/Feature/Api/V1/CollectionTest.php
@@ -1,0 +1,258 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Collection;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class CollectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function testGet()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+
+        $response = $this->getJson('/api/v1/collections/' . $collection->id);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'id' => $collection->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ], true);
+    }
+
+    public function testGetProtected()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $targetUser = factory(User::class)->state('protected')->create();
+        $collection = Collection::factory()->create([
+            'user_id' => $targetUser->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+
+        $response = $this->getJson('/api/v1/collections/' . $collection->id);
+
+        $response->assertStatus(404);
+    }
+
+    public function testGetMyPrivate()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => true,
+        ]);
+
+        $response = $this->getJson('/api/v1/collections/' . $collection->id);
+
+        $response->assertStatus(200);
+    }
+
+    public function testGetOthersPrivate()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $targetUser = factory(User::class)->create();
+        $collection = Collection::factory()->create([
+            'user_id' => $targetUser->id,
+            'title' => 'test collection',
+            'is_private' => true,
+        ]);
+
+        $response = $this->getJson('/api/v1/collections/' . $collection->id);
+
+        $response->assertStatus(404);
+    }
+
+    public function testGetMissing()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $response = $this->getJson('/api/v1/collections/0');
+
+        $response->assertStatus(404);
+    }
+
+    public function testPost()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $response = $this->postJson('/api/v1/collections', [
+            'title' => 'new collection',
+            'is_private' => false,
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJson([
+            'title' => 'new collection',
+            'is_private' => false,
+        ], true);
+
+        $collectionId = $response->json('id');
+        $collection = Collection::find($collectionId);
+        $this->assertSame($user->id, $collection->user_id);
+        $this->assertSame('new collection', $collection->title);
+        $this->assertFalse($collection->is_private);
+    }
+
+    public function testPostConflictTitle()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'new collection',
+            'is_private' => false,
+        ]);
+
+        $response = $this->postJson('/api/v1/collections', [
+            'title' => 'new collection',
+            'is_private' => false,
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('status', 422)
+            ->assertJsonPath('error.message', 'そのタイトルはすでに使われています。')
+            ->assertJsonCount(1, 'error.violations')
+            ->assertJsonPath('error.violations.0.field', 'title')
+            ->assertJsonPath('error.violations.0.message', 'そのタイトルはすでに使われています。');
+    }
+
+    public function testPatch()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+
+        $response = $this->patchJson('/api/v1/collections/' . $collection->id, [
+            'title' => 'updated',
+            'is_private' => false,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'id' => $collection->id,
+            'title' => 'updated',
+            'is_private' => false,
+        ], true);
+    }
+
+    public function testPatchMissing()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $response = $this->patchJson('/api/v1/collections/0', [
+            'title' => 'updated',
+            'is_private' => false,
+        ]);
+
+        $response->assertStatus(404);
+    }
+
+    public function testPatchOthers()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $targetUser = factory(User::class)->create();
+        $collection = Collection::factory()->create([
+            'user_id' => $targetUser->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+
+        $response = $this->patchJson('/api/v1/collections/' . $collection->id, [
+            'title' => 'updated',
+            'is_private' => false,
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function testDelete()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+
+        $response = $this->deleteJson('/api/v1/collections/' . $collection->id);
+
+        $response->assertStatus(204);
+        $this->assertDatabaseMissing('collections', ['id' => $collection->id]);
+    }
+
+    public function testDeleteMissing()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+        $collection->delete();
+
+        $response = $this->deleteJson('/api/v1/collections/' . $collection->id);
+
+        $response->assertStatus(404);
+    }
+
+    public function testDeleteOthers()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $targetUser = factory(User::class)->create();
+        $collection = Collection::factory()->create([
+            'user_id' => $targetUser->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+
+        $response = $this->deleteJson('/api/v1/collections/' . $collection->id);
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('collections', ['id' => $collection->id]);
+    }
+}

--- a/tests/Feature/Api/V1/UserCollectionTest.php
+++ b/tests/Feature/Api/V1/UserCollectionTest.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Collection;
+use App\User;
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class UserCollectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function testDefaultQuery()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $collection = Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'test collection',
+            'is_private' => false,
+        ]);
+
+        $response = $this->getJson('/api/v1/users/' . $user->name . '/collections');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(1);
+        $response->assertJson([
+            [
+                'id' => $collection->id,
+                'title' => 'test collection',
+                'is_private' => false,
+            ]
+        ], true);
+    }
+
+    public function testPagination()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        Collection::factory(11)
+            ->sequence(fn (Sequence $seq) => ['title' => 'collection #' . $seq->index])
+            ->create([
+                'user_id' => $user->id,
+            ]);
+        $last = $user->collections()->orderByDesc('id')->first();
+
+        $response = $this->getJson('/api/v1/users/' . $user->name . '/collections?page=2&per_page=10');
+
+        $response->assertStatus(200);
+        $response->assertHeader('X-Total-Count', 11);
+        $response->assertJsonCount(1);
+        $response->assertJson([
+            [
+                'id' => $last->id,
+            ]
+        ], true);
+    }
+
+    public function testProtected()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $target = factory(User::class)->state('protected')->create();
+
+        $response = $this->getJson('/api/v1/users/' . $target->name . '/collections');
+
+        $response->assertStatus(403);
+    }
+
+    public function testMissing()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $target = factory(User::class)->create();
+        $target->delete();
+
+        $response = $this->getJson('/api/v1/users/' . $target->name . '/collections');
+
+        $response->assertStatus(404);
+    }
+
+    public function testExposeMyPrivateCollections()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'public collection',
+            'is_private' => false,
+        ]);
+        Collection::factory()->create([
+            'user_id' => $user->id,
+            'title' => 'private collection',
+            'is_private' => true,
+        ]);
+
+        $response = $this->getJson('/api/v1/users/' . $user->name . '/collections');
+
+        $response->assertStatus(200);
+        $response->assertHeader('X-Total-Count', 2);
+        $response->assertJsonCount(2);
+    }
+
+    public function testHidePrivateCollections()
+    {
+        $user = factory(User::class)->create();
+        Passport::actingAs($user);
+
+        $target = factory(User::class)->create();
+        $public = Collection::factory()->create([
+            'user_id' => $target->id,
+            'title' => 'public collection',
+            'is_private' => false,
+        ]);
+        Collection::factory()->create([
+            'user_id' => $target->id,
+            'title' => 'private collection',
+            'is_private' => true,
+        ]);
+
+        $response = $this->getJson('/api/v1/users/' . $target->name . '/collections');
+
+        $response->assertStatus(200);
+        $response->assertHeader('X-Total-Count', 1);
+        $response->assertJsonCount(1);
+        $response->assertJson([
+            [
+                'id' => $public->id,
+            ]
+        ], true);
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,12 +2035,17 @@ ansi-html-community@^0.0.8:
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-styles@^3.2.1:
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -2545,7 +2550,7 @@ camelcase-keys@^6.2.2:
     map-obj "^4.0.0"
     quick-lru "^4.0.1"
 
-camelcase@^5.3.1:
+camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -2619,6 +2624,16 @@ check-types@^8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
   integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
+
+chokidar-cli@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chokidar-cli/-/chokidar-cli-3.0.0.tgz#29283666063b9e167559d30f247ff8fc48794eb7"
+  integrity sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==
+  dependencies:
+    chokidar "^3.5.2"
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    yargs "^13.3.0"
 
 "chokidar@>=3.0.0 <4.0.0", chokidar@^3.5.1, chokidar@^3.5.2, chokidar@^3.5.3:
   version "3.5.3"
@@ -2709,6 +2724,15 @@ clipboard@*, clipboard@^2.0.11:
     good-listener "^1.2.2"
     select "^1.1.2"
     tiny-emitter "^2.0.0"
+
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  dependencies:
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -3397,6 +3421,11 @@ elliptic@^6.5.3, elliptic@^6.5.4:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -3957,6 +3986,13 @@ find-cache-dir@^3.3.1:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -4094,7 +4130,7 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.5:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -4805,6 +4841,11 @@ is-finalizationregistry@^1.0.2:
   dependencies:
     call-bind "^1.0.2"
 
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+  integrity sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==
+
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
@@ -5253,6 +5294,14 @@ loader-utils@^2.0.0, loader-utils@^2.0.4:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -5286,6 +5335,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
 lodash.truncate@^4.4.2:
   version "4.4.2"
@@ -5973,7 +6027,7 @@ os-browserify@^0.3.0:
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==
 
-p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -5986,6 +6040,13 @@ p-limit@^3.0.2:
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -6089,6 +6150,11 @@ path-browserify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
   integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+  integrity sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -6978,6 +7044,11 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -7265,6 +7336,11 @@ serve-static@1.15.0:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.18.0"
+
+set-blocking@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+  integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
 set-function-length@^1.1.1:
   version "1.1.1"
@@ -7563,6 +7639,15 @@ string-argv@0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
+string-width@^3.0.0, string-width@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -7654,6 +7739,13 @@ stringify-object@^3.3.0:
     get-own-enumerable-property-symbols "^3.0.0"
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
+
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -8461,6 +8553,11 @@ which-collection@^1.0.1:
     is-weakmap "^2.0.1"
     is-weakset "^2.0.1"
 
+which-module@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
+  integrity sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==
+
 which-pm-runs@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.1.0.tgz#35ccf7b1a0fce87bd8b92a478c9d045785d3bf35"
@@ -8505,6 +8602,15 @@ wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
 
 wrap-ansi@^6.2.0:
   version "6.2.0"
@@ -8554,6 +8660,11 @@ xtend@^4.0.0:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
+y18n@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
@@ -8574,6 +8685,14 @@ yaml@^1.10.0, yaml@^1.10.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
@@ -8583,6 +8702,22 @@ yargs-parser@^21.0.0:
   version "21.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
   integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
+
+yargs@^13.3.0:
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
+  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.2"
 
 yargs@^17.0.1, yargs@^17.2.1, yargs@^17.3.1:
   version "17.5.1"


### PR DESCRIPTION
この機能を愛用している方が一部にいるので、応用してもらえるように公開API化を検討しています。

現状の非公開APIの実装でほぼ十分なので、少しだけ手直しして公開APIに移動させます。

## 非公開APIとの差異
- 認証必須
- 自分のコレクションをユーザー名指定省略で取るAPIは無い

## 既存の公開APIとの仕様差異
- DELETEがべき等ではない
  - べき等にするのは仕様検討[^1]も実装[^2]も面倒なので、今後は削除済みリソースは404返す方針に揃えるかも

[^1]: 他人の非公開リソースへの操作を404で返すと定義した場合、それにDELETEを送ったら消せないはずなのに204になるの? でも、404を返したら存在することが分かるよね? とか、そういう悩み
[^2]: ルートモデル結合が使えなくなる