### PR TITLE
チェックインのオカズリンクを更新した時にnormalized_linkも更新する

### DIFF
--- a/app/Ejaculation.php
+++ b/app/Ejaculation.php
@@ -60,6 +60,9 @@ class Ejaculation extends Model
         self::creating(function (Ejaculation $ejaculation) {
             $ejaculation->normalized_link = app(Formatter::class)->normalizeUrl($ejaculation->link);
         });
+        self::updating(function (Ejaculation $ejaculation) {
+            $ejaculation->normalized_link = app(Formatter::class)->normalizeUrl($ejaculation->link);
+        });
     }
 
     public function user()


### PR DESCRIPTION
fix #1154 