### PR TITLE
REST API呼び出し時に指定したクエリーパラメーターがLinkヘッダーへ出力されるURLから欠落している問題を修正

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -41,6 +41,8 @@ class AppServiceProvider extends ServiceProvider
                 throw new \LogicException('invalid type');
             }
 
+            $paginator = $paginator->withQueryString();
+
             $headers = [];
 
             $links = [


### PR DESCRIPTION
`per_page`などのパラメーターを付与した状態でREST APIを呼び出した際、レスポンスヘッダー(Linkヘッダー)へ出力されるURLから呼び出し時に付与したパラメーターが欠落した状態で出力されていました。
本修正では、呼び出し時に付与したクエリーパラメーターを引き継ぐよう修正を行っています。