### PR TITLE
jQueryを明示的にimportする

### DIFF
--- a/resources/assets/js/app.ts
+++ b/resources/assets/js/app.ts
@@ -1,4 +1,5 @@
 import Cookies from 'js-cookie';
+import $ from 'jquery';
 import { fetchPostJson, fetchDeleteJson, ResponseError } from './fetch';
 import { linkCard, pageSelector, deleteCheckinModal, checkinMutedWarning } from './tissue';
 import { initAddToCollectionButtons } from './collection';

--- a/resources/assets/js/setting/deactivate.ts
+++ b/resources/assets/js/setting/deactivate.ts
@@ -1,3 +1,5 @@
+import $ from 'jquery';
+
 $('#deactivate-form').on('submit', function () {
     if (!confirm('本当にアカウントを削除してもよろしいですか？')) {
         return false;

--- a/resources/assets/js/setting/filter/tags.ts
+++ b/resources/assets/js/setting/filter/tags.ts
@@ -1,3 +1,5 @@
+import $ from 'jquery';
+
 const deleteModal = document.getElementById('deleteTagFilterModal');
 if (deleteModal) {
     let id: any = null;

--- a/resources/assets/js/setting/import.ts
+++ b/resources/assets/js/setting/import.ts
@@ -1,3 +1,5 @@
+import $ from 'jquery';
+
 $('#destroy-form').on('submit', function () {
     if (!confirm('本当に削除してもよろしいですか？')) {
         return false;

--- a/resources/assets/js/setting/privacy.ts
+++ b/resources/assets/js/setting/privacy.ts
@@ -1,3 +1,5 @@
+import $ from 'jquery';
+
 $('#protected').on('change', function () {
     if (!$(this).prop('checked')) {
         alert(

--- a/resources/assets/js/setting/tokens.ts
+++ b/resources/assets/js/setting/tokens.ts
@@ -1,4 +1,5 @@
 import ClipboardJS from 'clipboard';
+import $ from 'jquery';
 
 $('.access-token').on('focus', function () {
     $(this).trigger('select');

--- a/resources/assets/js/setting/webhooks.ts
+++ b/resources/assets/js/setting/webhooks.ts
@@ -1,4 +1,5 @@
 import ClipboardJS from 'clipboard';
+import $ from 'jquery';
 
 $('.webhook-url').on('focus', function () {
     $(this).trigger('select');

--- a/resources/assets/js/tissue.ts
+++ b/resources/assets/js/tissue.ts
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import { fetchGet, fetchDeleteJson, ResponseError } from './fetch';
 
 export function suicide<T>(e: T) {

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -27,9 +27,6 @@ mix.ts('resources/assets/js/app.ts', 'public/js')
     .ts('resources/assets/js/checkin.tsx', 'public/js')
     .ts('resources/assets/js/collect.tsx', 'public/js')
     .sass('resources/assets/sass/app.scss', 'public/css')
-    .autoload({
-        jquery: ['$', 'jQuery', 'window.jQuery'],
-    })
     .extract(['jquery', 'bootstrap', 'react', 'react-dom', 'react-bootstrap'])
     .extract(['chart.js', '@kurkle/color', 'cal-heatmap', 'd3'], 'public/js/vendor/chart')
     .react()


### PR DESCRIPTION
大昔の自分が便利だと思って入れたのだろうけど、今となっては便利さよりも余計な驚きという気持ちが強い。

mix.autoloadで注入するのではなく、普通にimportするようにする。