### PR TITLE
Collectionの最大数緩和とUI改善

### DIFF
--- a/app/Collection.php
+++ b/app/Collection.php
@@ -10,7 +10,7 @@ class Collection extends Model
     use HasFactory;
 
     /** @var int ユーザーごとの作成数制限 */
-    const PER_USER_LIMIT = 100;
+    const PER_USER_LIMIT = 500;
 
     protected $fillable = [
         'title',

--- a/app/Http/Controllers/Api/V1/CollectionItemController.php
+++ b/app/Http/Controllers/Api/V1/CollectionItemController.php
@@ -72,6 +72,7 @@ class CollectionItemController extends Controller
         $item = DB::transaction(function () use ($collection, $validated) {
             $item = new CollectionItem($validated);
             $collection->items()->save($item);
+            $collection->touch();
 
             $tagIds = [];
             if (!empty($validated['tags'])) {
@@ -119,6 +120,7 @@ class CollectionItemController extends Controller
 
         DB::transaction(function () use ($item, $validated) {
             $item->save();
+            $item->collection->touch();
 
             if (isset($validated['tags'])) {
                 $tagIds = [];
@@ -143,7 +145,11 @@ class CollectionItemController extends Controller
     public function destroy(Collection $collection, CollectionItem $item)
     {
         $this->authorize('edit', $item);
-        $item->delete();
+
+        DB::transaction(function () use ($item) {
+            $item->collection->touch();
+            $item->delete();
+        });
 
         return response()->noContent();
     }

--- a/app/Http/Resources/CollectionResource.php
+++ b/app/Http/Resources/CollectionResource.php
@@ -20,6 +20,7 @@ class CollectionResource extends JsonResource
             'user_name' => $this->user->name,
             'title' => $this->title,
             'is_private' => $this->is_private,
+            'updated_at' => $this->updated_at,
         ];
     }
 }

--- a/resources/assets/js/components/collections/AddToCollectionButton.tsx
+++ b/resources/assets/js/components/collections/AddToCollectionButton.tsx
@@ -9,6 +9,7 @@ import {
     CollectionFormValues,
 } from './CollectionEditModal';
 import { CollectionSelectModal } from './CollectionSelectModal';
+import { parseISO, compareDesc } from 'date-fns';
 
 const ToggleButton = React.forwardRef<HTMLButtonElement>((props, ref) => (
     <Button {...props} ref={ref} variant="" className="text-secondary">
@@ -115,7 +116,8 @@ export const AddToCollectionButton: React.FC<AddToCollectionButtonProps> = ({
                 {collections ? (
                     <>
                         {collections
-                            .filter((_, i) => i < 5) // TODO: 最近使ったものを表示したい
+                            .sort((a, b) => compareDesc(parseISO(a.updated_at), parseISO(b.updated_at)))
+                            .filter((_, i) => i < 5)
                             .map((collection) => (
                                 <Dropdown.Item key={collection.id} eventKey={collection.id}>
                                     <i className="ti ti-folder mr-2 text-secondary" />

--- a/resources/assets/js/components/collections/CollectionSelectModal.tsx
+++ b/resources/assets/js/components/collections/CollectionSelectModal.tsx
@@ -1,5 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { ListGroup, ListGroupItem, Modal, ModalProps } from 'react-bootstrap';
+import { compareAsc, parseISO } from 'date-fns';
+
+type SortKey = 'id:asc' | 'id:desc' | 'name:asc' | 'name:desc' | 'updated_at:asc' | 'updated_at:desc';
 
 interface CollectionSelectModalProps extends ModalProps {
     title: string;
@@ -11,21 +14,83 @@ export const CollectionSelectModal: React.FC<CollectionSelectModalProps> = ({
     title,
     collections,
     onSelectCollection,
+    show,
     ...rest
 }) => {
+    const [filter, setFilter] = useState('');
+    const [sort, setSort] = useState<SortKey>('updated_at:desc');
+
+    useEffect(() => {
+        if (show) {
+            setFilter('');
+            setSort('updated_at:desc');
+        }
+    }, [show]);
+
+    const sortedCollections = collections.sort((a, b) => {
+        const [field] = sort.split(':');
+        switch (field) {
+            case 'id':
+                return a.id - b.id;
+            case 'name':
+                return a.title.localeCompare(b.title);
+            case 'updated_at':
+                return compareAsc(parseISO(a.updated_at), parseISO(b.updated_at));
+            default:
+                throw 'invalid sort key';
+        }
+    });
+    if (sort.split(':')[1] === 'desc') {
+        sortedCollections.reverse();
+    }
+
     return (
-        <Modal {...rest}>
+        <Modal show={show} {...rest}>
             <Modal.Header closeButton>
                 <Modal.Title as="h5">{title}</Modal.Title>
             </Modal.Header>
             <Modal.Body>
                 <ListGroup variant="flush" className="m-n3 rounded">
-                    {collections.map((collection) => (
-                        <ListGroupItem key={collection.id} action onClick={() => onSelectCollection(collection)}>
-                            <i className="ti ti-folder mr-2 text-secondary" />
-                            {collection.title}
-                        </ListGroupItem>
-                    ))}
+                    <ListGroupItem>
+                        <div>
+                            <input
+                                className="form-control"
+                                type="search"
+                                placeholder="検索"
+                                value={filter}
+                                onChange={(e) => setFilter(e.target.value)}
+                            />
+                        </div>
+                        <div className="mt-2 position-relative">
+                            <i
+                                className="ti ti-sort-ascending-letters mr-2 position-absolute text-secondary"
+                                style={{ top: '22%', left: '0.75rem' }}
+                            />
+                            <select
+                                className="form-control form-control-sm"
+                                style={{ paddingLeft: '1.75rem' }}
+                                value={sort}
+                                onChange={(e) => setSort(e.target.value as SortKey)}
+                            >
+                                <option value="name:asc">名前 昇順</option>
+                                <option value="name:desc">名前 降順</option>
+                                <option value="id:asc">作成日時 昇順</option>
+                                <option value="id:desc">作成日時 降順</option>
+                                <option value="updated_at:asc">更新日時 昇順</option>
+                                <option value="updated_at:desc">更新日時 降順</option>
+                            </select>
+                        </div>
+                    </ListGroupItem>
+                    {sortedCollections
+                        .filter((collection) =>
+                            filter ? collection.title.toLowerCase().includes(filter.toLowerCase()) : true,
+                        )
+                        .map((collection) => (
+                            <ListGroupItem key={collection.id} action onClick={() => onSelectCollection(collection)}>
+                                <i className="ti ti-folder mr-2 text-secondary" />
+                                {collection.title}
+                            </ListGroupItem>
+                        ))}
                 </ListGroup>
             </Modal.Body>
         </Modal>

--- a/resources/assets/js/components/collections/CollectionSelectModal.tsx
+++ b/resources/assets/js/components/collections/CollectionSelectModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { ListGroup, ListGroupItem, Modal, ModalProps } from 'react-bootstrap';
-import { compareAsc, parseISO } from 'date-fns';
 import { SortKeySelect } from './SortKeySelect';
+import { sortAndFilteredCollections } from './search';
 
 type SortKey = 'id:asc' | 'id:desc' | 'name:asc' | 'name:desc' | 'updated_at:asc' | 'updated_at:desc';
 
@@ -28,23 +28,6 @@ export const CollectionSelectModal: React.FC<CollectionSelectModalProps> = ({
         }
     }, [show]);
 
-    const sortedCollections = collections.sort((a, b) => {
-        const [field] = sort.split(':');
-        switch (field) {
-            case 'id':
-                return a.id - b.id;
-            case 'name':
-                return a.title.localeCompare(b.title);
-            case 'updated_at':
-                return compareAsc(parseISO(a.updated_at), parseISO(b.updated_at));
-            default:
-                throw 'invalid sort key';
-        }
-    });
-    if (sort.split(':')[1] === 'desc') {
-        sortedCollections.reverse();
-    }
-
     return (
         <Modal show={show} {...rest}>
             <Modal.Header closeButton>
@@ -64,16 +47,12 @@ export const CollectionSelectModal: React.FC<CollectionSelectModalProps> = ({
                         </div>
                         <SortKeySelect className="mt-2" value={sort} onChange={setSort} />
                     </ListGroupItem>
-                    {sortedCollections
-                        .filter((collection) =>
-                            filter ? collection.title.toLowerCase().includes(filter.toLowerCase()) : true,
-                        )
-                        .map((collection) => (
-                            <ListGroupItem key={collection.id} action onClick={() => onSelectCollection(collection)}>
-                                <i className="ti ti-folder mr-2 text-secondary" />
-                                {collection.title}
-                            </ListGroupItem>
-                        ))}
+                    {sortAndFilteredCollections(collections, sort, filter).map((collection) => (
+                        <ListGroupItem key={collection.id} action onClick={() => onSelectCollection(collection)}>
+                            <i className="ti ti-folder mr-2 text-secondary" />
+                            {collection.title}
+                        </ListGroupItem>
+                    ))}
                 </ListGroup>
             </Modal.Body>
         </Modal>

--- a/resources/assets/js/components/collections/CollectionSelectModal.tsx
+++ b/resources/assets/js/components/collections/CollectionSelectModal.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ListGroup, ListGroupItem, Modal, ModalProps } from 'react-bootstrap';
+
+interface CollectionSelectModalProps extends ModalProps {
+    title: string;
+    collections: Tissue.Collection[];
+    onSelectCollection: (collection: Tissue.Collection) => void;
+}
+
+export const CollectionSelectModal: React.FC<CollectionSelectModalProps> = ({
+    title,
+    collections,
+    onSelectCollection,
+    ...rest
+}) => {
+    return (
+        <Modal {...rest}>
+            <Modal.Header closeButton>
+                <Modal.Title as="h5">{title}</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <ListGroup variant="flush" className="m-n3 rounded">
+                    {collections.map((collection) => (
+                        <ListGroupItem key={collection.id} action onClick={() => onSelectCollection(collection)}>
+                            <i className="ti ti-folder mr-2 text-secondary" />
+                            {collection.title}
+                        </ListGroupItem>
+                    ))}
+                </ListGroup>
+            </Modal.Body>
+        </Modal>
+    );
+};

--- a/resources/assets/js/components/collections/CollectionSelectModal.tsx
+++ b/resources/assets/js/components/collections/CollectionSelectModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { ListGroup, ListGroupItem, Modal, ModalProps } from 'react-bootstrap';
 import { compareAsc, parseISO } from 'date-fns';
+import { SortKeySelect } from './SortKeySelect';
 
 type SortKey = 'id:asc' | 'id:desc' | 'name:asc' | 'name:desc' | 'updated_at:asc' | 'updated_at:desc';
 
@@ -61,25 +62,7 @@ export const CollectionSelectModal: React.FC<CollectionSelectModalProps> = ({
                                 onChange={(e) => setFilter(e.target.value)}
                             />
                         </div>
-                        <div className="mt-2 position-relative">
-                            <i
-                                className="ti ti-sort-ascending-letters mr-2 position-absolute text-secondary"
-                                style={{ top: '22%', left: '0.75rem' }}
-                            />
-                            <select
-                                className="form-control form-control-sm"
-                                style={{ paddingLeft: '1.75rem' }}
-                                value={sort}
-                                onChange={(e) => setSort(e.target.value as SortKey)}
-                            >
-                                <option value="name:asc">名前 昇順</option>
-                                <option value="name:desc">名前 降順</option>
-                                <option value="id:asc">作成日時 昇順</option>
-                                <option value="id:desc">作成日時 降順</option>
-                                <option value="updated_at:asc">更新日時 昇順</option>
-                                <option value="updated_at:desc">更新日時 降順</option>
-                            </select>
-                        </div>
+                        <SortKeySelect className="mt-2" value={sort} onChange={setSort} />
                     </ListGroupItem>
                     {sortedCollections
                         .filter((collection) =>

--- a/resources/assets/js/components/collections/SortKeySelect.tsx
+++ b/resources/assets/js/components/collections/SortKeySelect.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export type SortKey = 'id:asc' | 'id:desc' | 'name:asc' | 'name:desc' | 'updated_at:asc' | 'updated_at:desc';
+
+interface SortKeySelectProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
+    value: SortKey;
+    onChange: (value: SortKey) => void;
+}
+
+export const SortKeySelect: React.FC<SortKeySelectProps> = ({ className, value, onChange, ...rest }) => {
+    return (
+        <div className={classNames('position-relative', className)} {...rest}>
+            <i
+                className="ti ti-sort-ascending-letters mr-2 position-absolute text-secondary"
+                style={{ top: '22%', left: '0.75rem' }}
+            />
+            <select
+                className="form-control form-control-sm"
+                style={{ paddingLeft: '1.75rem' }}
+                value={value}
+                onChange={(e) => onChange(e.target.value as SortKey)}
+            >
+                <option value="name:asc">名前 昇順</option>
+                <option value="name:desc">名前 降順</option>
+                <option value="id:asc">作成日時 昇順</option>
+                <option value="id:desc">作成日時 降順</option>
+                <option value="updated_at:asc">更新日時 昇順</option>
+                <option value="updated_at:desc">更新日時 降順</option>
+            </select>
+        </div>
+    );
+};

--- a/resources/assets/js/components/collections/search.ts
+++ b/resources/assets/js/components/collections/search.ts
@@ -1,0 +1,29 @@
+import { SortKey } from './SortKeySelect';
+import { compareAsc, parseISO } from 'date-fns';
+
+export function sortAndFilteredCollections(
+    collections: Tissue.Collection[],
+    sort: SortKey,
+    filter: string,
+): Tissue.Collection[] {
+    const sortedCollections = [...collections].sort((a, b) => {
+        const [field] = sort.split(':');
+        switch (field) {
+            case 'id':
+                return a.id - b.id;
+            case 'name':
+                return a.title.localeCompare(b.title);
+            case 'updated_at':
+                return compareAsc(parseISO(a.updated_at), parseISO(b.updated_at));
+            default:
+                throw 'invalid sort key';
+        }
+    });
+    if (sort.split(':')[1] === 'desc') {
+        sortedCollections.reverse();
+    }
+
+    return sortedCollections.filter((collection) => {
+        return collection.title.toLowerCase().includes(filter.toLowerCase());
+    });
+}

--- a/resources/assets/js/user/collections.tsx
+++ b/resources/assets/js/user/collections.tsx
@@ -16,7 +16,7 @@ import {
     CollectionFormValues,
 } from '../components/collections/CollectionEditModal';
 import { SortKey, SortKeySelect } from '../components/collections/SortKeySelect';
-import { compareAsc, parseISO } from 'date-fns';
+import { sortAndFilteredCollections } from '../components/collections/search';
 
 type SidebarItemProps = {
     collection: Tissue.Collection;
@@ -104,23 +104,6 @@ const Sidebar: React.FC<SidebarProps> = ({ collections }) => {
         return null;
     }
 
-    const sortedCollections = collections.sort((a, b) => {
-        const [field] = sort.split(':');
-        switch (field) {
-            case 'id':
-                return a.id - b.id;
-            case 'name':
-                return a.title.localeCompare(b.title);
-            case 'updated_at':
-                return compareAsc(parseISO(a.updated_at), parseISO(b.updated_at));
-            default:
-                throw 'invalid sort key';
-        }
-    });
-    if (sort.split(':')[1] === 'desc') {
-        sortedCollections.reverse();
-    }
-
     return (
         <div className="card mb-4">
             <div className="card-header align-items-center d-flex d-lg-none">
@@ -163,13 +146,9 @@ const Sidebar: React.FC<SidebarProps> = ({ collections }) => {
                 </div>
             </div>
             <div className="list-group list-group-flush">
-                {sortedCollections
-                    .filter((collection) =>
-                        filter ? collection.title.toLowerCase().includes(filter.toLowerCase()) : true,
-                    )
-                    .map((collection) => (
-                        <SidebarItem key={collection.id} collection={collection} collapse={collapse} />
-                    ))}
+                {sortAndFilteredCollections(collections, sort, filter).map((collection) => (
+                    <SidebarItem key={collection.id} collection={collection} collapse={collapse} />
+                ))}
                 {collections.length === 0 && (
                     <li className="list-group-item d-flex justify-content-between align-items-center" />
                 )}

--- a/resources/assets/js/user/collections.tsx
+++ b/resources/assets/js/user/collections.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter, Link, Outlet, Route, Routes, useNavigate, useParams } from 'react-router-dom';
+import { BrowserRouter, Link, Outlet, Route, Routes, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Button } from 'react-bootstrap';
 import { useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
@@ -18,9 +18,10 @@ import {
 
 type SidebarItemProps = {
     collection: Tissue.Collection;
+    collapse: boolean;
 };
 
-const SidebarItem: React.FC<SidebarItemProps> = ({ collection }) => {
+const SidebarItem: React.FC<SidebarItemProps> = ({ collection, collapse }) => {
     const { id } = useParams();
     const isSelected = collection.id == id;
 
@@ -30,10 +31,11 @@ const SidebarItem: React.FC<SidebarItemProps> = ({ collection }) => {
             className={classNames(
                 'list-group-item',
                 'list-group-item-action',
-                'd-flex',
+                'd-lg-flex',
                 'justify-content-between',
                 'align-items-center',
                 isSelected ? 'active' : 'text-dark',
+                !isSelected && collapse ? 'd-none' : 'd-flex',
             )}
         >
             <div style={{ wordBreak: 'break-all' }}>
@@ -50,12 +52,18 @@ type SidebarProps = {
 
 const Sidebar: React.FC<SidebarProps> = ({ collections }) => {
     const { data: me } = useMyProfileQuery();
+    const location = useLocation();
     const { username } = useParams();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
     const [filter, setFilter] = useState('');
     const [showCreateModal, setShowCreateModal] = useState(false);
     const [order, setOrder] = useState<'asc' | 'desc'>('asc');
+    const [collapse, setCollapse] = useState(true);
+
+    useEffect(() => {
+        setCollapse(true);
+    }, [location]);
 
     const handleSubmit = async (values: CollectionFormValues) => {
         try {
@@ -96,7 +104,24 @@ const Sidebar: React.FC<SidebarProps> = ({ collections }) => {
 
     return (
         <div className="card mb-4">
-            <div className="card-header d-flex justify-content-between align-items-center" style={{ gap: '1rem' }}>
+            <div className="card-header align-items-center d-flex d-lg-none">
+                <Button
+                    variant=""
+                    className="text-secondary ml-n2 mr-1"
+                    size="sm"
+                    onClick={() => setCollapse((v) => !v)}
+                >
+                    {collapse ? <i className="ti ti-caret-right-filled" /> : <i className="ti ti-caret-down-filled" />}
+                </Button>
+                コレクション
+            </div>
+            <div
+                className={classNames(
+                    'card-header d-lg-flex justify-content-between align-items-center',
+                    collapse ? 'd-none' : 'd-flex',
+                )}
+                style={{ gap: '1rem' }}
+            >
                 <div className="flex-grow-1">
                     <input
                         className="form-control"
@@ -140,7 +165,7 @@ const Sidebar: React.FC<SidebarProps> = ({ collections }) => {
                         filter ? collection.title.toLowerCase().includes(filter.toLowerCase()) : true,
                     )
                     .map((collection) => (
-                        <SidebarItem key={collection.id} collection={collection} />
+                        <SidebarItem key={collection.id} collection={collection} collapse={collapse} />
                     ))}
                 {collections.length === 0 && (
                     <li className="list-group-item d-flex justify-content-between align-items-center" />

--- a/resources/assets/js/user/collections.tsx
+++ b/resources/assets/js/user/collections.tsx
@@ -53,6 +53,7 @@ const Sidebar: React.FC<SidebarProps> = ({ collections }) => {
     const { username } = useParams();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
+    const [filter, setFilter] = useState('');
     const [showCreateModal, setShowCreateModal] = useState(false);
     const [order, setOrder] = useState<'asc' | 'desc'>('asc');
 
@@ -95,8 +96,16 @@ const Sidebar: React.FC<SidebarProps> = ({ collections }) => {
 
     return (
         <div className="card mb-4">
-            <div className="card-header d-flex justify-content-between align-items-center">
-                <span>コレクション</span>
+            <div className="card-header d-flex justify-content-between align-items-center" style={{ gap: '1rem' }}>
+                <div className="flex-grow-1">
+                    <input
+                        className="form-control"
+                        type="search"
+                        placeholder="検索"
+                        value={filter}
+                        onChange={(e) => setFilter(e.target.value)}
+                    />
+                </div>
                 <div>
                     {username === me?.name && (
                         <Button
@@ -127,6 +136,9 @@ const Sidebar: React.FC<SidebarProps> = ({ collections }) => {
             <div className="list-group list-group-flush">
                 {collections
                     .sort((a, b) => (order === 'asc' ? a.id - b.id : b.id - a.id))
+                    .filter((collection) =>
+                        filter ? collection.title.toLowerCase().includes(filter.toLowerCase()) : true,
+                    )
                     .map((collection) => (
                         <SidebarItem key={collection.id} collection={collection} />
                     ))}


### PR DESCRIPTION
fix #1197 

## サーバー仕様変更
- コレクション作成数の上限を 100 → 500 に緩和しました。

## コレクション一覧
- 検索ボックスを追加しました。名前で絞り込みができます。
- ソート順序のバリエーションを増やしました。

<img width="409" alt="image" src="https://github.com/shikorism/tissue/assets/1352154/998836a8-ec6c-4a24-b11f-c04b6b13f8cd">
<img width="375" alt="image" src="https://github.com/shikorism/tissue/assets/1352154/ed2bc86c-d4ef-4a31-914a-b26bc01b22c1">

- スマホ表示の場合、コレクション一覧を折り畳むようにしました。

<img width="439" alt="image" src="https://github.com/shikorism/tissue/assets/1352154/4f4e1020-ea10-4fe9-a20f-c62995206bbb">


## コレクション追加ボタン
- 表示を更新日時の降順で、先頭5件に制限しました。
- 6件目以降を選択するためのモーダルを追加しました。

<img width="580" alt="image" src="https://github.com/shikorism/tissue/assets/1352154/59d010d9-8240-4e8d-9af8-a74d593d88b2">
<img width="1176" alt="image" src="https://github.com/shikorism/tissue/assets/1352154/ece1fd99-e531-40ba-8627-a7e3aac9b59e">
