### PR TITLE
GET /api/users/{user}/collections の結果をID順にソートする

### DIFF
--- a/app/Http/Controllers/Api/UserCollectionController.php
+++ b/app/Http/Controllers/Api/UserCollectionController.php
@@ -15,7 +15,7 @@ class UserCollectionController extends Controller
             throw new AccessDeniedHttpException('このユーザはチェックイン履歴を公開していません');
         }
 
-        $collections = $user->collections();
+        $collections = $user->collections()->orderBy('id');
         if (!$user->isMe()) {
             $collections = $collections->where('is_private', false);
         }


### PR DESCRIPTION
公開API `GET /api/v1/users/{user}/collections` と挙動を揃える。

こうすることで、フロントエンドで一番若いIDのコレクションを表示するつもりが適当なコレクションを表示してしまっているバグも直る。