### PR TITLE
通報理由の管理画面が開発環境以外で開けないバグを修正

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig({
             'resources/assets/sass/app.scss',
             'resources/assets/js/app.ts',
             'resources/assets/js/home.ts',
+            'resources/assets/js/admin/rules.ts',
             'resources/assets/js/user/profile.ts',
             'resources/assets/js/user/stats.ts',
             'resources/assets/js/user/collections.tsx',


### PR DESCRIPTION
開発環境では開けるから油断した