### PR TITLE
FxTwitterResolverの追加 & 同時アクセス制御・ポリシー制御単位をResolver内のHTTPリクエスト毎に変更

### DIFF
--- a/app/Console/Commands/CleanLock.php
+++ b/app/Console/Commands/CleanLock.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class CleanLock extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'tissue:lock:clean';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete obsolete global lock file';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $lockDir = storage_path('global_lock');
+        if (!is_dir($lockDir)) {
+            return Command::SUCCESS;
+        }
+        $dh = opendir($lockDir);
+        if (!$dh) {
+            $this->error("Can't open directory: {$lockDir}");
+
+            return Command::FAILURE;
+        }
+        try {
+            while (($file = readdir($dh)) !== false) {
+                $path = $lockDir . DIRECTORY_SEPARATOR . $file;
+                if (!is_file($path) || str_starts_with($file, '.')) {
+                    continue;
+                }
+
+                // あまり古くないファイルはスキップ
+                $mtime = filemtime($path);
+                if ($mtime === false || !Carbon::createFromTimestamp($mtime)->isBefore(Carbon::now()->subDays(7))) {
+                    continue;
+                }
+
+                // サーバープロセスで使用中だと困るので排他ロックを取ってから削除する
+                $fp = fopen($path, 'r');
+                if ($fp === false) {
+                    $this->error("Error (can't open lock file): {$file}");
+                    continue;
+                }
+                try {
+                    if (!flock($fp, LOCK_EX)) {
+                        $this->error("Error (can't lock file): {$file}");
+                        continue;
+                    }
+
+                    if (unlink($path)) {
+                        $this->info("Delete: {$file}");
+                    } else {
+                        $this->error("Error (can't delete lock file): {$file}");
+                    }
+                } finally {
+                    if (!fclose($fp)) {
+                        $this->error("Error (can't close lock file): {$file}");
+                    }
+                }
+            }
+        } finally {
+            closedir($dh);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,7 +15,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->command('tissue:lock:clean')->hourly();
     }
 
     /**

--- a/app/Exceptions/GlobalLockException.php
+++ b/app/Exceptions/GlobalLockException.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use App\Utilities\GlobalLock;
+
+/**
+ * {@see GlobalLock} のロック処理に失敗した時にスローされる例外
+ */
+class GlobalLockException extends \RuntimeException
+{
+}

--- a/app/MetadataResolver/CienResolver.php
+++ b/app/MetadataResolver/CienResolver.php
@@ -5,7 +5,7 @@ namespace App\MetadataResolver;
 use Carbon\Carbon;
 use GuzzleHttp\Client;
 
-class CienResolver extends MetadataResolver
+class CienResolver implements Resolver
 {
     /**
      * @var Client

--- a/app/MetadataResolver/FxTwitterResolver.php
+++ b/app/MetadataResolver/FxTwitterResolver.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace App\MetadataResolver;
+
+use GuzzleHttp\Client;
+
+class FxTwitterResolver implements TwitterResolver
+{
+    private Client $client;
+    private OGPResolver $ogpResolver;
+
+    public function __construct(Client $client, OGPResolver $ogpResolver)
+    {
+        $this->client = $client;
+        $this->ogpResolver = $ogpResolver;
+    }
+
+    public function resolve(string $url): Metadata
+    {
+        $url = preg_replace('/(www\.)?((mobile|m)\.)?(twitter|x)\.com/u', 'fxtwitter.com', $url);
+
+        $res = $this->client->get($url);
+        $html = (string) $res->getBody();
+
+        return $this->ogpResolver->parse($html);
+    }
+}

--- a/app/MetadataResolver/FxTwitterResolver.php
+++ b/app/MetadataResolver/FxTwitterResolver.php
@@ -7,13 +7,8 @@ use GuzzleHttp\Client;
 
 class FxTwitterResolver implements TwitterResolver
 {
-    private Client $client;
-    private OGPResolver $ogpResolver;
-
-    public function __construct(Client $client, OGPResolver $ogpResolver)
+    public function __construct(private Client $client, private OGPResolver $ogpResolver)
     {
-        $this->client = $client;
-        $this->ogpResolver = $ogpResolver;
     }
 
     public function resolve(string $url): Metadata

--- a/app/MetadataResolver/MetadataResolver.php
+++ b/app/MetadataResolver/MetadataResolver.php
@@ -46,13 +46,17 @@ class MetadataResolver implements Resolver
 
     public $defaultResolver = OGPResolver::class;
 
+    public function __construct(private Client $client)
+    {
+    }
+
     public function resolve(string $url): Metadata
     {
         foreach ($this->rules as $pattern => $class) {
             if (preg_match($pattern, $url) === 1) {
                 try {
                     /** @var Resolver $resolver */
-                    $resolver = app($class);
+                    $resolver = app($class, ['client' => $this->client]);
 
                     return $resolver->resolve($url);
                 } catch (UnsupportedContentException $e) {
@@ -67,7 +71,7 @@ class MetadataResolver implements Resolver
 
         if (isset($this->defaultResolver)) {
             /** @var Resolver $resolver */
-            $resolver = app($this->defaultResolver);
+            $resolver = app($this->defaultResolver, ['client' => $this->client]);
 
             return $resolver->resolve($url);
         }
@@ -84,8 +88,7 @@ class MetadataResolver implements Resolver
             // Acceptヘッダには */* を足さないことにする。
             $acceptTypes = array_diff(array_keys($this->mimeTypes), ['*/*']);
 
-            $client = app(Client::class);
-            $res = $client->request('GET', $url, [
+            $res = $this->client->request('GET', $url, [
                 'headers' => [
                     'Accept' => implode(', ', $acceptTypes)
                 ]
@@ -97,14 +100,14 @@ class MetadataResolver implements Resolver
 
                 if (isset($this->mimeTypes[$mimeType])) {
                     $class = $this->mimeTypes[$mimeType];
-                    $parser = app($class);
+                    $parser = app($class, ['client' => $this->client]);
 
                     return $parser->parse($res->getBody());
                 }
 
                 if (isset($this->mimeTypes['*/*'])) {
                     $class = $this->mimeTypes['*/*'];
-                    $parser = app($class);
+                    $parser = app($class, ['client' => $this->client]);
 
                     return $parser->parse($res->getBody());
                 }

--- a/app/MetadataResolver/MetadataResolver.php
+++ b/app/MetadataResolver/MetadataResolver.php
@@ -33,7 +33,7 @@ class MetadataResolver implements Resolver
         '~store\.steampowered\.com/app/\d+~' => SteamResolver::class,
         '~ss\.kb10uy\.org/posts/\d+$~' => Kb10uyShortStoryServerResolver::class,
         '~www\.hentai-foundry\.com/pictures/user/.+/\d+/.+~' => HentaiFoundryResolver::class,
-        '~(www\.)?((mobile|m)\.)?twitter\.com/(#!/)?[0-9a-zA-Z_]{1,15}/status(es)?/([0-9]+)(/photo/[1-4])?/?(\\?.+)?$~' => TwitterResolver::class,
+        '~(www\.)?((mobile|m)\.)?(twitter|x)\.com/(#!/)?[0-9a-zA-Z_]{1,15}/status(es)?/([0-9]+)(/photo/[1-4])?/?(\\?.+)?$~' => TwitterResolver::class,
         '~www\.mgstage\.com/~' => MGStageResolver::class,
     ];
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,9 +4,12 @@ namespace App\Providers;
 
 use App\MetadataResolver\FxTwitterResolver;
 use App\MetadataResolver\MetadataResolver;
+use App\MetadataResolver\Resolver;
 use App\MetadataResolver\TwitterResolver;
 use App\Services\MetadataResolveService;
+use App\Utilities\ApplyProviderPolicyMiddleware;
 use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -77,9 +80,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(MetadataResolver::class, function ($app) {
-            return new MetadataResolver();
-        });
+        $this->app->singleton(MetadataResolver::class);
         $this->app->singleton('parsedown', function () {
             return Parsedown::instance();
         });
@@ -90,10 +91,21 @@ class AppServiceProvider extends ServiceProvider
                 ]
             ]);
         });
+        $this->app->when(MetadataResolver::class)->needs(Client::class)->give(function ($app) {
+            $stack = HandlerStack::create();
+            $stack->push($app->make(ApplyProviderPolicyMiddleware::class));
+
+            return new Client([
+                RequestOptions::HEADERS => [
+                    'User-Agent' => 'TissueBot/1.0'
+                ],
+                'handler' => $stack,
+            ]);
+        });
         $this->app->when(MetadataResolveService::class)
             ->needs('$circuitBreakCount')
             ->give((int) config('metadata.circuit_break_count', 5));
-        $this->app->when(MetadataResolveService::class)
+        $this->app->when(ApplyProviderPolicyMiddleware::class)
             ->needs('$ignoreAccessInterval')
             ->give((bool) config('metadata.ignore_access_interval', false));
         $this->app->bind(TwitterResolver::class, function ($app) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,9 +2,8 @@
 
 namespace App\Providers;
 
+use App\MetadataResolver\FxTwitterResolver;
 use App\MetadataResolver\MetadataResolver;
-use App\MetadataResolver\TwitterApiResolver;
-use App\MetadataResolver\TwitterOGPResolver;
 use App\MetadataResolver\TwitterResolver;
 use App\Services\MetadataResolveService;
 use GuzzleHttp\Client;
@@ -98,11 +97,7 @@ class AppServiceProvider extends ServiceProvider
             ->needs('$ignoreAccessInterval')
             ->give((bool) config('metadata.ignore_access_interval', false));
         $this->app->bind(TwitterResolver::class, function ($app) {
-            if (empty(config('twitter.bearer_token'))) {
-                return $app->make(TwitterOGPResolver::class);
-            } else {
-                return $app->make(TwitterApiResolver::class);
-            }
+            return $app->make(FxTwitterResolver::class);
         });
     }
 }

--- a/app/Services/MetadataResolveService.php
+++ b/app/Services/MetadataResolveService.php
@@ -2,20 +2,16 @@
 
 namespace App\Services;
 
-use App\ContentProvider;
 use App\Metadata;
 use App\MetadataResolver\DeniedHostException;
-use App\MetadataResolver\DisallowedByProviderException;
 use App\MetadataResolver\MetadataResolver;
 use App\MetadataResolver\ResolverCircuitBreakException;
 use App\MetadataResolver\UncaughtResolverException;
 use App\Tag;
 use App\Utilities\Formatter;
-use Carbon\Carbon;
+use App\Utilities\GlobalLock;
 use Carbon\CarbonInterface;
-use GuzzleHttp\Client;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 
 class MetadataResolveService
 {
@@ -31,18 +27,11 @@ class MetadataResolveService
      */
     private $circuitBreakCount;
 
-    /**
-     * ContentProviderポリシー情報に基づく連続アクセス制限を無視する。
-     * @var bool
-     */
-    private $ignoreAccessInterval;
-
-    public function __construct(MetadataResolver $resolver, Formatter $formatter, int $circuitBreakCount, bool $ignoreAccessInterval = false)
+    public function __construct(MetadataResolver $resolver, Formatter $formatter, int $circuitBreakCount)
     {
         $this->resolver = $resolver;
         $this->formatter = $formatter;
         $this->circuitBreakCount = $circuitBreakCount;
-        $this->ignoreAccessInterval = $ignoreAccessInterval;
     }
 
     /**
@@ -67,194 +56,18 @@ class MetadataResolveService
         // 無かったら取得
         // TODO: ある程度古かったら再取得とかありだと思う
         if ($metadata == null || $metadata->needRefresh()) {
-            $hostWithPort = $this->getHostWithPortFromUrl($url);
-            $metadata = $this->hostLock($hostWithPort, function (?CarbonInterface $lastAccess) use ($url) {
-                // HostLockの解放待ちをしている間に、他のプロセスで取得完了しているかもしれない
+            $metadata = GlobalLock::urlLock($url, function (?CarbonInterface $lastAccess) use ($url) {
+                // GlobalLockの解放待ちをしている間に、他のプロセスで取得完了しているかもしれない
                 $metadata = Metadata::find($url);
                 if ($metadata !== null && !$metadata->needRefresh()) {
                     return $metadata;
                 }
-
-                $this->checkProviderPolicy($url, $this->ignoreAccessInterval ? null : $lastAccess);
 
                 return $this->resolve($url, $metadata);
             });
         }
 
         return $metadata;
-    }
-
-    /**
-     * URLからホスト部とポート部を抽出
-     * @param string $url
-     * @return string
-     */
-    private function getHostWithPortFromUrl(string $url): string
-    {
-        $parts = parse_url($url);
-        $host = $parts['host'];
-        if (isset($parts['port'])) {
-            $host .= ':' . $parts['port'];
-        }
-
-        return $host;
-    }
-
-    /**
-     * アクセス先ホスト単位の排他ロックを取って処理を実行
-     * @param string $host
-     * @param callable $fn
-     * @return mixed return of $fn
-     * @throws \RuntimeException いろいろな死に方をする
-     */
-    private function hostLock(string $host, callable $fn)
-    {
-        $lockDir = storage_path('content_providers_lock');
-        if (!file_exists($lockDir)) {
-            if (!mkdir($lockDir)) {
-                throw new \RuntimeException("Lock failed! Can't create lock directory.");
-            }
-        }
-
-        $lockFile = $lockDir . DIRECTORY_SEPARATOR . $host;
-        $fp = fopen($lockFile, 'c+b');
-        if ($fp === false) {
-            throw new \RuntimeException("Lock failed! Can't open lock file.");
-        }
-
-        try {
-            if (!flock($fp, LOCK_EX)) {
-                throw new \RuntimeException("Lock failed! Can't lock file.");
-            }
-
-            try {
-                $accessInfoText = stream_get_contents($fp);
-                if ($accessInfoText !== false) {
-                    $accessInfo = json_decode($accessInfoText, true);
-                }
-
-                $result = $fn(isset($accessInfo['time']) ? new Carbon($accessInfo['time']) : null);
-
-                $accessInfo = [
-                    'time' => now()->toIso8601String()
-                ];
-                fseek($fp, 0);
-                if (fwrite($fp, json_encode($accessInfo)) === false) {
-                    throw new \RuntimeException("I/O Error! Can't write to lock file.");
-                }
-
-                return $result;
-            } finally {
-                if (!flock($fp, LOCK_UN)) {
-                    throw new \RuntimeException("Unlock failed! Can't unlock file.");
-                }
-            }
-        } finally {
-            if (!fclose($fp)) {
-                throw new \RuntimeException("Unlock failed! Can't close lock file.");
-            }
-        }
-    }
-
-    /**
-     * 指定したメタデータURLのホストが持つrobots.txtをダウンロードします。
-     * @param string $url メタデータのURL
-     * @return string
-     */
-    private function fetchRobotsTxt(string $url): ?string
-    {
-        $parts = parse_url($url);
-        $robotsUrl = http_build_url([
-            'scheme' => $parts['scheme'],
-            'host' => $parts['host'],
-            'port' => $parts['port'] ?? null,
-            'path' => '/robots.txt'
-        ]);
-
-        $client = app(Client::class);
-        try {
-            $res = $client->get($robotsUrl);
-            if (stripos($res->getHeaderLine('Content-Type'), 'text/plain') !== 0) {
-                Log::error('robots.txtの取得に失敗: 不適切なContent-Type (' . $res->getHeaderLine('Content-Type') . ')');
-
-                return null;
-            }
-
-            return (string) $res->getBody();
-        } catch (\Exception $e) {
-            Log::error("robots.txtの取得に失敗: {$e}");
-
-            return null;
-        }
-    }
-
-    /**
-     * ContentProviderポリシー情報との照合を行い、アクセス可能かチェックします。アクセスできない場合は例外をスローします。
-     * @param string $url メタデータを取得したいURL
-     * @param CarbonInterface|null $lastAccess アクセス先ホストへの最終アクセス日時 (記録がある場合)
-     * @throws DeniedHostException アクセス先がTissue内のブラックリストに入っている場合にスロー
-     * @throws DisallowedByProviderException アクセス先のrobots.txtによって拒否されている場合にスロー
-     */
-    private function checkProviderPolicy(string $url, ?CarbonInterface $lastAccess): void
-    {
-        DB::beginTransaction();
-        try {
-            $hostWithPort = $this->getHostWithPortFromUrl($url);
-            $contentProvider = ContentProvider::sharedLock()->find($hostWithPort);
-            if ($contentProvider === null) {
-                $contentProvider = ContentProvider::create([
-                    'host' => $hostWithPort,
-                    'robots' => $this->fetchRobotsTxt($url),
-                    'robots_cached_at' => now(),
-                ]);
-            }
-
-            if ($contentProvider->is_blocked) {
-                throw new DeniedHostException($url);
-            }
-
-            // 連続アクセス制限
-            if ($lastAccess !== null) {
-                $elapsedSeconds = $lastAccess->diffInSeconds(now(), false);
-                if ($elapsedSeconds < $contentProvider->access_interval_sec) {
-                    if ($elapsedSeconds < 0) {
-                        $wait = abs($elapsedSeconds) + $contentProvider->access_interval_sec;
-                    } else {
-                        $wait = $contentProvider->access_interval_sec - $elapsedSeconds;
-                    }
-                    sleep($wait);
-                }
-            }
-
-            // Fetch robots.txt
-            if ($contentProvider->robots_cached_at->diffInDays(now()) >= 7) {
-                $contentProvider->update([
-                    'robots' => $this->fetchRobotsTxt($url),
-                    'robots_cached_at' => now(),
-                ]);
-            }
-
-            // Check robots.txt
-            $robotsParser = new \RobotsTxtParser($contentProvider->robots);
-            $robotsParser->setUserAgent('TissueBot');
-            $robotsDelay = $robotsParser->getDelay();
-            if ($robotsDelay !== 0 && $robotsDelay >= $contentProvider->access_interval_sec) {
-                $contentProvider->access_interval_sec = (int) $robotsDelay;
-                $contentProvider->save();
-            }
-            if ($robotsParser->isDisallowed(parse_url($url, PHP_URL_PATH))) {
-                throw new DisallowedByProviderException($url);
-            }
-
-            DB::commit();
-        } catch (DeniedHostException | DisallowedByProviderException $e) {
-            // ContentProviderのデータ更新は行うため
-            DB::commit();
-            throw $e;
-        } catch (\Exception $e) {
-            DB::rollBack();
-            throw $e;
-        }
     }
 
     /**

--- a/app/Utilities/ApplyProviderPolicyMiddleware.php
+++ b/app/Utilities/ApplyProviderPolicyMiddleware.php
@@ -1,0 +1,142 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Utilities;
+
+use App\ContentProvider;
+use App\MetadataResolver\DeniedHostException;
+use App\MetadataResolver\DisallowedByProviderException;
+use Carbon\CarbonInterface;
+use GuzzleHttp\Client;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * リクエストに対して {@see ContentProvider} のポリシーを適用するGuzzle Middleware
+ */
+class ApplyProviderPolicyMiddleware
+{
+    /**
+     * @param bool $ignoreAccessInterval ContentProviderポリシー情報に基づく連続アクセス制限を無視する
+     */
+    public function __construct(private bool $ignoreAccessInterval = false)
+    {
+    }
+
+    public function __invoke(callable $next): callable
+    {
+        return function (RequestInterface $request, array $options) use ($next) {
+            $url = (string) $request->getUri();
+            $hostWithPort = URLUtility::getHostWithPortFromUrl($url);
+
+            // 同一オリジンへの連続アクセス制限のために排他ロックを取る
+            return GlobalLock::hostLock($hostWithPort, function (?CarbonInterface $lastAccess) use ($request, $options, $next, $url) {
+                $this->checkProviderPolicy($url, $this->ignoreAccessInterval ? null : $lastAccess);
+
+                return $next($request, $options);
+            });
+        };
+    }
+
+    /**
+     * ContentProviderポリシー情報との照合を行い、アクセス可能かチェックします。アクセスできない場合は例外をスローします。
+     * @param string $url アクセス先のURL
+     * @param CarbonInterface|null $lastAccess アクセス先ホストへの最終アクセス日時 (記録がある場合)
+     * @throws DeniedHostException アクセス先がTissue内のブラックリストに入っている場合にスロー
+     * @throws DisallowedByProviderException アクセス先のrobots.txtによって拒否されている場合にスロー
+     */
+    private function checkProviderPolicy(string $url, ?CarbonInterface $lastAccess)
+    {
+        DB::beginTransaction();
+        try {
+            $hostWithPort = URLUtility::getHostWithPortFromUrl($url);
+            $contentProvider = ContentProvider::sharedLock()->find($hostWithPort);
+            if ($contentProvider === null) {
+                $contentProvider = ContentProvider::create([
+                    'host' => $hostWithPort,
+                    'robots' => $this->fetchRobotsTxt($url),
+                    'robots_cached_at' => now(),
+                ]);
+            }
+
+            if ($contentProvider->is_blocked) {
+                throw new DeniedHostException($url);
+            }
+
+            // 連続アクセス制限
+            if ($lastAccess !== null) {
+                $elapsedSeconds = $lastAccess->diffInSeconds(now(), false);
+                if ($elapsedSeconds < $contentProvider->access_interval_sec) {
+                    if ($elapsedSeconds < 0) {
+                        $wait = abs($elapsedSeconds) + $contentProvider->access_interval_sec;
+                    } else {
+                        $wait = $contentProvider->access_interval_sec - $elapsedSeconds;
+                    }
+                    sleep($wait);
+                }
+            }
+
+            // Fetch robots.txt
+            if ($contentProvider->robots_cached_at->diffInDays(now()) >= 7) {
+                $contentProvider->update([
+                    'robots' => $this->fetchRobotsTxt($url),
+                    'robots_cached_at' => now(),
+                ]);
+            }
+
+            // Check robots.txt
+            $robotsParser = new \RobotsTxtParser($contentProvider->robots);
+            $robotsParser->setUserAgent('TissueBot');
+            $robotsDelay = $robotsParser->getDelay();
+            if ($robotsDelay !== 0 && $robotsDelay >= $contentProvider->access_interval_sec) {
+                $contentProvider->access_interval_sec = (int) $robotsDelay;
+                $contentProvider->save();
+            }
+            if ($robotsParser->isDisallowed(parse_url($url, PHP_URL_PATH))) {
+                throw new DisallowedByProviderException($url);
+            }
+
+            DB::commit();
+        } catch (DeniedHostException | DisallowedByProviderException $e) {
+            // ContentProviderのデータ更新は行うため
+            DB::commit();
+            throw $e;
+        } catch (\Exception $e) {
+            DB::rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * 指定したメタデータURLのホストが持つrobots.txtをダウンロードします。
+     * @param string $url メタデータのURL
+     * @return string
+     */
+    private function fetchRobotsTxt(string $url): ?string
+    {
+        $parts = parse_url($url);
+        $robotsUrl = http_build_url([
+            'scheme' => $parts['scheme'],
+            'host' => $parts['host'],
+            'port' => $parts['port'] ?? null,
+            'path' => '/robots.txt'
+        ]);
+
+        $client = app(Client::class);
+        try {
+            $res = $client->get($robotsUrl);
+            if (stripos($res->getHeaderLine('Content-Type'), 'text/plain') !== 0) {
+                Log::error('robots.txtの取得に失敗: 不適切なContent-Type (' . $res->getHeaderLine('Content-Type') . ')');
+
+                return null;
+            }
+
+            return (string) $res->getBody();
+        } catch (\Exception $e) {
+            Log::error("robots.txtの取得に失敗: {$e}");
+
+            return null;
+        }
+    }
+}

--- a/app/Utilities/GlobalLock.php
+++ b/app/Utilities/GlobalLock.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Utilities;
+
+use App\Exceptions\GlobalLockException;
+use Carbon\Carbon;
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * システムグローバルな排他ロックを取るためのユーティリティ
+ */
+class GlobalLock
+{
+    /**
+     * ホスト名をキーとして排他ロックを取って処理を実行する
+     * @param string $host ロック対象のホスト名
+     * @param callable $fn ロックを獲得したら実行する処理
+     * @return mixed `$fn` の戻り値
+     * @throws GlobalLockException ロック・ロック解除処理に失敗した場合にスロー
+     */
+    public static function hostLock(string $host, callable $fn): mixed
+    {
+        return static::lock('host$' . $host, $fn);
+    }
+
+    /**
+     * URIをキーとして排他ロックを取って処理を実行する
+     * @param UriInterface $uri ロック対象のURI
+     * @param callable $fn ロックを獲得したら実行する処理
+     * @return mixed `$fn` の戻り値
+     * @throws GlobalLockException ロック・ロック解除処理に失敗した場合にスロー
+     */
+    public static function uriLock(UriInterface $uri, callable $fn): mixed
+    {
+        $hash = hash('sha256', implode("\0", [$uri->getPath(), $uri->getQuery(), $uri->getFragment()]));
+
+        return static::lock('uri$' . $uri->getHost() . '$' . $hash, $fn);
+    }
+
+    /**
+     * URL文字列をキーとして排他ロックを取って処理を実行する
+     * @param string $url ロック対象のURL文字列
+     * @param callable $fn ロックを獲得したら実行する処理
+     * @return mixed `$fn` の戻り値
+     * @throws GlobalLockException ロック・ロック解除処理に失敗した場合にスロー
+     */
+    public static function urlLock(string $url, callable $fn): mixed
+    {
+        return static::uriLock(new Uri($url), $fn);
+    }
+
+    /**
+     * 指定したキーで排他ロックを取って処理を実行する。
+     * @param string $key ロックに使うキー
+     * @param callable $fn ロックを獲得したら実行する処理
+     * @return mixed `$fn` の戻り値
+     * @throws GlobalLockException ロック・ロック解除処理に失敗した場合にスロー
+     */
+    public static function lock(string $key, callable $fn): mixed
+    {
+        $lockDir = storage_path('global_lock');
+        if (!file_exists($lockDir)) {
+            if (!mkdir($lockDir)) {
+                throw new GlobalLockException("Lock failed! Can't create lock directory.");
+            }
+        }
+
+        $lockFile = $lockDir . DIRECTORY_SEPARATOR . $key;
+        $fp = fopen($lockFile, 'c+b');
+        if ($fp === false) {
+            throw new GlobalLockException("Lock failed! Can't open lock file.");
+        }
+
+        try {
+            if (!flock($fp, LOCK_EX)) {
+                throw new GlobalLockException("Lock failed! Can't lock file.");
+            }
+
+            try {
+                $accessInfoText = stream_get_contents($fp);
+                if ($accessInfoText !== false) {
+                    $accessInfo = json_decode($accessInfoText, true);
+                } else {
+                    $accessInfo = [];
+                }
+
+                $result = $fn(isset($accessInfo['time']) ? new Carbon($accessInfo['time']) : null);
+
+                $accessInfo = [
+                    'time' => now()->toIso8601String()
+                ];
+                fseek($fp, 0);
+                if (fwrite($fp, json_encode($accessInfo)) === false) {
+                    throw new GlobalLockException("I/O Error! Can't write to lock file.");
+                }
+
+                return $result;
+            } finally {
+                if (!flock($fp, LOCK_UN)) {
+                    throw new GlobalLockException("Unlock failed! Can't unlock file.");
+                }
+            }
+        } finally {
+            if (!fclose($fp)) {
+                throw new GlobalLockException("Unlock failed! Can't close lock file.");
+            }
+        }
+
+        throw new \LogicException('unreachable');
+    }
+}

--- a/app/Utilities/URLUtility.php
+++ b/app/Utilities/URLUtility.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Utilities;
+
+class URLUtility
+{
+    /**
+     * URLからホスト部とポート部を抽出
+     * @param string $url
+     * @return string
+     */
+    public static function getHostWithPortFromUrl(string $url): string
+    {
+        $parts = parse_url($url);
+        $host = $parts['host'];
+        if (isset($parts['port'])) {
+            $host .= ':' . $parts['port'];
+        }
+
+        return $host;
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,5 @@
 services:
-  web:
+  web: &php
     build:
       context: .
       dockerfile: docker/development/web.dockerfile
@@ -25,6 +25,10 @@ services:
     networks:
       - backend
     restart: always
+  scheduler:
+    <<: *php
+    command: php artisan schedule:work
+    ports: []
   antlr:
     build:
       context: .

--- a/docker/production/sample/compose.yaml
+++ b/docker/production/sample/compose.yaml
@@ -1,5 +1,5 @@
 services:
-  php:
+  php: &php
     image: ghcr.io/shikorism/tissue-php
     restart: always
     env_file: .env
@@ -17,3 +17,7 @@ services:
       - 127.0.0.1:4545:80
     depends_on:
       - php
+
+  scheduler:
+    <<: *php
+    command: php artisan schedule:work

--- a/storage/global_lock/.gitignore
+++ b/storage/global_lock/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Unit/Services/MetadataResolverServiceTest.php
+++ b/tests/Unit/Services/MetadataResolverServiceTest.php
@@ -68,6 +68,7 @@ class MetadataResolverServiceTest extends TestCase
         $handler = HandlerStack::create(new MockHandler([new Response(404)]));
         $client = new Client(['handler' => $handler]);
         $this->instance(Client::class, $client);
+        $this->app->when(MetadataResolver::class)->needs(Client::class)->give(fn () => $client);
 
         try {
             $service = app()->make(MetadataResolveService::class);
@@ -91,6 +92,7 @@ class MetadataResolverServiceTest extends TestCase
         $handler = HandlerStack::create(new MockHandler([new Response(503), new Response(503)]));
         $client = new Client(['handler' => $handler]);
         $this->instance(Client::class, $client);
+        $this->app->when(MetadataResolver::class)->needs(Client::class)->give(fn () => $client);
 
         try {
             $service = app()->make(MetadataResolveService::class);
@@ -161,6 +163,7 @@ HTML;
         ]));
         $client = new Client(['handler' => $handler]);
         $this->instance(Client::class, $client);
+        $this->app->when(MetadataResolver::class)->needs(Client::class)->give(fn () => $client);
 
         for ($i = 0; $i < 2; $i++) {
             try {

--- a/tests/Unit/Utilities/URLUtilityTest.php
+++ b/tests/Unit/Utilities/URLUtilityTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Utilities;
+
+use App\Utilities\URLUtility;
+use Tests\TestCase;
+
+class URLUtilityTest extends TestCase
+{
+    /**
+     * @dataProvider provideGetHostWithPortFromUrl
+     */
+    public function testGetHostWithPortFromUrl($expected, $url)
+    {
+        $this->assertSame($expected, URLUtility::getHostWithPortFromUrl($url));
+    }
+
+    public function provideGetHostWithPortFromUrl()
+    {
+        return [
+            'host' => ['example.com', 'http://example.com'],
+            'host with port' => ['example.com:8080', 'http://example.com:8080'],
+        ];
+    }
+}


### PR DESCRIPTION
## FxTwitterResolver
fxtwitter.com を経由してXのポストからメタデータを取得する実装を追加しました。

## 同時アクセス制御・ポリシー制御単位をResolver内のHTTPリクエスト毎に変更
FxTwitterResolverを追加したのはいいのですが、これだけだとダメでした。

既存実装ではメタデータ解決の入力URLに書かれているホストに対してrobots.txtチェックを行っていますが、https://x.com/robots.txt ではほとんどのbotが拒否されているからです。

この制御の目的は

- 同時アクセスが発生しないようにする
- robots.txtの解析を行い拒否されている場合にメタデータの取得処理を行わない

ことですが (#468 より) 、実際にHTTPリクエストを行う先に対してチェックするほうがより妥当と言えます。  
(x.comにアクセスしていないのに、そこのrobots.txtに従う道理は無い)

そのため、制御を行う場所をMetadataResolverの実行前から、MetadataResolverが使うGuzzleのmiddlewareスタック内に移動させました。