### PR TITLE
Tabler Icons 3.6, タグ周りのUI差し戻し

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/preset-react": "^7.24.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
-    "@tabler/icons-webfont": "^2.44.0",
+    "@tabler/icons-webfont": "^3.6.0",
     "@tanstack/react-query": "^4.0.0",
     "@tanstack/react-query-devtools": "^4.0.0",
     "@types/bootstrap": "^4.5.0",

--- a/resources/assets/js/components/MetadataPreview.tsx
+++ b/resources/assets/js/components/MetadataPreview.tsx
@@ -138,7 +138,7 @@ export const MetadataPreview: React.FC<MetadataPreviewProps> = ({ link, tags, on
                                                         className={tagClasses(tag)}
                                                         onClick={() => !tag.used && onClickTag(tag.name)}
                                                     >
-                                                        <i className="ti ti-tag" /> {tag.name}
+                                                        <i className="ti ti-tag-filled" /> {tag.name}
                                                     </li>
                                                 ))}
                                             </ul>

--- a/resources/assets/js/components/TagInput.tsx
+++ b/resources/assets/js/components/TagInput.tsx
@@ -60,7 +60,7 @@ export const TagInput: React.FC<TagInputProps> = ({ id, name, values, isInvalid,
                         className={classNames('list-inline-item', 'badge', 'badge-primary', 'tis-tag-input-item')}
                         onClick={() => removeTag(i)}
                     >
-                        <i className="ti ti-tag" /> {tag} | x
+                        <i className="ti ti-tag-filled" /> {tag} | x
                     </li>
                 ))}
                 <li className="list-inline-item">

--- a/resources/assets/js/user/collection.tsx
+++ b/resources/assets/js/user/collection.tsx
@@ -233,19 +233,16 @@ const CollectionItem: React.FC<CollectionItemProps> = ({ item, onUpdate }) => {
                 </p>
             </div>
             {item.tags.length !== 0 && (
-                <p className="d-flex mb-2">
-                    <i className="ti ti-tag mr-1" style={{ marginTop: '0.25rem' }} />
-                    <p className="tis-checkin-tags mb-0">
-                        {item.tags.map((tag: string) => (
-                            <a
-                                key={tag}
-                                className="badge badge-secondary"
-                                href={`/search/collection?q=${encodeURIComponent(tag)}`}
-                            >
-                                {tag}
-                            </a>
-                        ))}
-                    </p>
+                <p className="tis-checkin-tags mb-2">
+                    {item.tags.map((tag: string) => (
+                        <a
+                            key={tag}
+                            className="badge badge-secondary"
+                            href={`/search/collection?q=${encodeURIComponent(tag)}`}
+                        >
+                            <i className="ti ti-tag-filled" /> {tag}
+                        </a>
+                    ))}
                 </p>
             )}
             {item.note_html != '' && (

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -5,7 +5,7 @@ $primary: #e53fb1;
 @import "~bootstrap/scss/bootstrap";
 
 // Tabler Icons
-@import "~@tabler/icons-webfont/tabler-icons";
+@import "~@tabler/icons-webfont/dist/tabler-icons";
 
 // Legacy app styles
 @import "tissue.css";

--- a/resources/views/components/ejaculation.blade.php
+++ b/resources/views/components/ejaculation.blade.php
@@ -14,7 +14,7 @@
     @endswitch
 </div>
 <!-- tags -->
-@if ($ejaculation->is_private || $ejaculation->source === 'csv')
+@if ($ejaculation->is_private || $ejaculation->source === 'csv' || $ejaculation->tags->isNotEmpty())
     <p class="tis-checkin-tags mb-2">
         @if ($ejaculation->is_private)
             <span class="badge badge-warning"><i class="ti ti-lock"></i> 非公開</span>
@@ -22,17 +22,10 @@
         @if ($ejaculation->source === 'csv')
             <span class="badge badge-info"><i class="ti ti-cloud-upload"></i> インポート</span>
         @endif
+        @foreach ($ejaculation->tags as $tag)
+            <a class="badge badge-secondary" href="{{ route('search', ['q' => $tag->name]) }}"><i class="ti ti-tag-filled"></i> {{ $tag->name }}</a>
+        @endforeach
     </p>
-@endif
-@if ($ejaculation->tags->isNotEmpty())
-    <div class="d-flex mb-2">
-        <i class="ti ti-tag mr-1" style="margin-top: 0.25rem;"></i>
-        <div class="tis-checkin-tags">
-            @foreach ($ejaculation->tags as $tag)
-                <a class="badge badge-secondary" href="{{ route('search', ['q' => $tag->name]) }}">{{ $tag->name }}</a>
-            @endforeach
-        </div>
-    </div>
 @endif
 <div class="{{ $ejaculation->isMuted() ? 'tis-checkin-muted' : '' }}">
     <!-- okazu link -->

--- a/resources/views/search/collection.blade.php
+++ b/resources/views/search/collection.blade.php
@@ -18,14 +18,11 @@
                     </p>
                 </div>
                 @if ($item->tags->isNotEmpty())
-                    <div class="d-flex mb-2">
-                        <i class="ti ti-tag mr-1" style="margin-top: 0.25rem;"></i>
-                        <div class="tis-checkin-tags">
-                            @foreach ($item->tags as $tag)
-                                <a class="badge badge-secondary" href="{{ route('search.collection', ['q' => $tag->name]) }}">{{ $tag->name }}</a>
-                            @endforeach
-                        </div>
-                    </div>
+                    <p class="tis-checkin-tags mb-2">
+                        @foreach ($item->tags as $tag)
+                            <a class="badge badge-secondary" href="{{ route('search.collection', ['q' => $tag->name]) }}"><i class="ti ti-tag-filled"></i> {{ $tag->name }}</a>
+                        @endforeach
+                    </p>
                 @endif
                 @if (!empty($item->note))
                     <p class="mb-2 text-break">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1464,6 +1464,18 @@
   dependencies:
     dequal "^2.0.3"
 
+"@tabler/icons-webfont@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@tabler/icons-webfont/-/icons-webfont-3.6.0.tgz#45a75c87cf239c1d6fe55cd46ad7ab80f63d7fed"
+  integrity sha512-UiJ3j6m9VEyfNBBYFxa89t1HtC5n1zA6wrQ+Z04zx2hQ6kyHMoj8DnSNSt0/KJipvnIbWgNxDBmGTXA2KjK+SA==
+  dependencies:
+    "@tabler/icons" "3.6.0"
+
+"@tabler/icons@3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@tabler/icons/-/icons-3.6.0.tgz#9d5aeb4108bcd0d97b3c955ea425b645ea79a304"
+  integrity sha512-Zv0Ofc64RCMpZ2F8CvsWAphrSjerx5hEErt/RMmE+W8r4E5l5Lizi+My9KbbZQ4NyAtrtrOX80OY1oROZrRzEA==
+
 "@tanstack/match-sorter-utils@^8.7.0":
   version "8.8.4"
   resolved "https://registry.yarnpkg.com/@tanstack/match-sorter-utils/-/match-sorter-utils-8.8.4.tgz#0b2864d8b7bac06a9f84cb903d405852cc40a457"
@@ -1492,18 +1504,6 @@
   dependencies:
     "@tanstack/query-core" "4.36.1"
     use-sync-external-store "^1.2.0"
-
-"@tabler/icons-webfont@^2.44.0":
-  version "2.44.0"
-  resolved "https://registry.yarnpkg.com/@tabler/icons-webfont/-/icons-webfont-2.44.0.tgz#105024173bf89964ec0485292daec62f2a6c2e90"
-  integrity sha512-E5+CYnZXKTUGFhpb0KGiRR4s+Tylbsq6/CA88QKn44xaBfU3ui/zVwKc1vaTKBL9kxZIxNz7qLkne+lUd/Hvzw==
-  dependencies:
-    "@tabler/icons" "2.44.0"
-
-"@tabler/icons@2.44.0":
-  version "2.44.0"
-  resolved "https://registry.yarnpkg.com/@tabler/icons/-/icons-2.44.0.tgz#9f3cf86150b23e84a6eaf9d29ab2b2aaa8c7eed6"
-  integrity sha512-WPPtihDcAwEm1QZM9MXQw6+r/R2/qx7KMU1eegsi9DsqBLAb0W2kbt6e/syvd6j9c+6XNpRVBW1ziGqSWQAWOg==
 
 "@trysound/sax@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
Tabler Icons 3.6がリリースされて、tag-filledがマージされたっぽいので使うことにしました。

<img width="795" alt="image" src="https://github.com/shikorism/tissue/assets/1352154/9beb9cf4-c61a-4edb-bc94-43e51d6374d2">
