### PR TITLE
チェックイン一覧API オカズリンクを含むチェックインのみ取得するオプションを追加

### DIFF
--- a/app/Http/Controllers/Api/V1/UserCheckinController.php
+++ b/app/Http/Controllers/Api/V1/UserCheckinController.php
@@ -36,6 +36,9 @@ discard_elapsed_time
 SQL
         ))
             ->where('user_id', $user->id);
+        if ($request->boolean('has_link')) {
+            $query = $query->where('link', '<>', '');
+        }
         if (!Auth::check() || $user->id !== Auth::id()) {
             $query = $query->where('is_private', false);
         }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -189,6 +189,12 @@ paths:
             default: 20
             minimum: 10
             maximum: 100
+        - name: has_link
+          in: query
+          description: オカズリンクを含むチェックインのみ取得
+          schema:
+            type: boolean
+            default: false
       responses:
         200:
           description: 成功

--- a/tests/Feature/Api/V1/UserCheckinTest.php
+++ b/tests/Feature/Api/V1/UserCheckinTest.php
@@ -144,4 +144,30 @@ class UserCheckinTest extends TestCase
             ]
         ], true);
     }
+
+    public function testHasLink()
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $target = User::factory()->create();
+        $hasLink = Ejaculation::factory()->create([
+            'user_id' => $target->id,
+            'link' => 'http://example.com',
+        ]);
+        Ejaculation::factory()->create([
+            'user_id' => $target->id,
+        ]);
+
+        $response = $this->getJson('/api/v1/users/' . $target->name . '/checkins?has_link=true');
+
+        $response->assertStatus(200);
+        $response->assertHeader('X-Total-Count', 1);
+        $response->assertJsonCount(1);
+        $response->assertJson([
+            [
+                'id' => $hasLink->id,
+            ]
+        ], true);
+    }
 }


### PR DESCRIPTION
WebUIの `/user/{username}/okazu` 相当のデータを取り出すためのオプションを追加しました。