### PR TITLE
よく使うタグ・最近使ったタグをチェックインフォームに表示

### DIFF
--- a/app/Http/Controllers/Api/V1/RecentTagsController.php
+++ b/app/Http/Controllers/Api/V1/RecentTagsController.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class RecentTagsController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        $ejaculations = Auth::user()
+            ->ejaculations()
+            ->with('tags')
+            ->orderByDesc('ejaculated_date')
+            ->limit(20);
+
+        $tags = [];
+        foreach ($ejaculations->get() as $ejaculation) {
+            foreach ($ejaculation->tags as $tag) {
+                $tags[$tag->name] = true;
+            }
+        }
+        $tags = array_keys($tags);
+
+        return response()->json($tags);
+    }
+}

--- a/app/Http/Controllers/Api/V1/UserStats/MostlyUsedCheckinTags.php
+++ b/app/Http/Controllers/Api/V1/UserStats/MostlyUsedCheckinTags.php
@@ -44,7 +44,7 @@ class MostlyUsedCheckinTags extends Controller
         $result = (new CountUsedTags(Auth::user(), $user))
             ->since($since)
             ->until($until)
-            ->setIncludesMetadata($request->boolean('includesMetadata'))
+            ->setIncludesMetadata($request->boolean('includes_metadata'))
             ->query();
 
         return response()->json($result);

--- a/resources/assets/js/@types/api.d.ts
+++ b/resources/assets/js/@types/api.d.ts
@@ -2,4 +2,8 @@ declare namespace Tissue {
     type Profile = any;
     type Collection = any;
     type CollectionItem = any;
+    type TagStats = {
+        name: string;
+        count: number;
+    };
 }

--- a/resources/assets/js/api.ts
+++ b/resources/assets/js/api.ts
@@ -57,3 +57,16 @@ export const useCollectionItemsQuery = (id: string, page?: string | null) =>
             ),
         { keepPreviousData: true },
     );
+
+export const useUserStatsTagsQuery = (username: string | undefined, includesMetadata?: boolean) =>
+    useQuery<Tissue.TagStats[], ResponseError>(
+        ['UserStatsTags', username, !!includesMetadata],
+        () =>
+            fetchGet(`/api/users/${username}/stats/tags`, {
+                includes_metadata: JSON.stringify(!!includesMetadata),
+            }).then(asJson),
+        { enabled: !!username },
+    );
+
+export const useRecentTagsQuery = () =>
+    useQuery<string[], ResponseError>(['RecentTags'], () => fetchGet(`/api/recent-tags`).then(asJson));

--- a/resources/assets/js/checkin.tsx
+++ b/resources/assets/js/checkin.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { CheckinForm } from './components/CheckinForm';
+import { QueryClientProvider } from './query';
 
 const initialState = JSON.parse(document.getElementById('initialState')?.textContent as string);
-createRoot(document.getElementById('checkinForm') as HTMLElement).render(<CheckinForm initialState={initialState} />);
+createRoot(document.getElementById('checkinForm') as HTMLElement).render(
+    <QueryClientProvider>
+        <CheckinForm initialState={initialState} />
+    </QueryClientProvider>,
+);

--- a/resources/assets/js/components/CheckinForm.tsx
+++ b/resources/assets/js/components/CheckinForm.tsx
@@ -5,6 +5,7 @@ import { CheckBox } from './CheckBox';
 import { FieldError, StandaloneFieldError } from './FieldError';
 import { TagInput } from './TagInput';
 import { MetadataPreview } from './MetadataPreview';
+import { FavoriteTags } from './FavoriteTags';
 
 type CheckinFormProps = {
     initialState: any;
@@ -104,6 +105,9 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
                     />
                     <small className="form-text text-muted">Tab, Enter, 半角スペースのいずれかで入力確定します。</small>
                     <FieldError errors={initialState.errors?.tags} />
+                </div>
+                <div className="form-group col-sm-12">
+                    <FavoriteTags tags={tags} onClickTag={(v) => setTags(tags.concat(v))} />
                 </div>
             </div>
             <div className="form-row">

--- a/resources/assets/js/components/FavoriteTags.tsx
+++ b/resources/assets/js/components/FavoriteTags.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { useMyProfileQuery, useRecentTagsQuery, useUserStatsTagsQuery } from '../api';
+import classNames from 'classnames';
+
+type Candidate = {
+    name: string;
+    used: boolean;
+};
+
+type FavoriteTagsProps = {
+    tags: string[];
+    onClickTag: (tag: string) => void;
+};
+
+export const FavoriteTags: React.FC<FavoriteTagsProps> = ({ tags, onClickTag }) => {
+    const { data: me } = useMyProfileQuery();
+    const { data: mostlyUsedTags } = useUserStatsTagsQuery(me?.name);
+    const { data: mostlyUsedMetaTags } = useUserStatsTagsQuery(me?.name, true);
+    const { data: recentlyUsedTags } = useRecentTagsQuery();
+
+    if (!mostlyUsedTags || !mostlyUsedMetaTags || !recentlyUsedTags) return null;
+
+    const mostlyCandidates: Candidate[] = Array.from(
+        [...mostlyUsedTags, ...mostlyUsedMetaTags].reduce((set, tag) => set.add(tag.name), new Set<string>()),
+    ).map((t) => ({ name: t, used: tags.indexOf(t) !== -1 }));
+
+    const recentlyCandidates: Candidate[] = recentlyUsedTags
+        .filter((_, i) => i < 20)
+        .map((t) => ({ name: t, used: tags.indexOf(t) !== -1 }));
+
+    if (mostlyCandidates.length === 0 && recentlyCandidates.length === 0) return null;
+
+    const tagClasses = (t: Candidate) =>
+        classNames({
+            'list-inline-item': true,
+            badge: true,
+            'badge-primary': !t.used,
+            'badge-secondary': t.used,
+            'cursor-pointer': true,
+        });
+
+    return (
+        <div className="card">
+            <div className="card-body px-3 py-2 d-flex flex-column" style={{ gap: '1rem' }}>
+                {mostlyCandidates.length > 0 && (
+                    <div>
+                        <div className="small">
+                            <i className="ti ti-heart mr-1" />
+                            よく使うタグ
+                        </div>
+                        <ul className="list-inline d-inline">
+                            {mostlyCandidates.map((tag) => (
+                                <li
+                                    key={tag.name}
+                                    className={tagClasses(tag)}
+                                    onClick={() => !tag.used && onClickTag(tag.name)}
+                                >
+                                    <i className="ti ti-tag-filled" /> {tag.name}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+                {recentlyCandidates.length > 0 && (
+                    <div>
+                        <div className="small">
+                            <i className="ti ti-history mr-1" />
+                            最近使ったタグ
+                        </div>
+                        <ul className="list-inline d-inline">
+                            {recentlyCandidates.map((tag) => (
+                                <li
+                                    key={tag.name}
+                                    className={tagClasses(tag)}
+                                    onClick={() => !tag.used && onClickTag(tag.name)}
+                                >
+                                    <i className="ti ti-tag-filled" /> {tag.name}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+                <div className="text-secondary small">クリックするとタグ入力欄にコピーできます</div>
+            </div>
+        </div>
+    );
+};

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -43,3 +43,7 @@ $primary: #e53fb1;
 .text-large {
     font-size: large;
 }
+
+.cursor-pointer {
+    cursor: pointer;
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,6 +24,7 @@ Route::middleware('stateful')->group(function () {
             Route::apiResource('checkin', 'Api\\CheckinController')->only(['destroy']);
             Route::apiResource('collections', 'Api\\V1\\CollectionController')->only(['index', 'store', 'update', 'destroy']);
             Route::apiResource('collections.items', 'Api\\V1\\CollectionItemController')->only(['store', 'update', 'destroy']);
+            Route::get('/recent-tags', 'Api\\V1\\RecentTagsController')->name('recent-tags');
         });
 
         Route::apiResource('users.collections', 'Api\\UserCollectionController')->only(['index']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,6 +29,16 @@ Route::middleware('stateful')->group(function () {
         Route::apiResource('users.collections', 'Api\\UserCollectionController')->only(['index']);
         Route::apiResource('collections', 'Api\\V1\\CollectionController')->only(['show']);
         Route::apiResource('collections.items', 'Api\\V1\\CollectionItemController')->only(['index']);
+
+        Route::namespace('Api\\V1\\UserStats')
+            ->prefix('users/{user}/stats')
+            ->name('users.stats.')
+            ->group(function () {
+                Route::get('/checkin/daily', 'DailyCheckinSummary')->name('checkin.daily');
+                Route::get('/checkin/hourly', 'HourlyCheckinSummary')->name('checkin.hourly');
+                Route::get('/links', 'MostlyUsedLinks')->name('links');
+                Route::get('/tags', 'MostlyUsedCheckinTags')->name('tags');
+            });
     });
 });
 


### PR DESCRIPTION
@eai04191 が作成した https://userscript-graveyard.vercel.app/#/userscript/tissue/favorite-tags の仕様をベースとして、だいたいそのまま本体に組み込むPRです。

## よく使うタグ
`GET /api/v1/users/{name}/stats/tags` から取得できる、ログインユーザーが最も使用したタグを列挙。

期間指定をせずに呼び出しているので全期間対象。集計が重くなるだけなので、直近1年かもっと短めに縛ってもいいかもしれない。

## 最近使ったタグ
元ネタだと最近のオカズリンク付きチェックインからスクレイピングしていたけど、オカズリンクがなくてもタグは書けるのでチェックイン日時降順のトップ20に設定されているタグを列挙するようにした。

全て表示するとキリがないので、適当に切り捨て。全表示するボタンを付けてもいいかも。

## スクリーンショット
<img width="646" alt="image" src="https://github.com/user-attachments/assets/43035477-0d00-45da-8f6a-177afa7a434b">
