### PR TITLE
Docker: node 22にアップデート

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,24 +29,24 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "composer.json" }}
+            - v1-dependencies-{{ checksum "composer.lock" }}
             - v1-dependencies-
   save_composer:
     steps:
       - save_cache:
-          key: v1-dependencies-{{ checksum "composer.json" }}
+          key: v1-dependencies-{{ checksum "composer.lock" }}
           paths:
             - ./vendor
   restore_npm:
     steps:
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-{{ checksum "yarn.lock" }}
             - v1-dependencies-
   save_npm:
     steps:
       - save_cache:
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v1-dependencies-{{ checksum "yarn.lock" }}
           paths:
             - ./node_modules
             - ~/.yarn

--- a/docker/development/web.dockerfile
+++ b/docker/development/web.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-buster as node
+FROM node:22.5.1-bullseye as node
 
 FROM php:8.0-apache
 
@@ -21,11 +21,10 @@ COPY --from=node /usr/local/bin/node /usr/local/bin/
 COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=node /opt/yarn-* /opt/yarn
 
-RUN ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
-    && ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
-    && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
-
-
+RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && ln -s ../lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack
+RUN corepack enable
 
 ENTRYPOINT ["tissue-entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/docker/development/web.dockerfile
+++ b/docker/development/web.dockerfile
@@ -26,6 +26,8 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack
 RUN corepack enable
 
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT 0
+
 ENTRYPOINT ["tissue-entrypoint.sh"]
 CMD ["apache2-foreground"]
 

--- a/docker/production/foundation.dockerfile
+++ b/docker/production/foundation.dockerfile
@@ -12,11 +12,12 @@ COPY . /app
 
 RUN composer install -n --no-dev --prefer-dist --optimize-autoloader
 
-FROM node:16.20.2-bullseye
+FROM node:22.5.1-bullseye
 
 WORKDIR /app
 COPY --from=php /app /app
 
+RUN corepack enable
 RUN yarn install \
     && yarn run prod \
     && yarn run doc

--- a/package.json
+++ b/package.json
@@ -88,5 +88,6 @@
     "*.php": [
       "composer fix"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
前回: #714 

ついでにcorepack enableをDockerfile内に仕込んだり、package.jsonに `packageManager` を書き込んだりした。