### PR TITLE
サイトトップのお知らせ表示を小さめにした

### DIFF
--- a/resources/assets/sass/tissue.css
+++ b/resources/assets/sass/tissue.css
@@ -54,12 +54,6 @@
     border-radius: 0;
 }
 
-@media (min-width: 992px) {
-    .tis-sidebar-info {
-        font-size: small;
-    }
-}
-
 #navbarNav > .d-lg-none > .row > div:first-of-type {
     padding-right: 7.5px;
     padding-left: 15px;

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -4,6 +4,22 @@
 @endpush
 
 @section('content')
+@if (!empty($informations))
+<div class="mt-n4 mb-4 pt-2 bg-light border-top border-bottom">
+    <div class="container d-flex" style="gap: .5rem;">
+        <div class="flex-shrink-0 font-weight-bold"><i class="ti ti-info-circle"></i></div>
+        <ul class="flex-grow list-unstyled mb-0 small">
+            @foreach($informations as $info)
+                <li class="mb-2">
+                    <a href="{{ route('info.show', ['id' => $info->id]) }}">
+                        <span class="badge {{ $categories[$info->category]['class'] }}">{{ $categories[$info->category]['label'] }}</span> {{ $info->title }} <small class="text-secondary">- {{ $info->created_at->format('n月j日') }}</small>
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+    </div>
+</div>
+@endif
 <div class="container">
     <div class="row">
         <div class="col-lg-4">
@@ -13,20 +29,6 @@
                     @endcomponent
                     @component('components.profile-stats', ['user' => Auth::user()])
                     @endcomponent
-                </div>
-            </div>
-            <div class="card mb-4">
-                <div class="card-header">サイトからのお知らせ</div>
-                <div class="list-group list-group-flush tis-sidebar-info">
-                    @foreach($informations as $info)
-                        <a class="list-group-item" href="{{ route('info.show', ['id' => $info->id]) }}">
-                            @if ($info->pinned)
-                                <span class="badge badge-secondary"><i class="ti ti-pinned-filled"></i>ピン留め</span>
-                            @endif
-                            <span class="badge {{ $categories[$info->category]['class'] }}">{{ $categories[$info->category]['label'] }}</span> {{ $info->title }} <small class="text-secondary">- {{ $info->created_at->format('n月j日') }}</small>
-                        </a>
-                    @endforeach
-                    <a href="{{ route('info') }}" class="list-group-item text-right">お知らせ一覧 &raquo;</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
お知らせ欄は、当初はメインカラムにあったのですが、その後[サイドカラムに移動](https://github.com/shikorism/tissue/pull/89)しています。  
これはメインコンテンツの表示量を稼ぐための変更だったのですが、PCの事しか考えられておらず、スマホでは依然邪魔な状態が続いていました。

このPRでは、スマホ向けの表示でもお知らせ欄が表示領域を占有しすぎないよう、表示位置とデザインを変更しました。

## PC

![image](https://github.com/shikorism/tissue/assets/1352154/6f34eca5-c1c6-4568-a73f-84af181ab10e)

## SP

<img width="454" alt="image" src="https://github.com/shikorism/tissue/assets/1352154/ade14450-2ee6-4f49-9f75-1e1690578e45">

## 意図的に変えた部分について
- 「ピン留め」は管理者都合の属性であり、閲覧者には特に意味のある情報ではないため削除しました。
- 過去のお知らせをわざわざ見る人はそんなに居ないので、一覧画面へのリンクは削除しました。一応、いずれかのお知らせを開いてからパンくずリストを経由すれば開ける。
