### PR TITLE
NarouResolver: 作品に含まれる要素のキーワードに含まれるnbspを除去

### DIFF
--- a/app/MetadataResolver/NarouResolver.php
+++ b/app/MetadataResolver/NarouResolver.php
@@ -52,7 +52,7 @@ class NarouResolver implements Resolver
         $keywordNodeList = $xpath->query('//th[contains(text(), "キーワード")]/following-sibling::td[1]');
         if ($keywordNodeList->length !== 0) {
             $keyword = trim($keywordNodeList->item(0)->textContent);
-            $metadata->tags = array_values(array_filter(preg_split('/\s/u', $keyword)));
+            $metadata->tags = preg_split('/\s+/u', $keyword);
         }
 
         // 作者名

--- a/app/MetadataResolver/NarouResolver.php
+++ b/app/MetadataResolver/NarouResolver.php
@@ -51,8 +51,8 @@ class NarouResolver implements Resolver
         // タグ
         $keywordNodeList = $xpath->query('//th[contains(text(), "キーワード")]/following-sibling::td[1]');
         if ($keywordNodeList->length !== 0) {
-            $keyword =  trim($keywordNodeList->item(0)->textContent);
-            $metadata->tags = explode(' ', $keyword);
+            $keyword = trim($keywordNodeList->item(0)->textContent);
+            $metadata->tags = array_values(array_filter(preg_split('/\s/u', $keyword)));
         }
 
         // 作者名

--- a/tests/Unit/MetadataResolver/NarouResolverTest.php
+++ b/tests/Unit/MetadataResolver/NarouResolverTest.php
@@ -62,4 +62,19 @@ class NarouResolverTest extends TestCase
             $this->assertSame('https://novel18.syosetu.com/novelview/infotop/ncode/n0477gn/', (string) $this->handler->getLastRequest()->getUri());
         }
     }
+
+    public function testFeaturesInKeyword()
+    {
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/Narou/testFeaturesInKeyword.html');
+
+        $this->createResolver(NarouResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://novel18.syosetu.com/n6404hk/');
+        $this->assertEquals('王子繁殖促進計画「王子の性欲を刺激せよ」　～よってたかって性欲を刺激される小国王子の異世界奮闘記～', $metadata->title);
+        $this->assertEquals("作者: ひもの\n小国だが王子に転生した俺。　\n意外に甘くない現実に戸惑いつつも、いつかはエロエロハーレムが作れたらいいな、と思っていたが……　\n\n幼馴染が、いとこのお姉ちゃんが、周りの美少女達が、恥じらいながらも一生懸命、俺の性欲を刺激してくる。　\n\nえ？　俺の性欲を刺激するために、国家プロジェクトが立ち上がった？……", $metadata->description);
+        $this->assertEquals(['残酷な描写あり', '異世界転生', '男主人公', 'ハーレム', '魔法', 'オリジナル戦記', '戦記', '淫語', '羞恥', '美少女', 'イチャラブ', '♡喘ぎ', '孕ませ', '巨乳'], $metadata->tags);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://novel18.syosetu.com/novelview/infotop/ncode/n6404hk/', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
 }

--- a/tests/fixture/Narou/testFeaturesInKeyword.html
+++ b/tests/fixture/Narou/testFeaturesInKeyword.html
@@ -1,0 +1,435 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ja" lang="ja" class="is-pc">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<title>王子繁殖促進計画「王子の性欲を刺激せよ」　～よってたかって性欲を刺激される小国王子の異世界奮闘記～[作品情報]</title>
+<meta http-equiv="Content-Script-Type" content="text/javascript" />
+<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta name="format-detection" content="telephone=no" />
+
+<meta property="og:type" content="website" />
+<meta property="og:title" content="王子繁殖促進計画「王子の性欲を刺激せよ」　～よってたかって性欲を刺激される小国王子の異世界奮闘記～" />
+<meta property="og:url" content="https://ncode.syosetu.com/n6404hk/" />
+<meta property="og:description" content="男主人公 ハーレム 魔法 オリジナル戦記 戦記 淫語 羞恥 美少女 イチャラブ ♡喘ぎ 孕ませ 巨乳 残酷な描写あり 異世界転生" />
+<meta property="og:image" content="https://sbo.syosetu.com/n6404hk/twitter.png" />
+<meta property="og:site_name" content="小説家になろう" />
+<meta name="twitter:site" content="@syosetu">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:creator" content="ひもの">
+
+
+<link rel="shortcut icon" href="https://static.syosetu.com/sub/nocview/images/noc.ico?mmxhfu" />
+<link rel="icon" href="https://static.syosetu.com/sub/nocview/images/noc.ico?mmxhfu" />
+<link rel="apple-touch-icon-precomposed" href="https://static.syosetu.com/sub/nocview/images/apple-touch-icon-precomposed.png?ojjr8y" />
+
+<link href="https://api.syosetu.com/writernovel/x7007ca.Atom" rel="alternate" type="application/atom+xml" title="Atom" />
+
+<link rel="stylesheet" type="text/css" href="https://static.syosetu.com/novelview/css/reset.css?piu6zr" media="screen,print" />
+<link rel="stylesheet" type="text/css" href="https://static.syosetu.com/view/css/lib/jquery.hina.css?oyb9lo" media="screen,print" />
+
+<link rel="stylesheet" type="text/css" media="all" href="https://static.syosetu.com/view/css/lib/tippy.css?ov2lia" />
+<link rel="stylesheet" type="text/css" media="all" href="https://static.syosetu.com/novelview/css/siori_toast_pc.css?q6lspt" />
+<link rel="stylesheet" type="text/css" media="all" href="https://static.syosetu.com/view/css/lib/remodal.css?oqe20g" />
+<link rel="stylesheet" type="text/css" media="all" href="https://static.syosetu.com/view/css/lib/remodal-default_pc-theme.css?r9whxq" />
+<link rel="stylesheet" type="text/css" media="all" href="https://static.syosetu.com/novelview/css/remodal_pc.css?rfnxgm" />
+<link rel="stylesheet" type="text/css" media="all" href="https://static.syosetu.com/novelview/css/novel_view.css?sl0u6z" />
+<link rel="stylesheet" type="text/css" media="all" href="https://static.syosetu.com/novelview/css/infotop.css?s8d9fe" />
+
+
+
+<script type="text/javascript"><!--
+var domain = 'syosetu.com';
+//--></script>
+
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+<script type="text/javascript" src="https://static.syosetu.com/view/js/lib/jquery.hina.js?rq7apb"></script>
+<script type="text/javascript" src="https://static.syosetu.com/view/js/global.js?schjuj"></script>
+<script type="text/javascript" src="https://static.syosetu.com/view/js/char_count.js?scfmgz"></script>
+<script type="text/javascript" src="https://static.syosetu.com/novelview/js/novelview.js?sjzs4k"></script>
+
+<script type="text/javascript" src="https://static.syosetu.com/view/js/lib/jquery.readmore.js?o7mki8"></script>
+<script type="text/javascript" src="https://static.syosetu.com/view/js/lib/tippy.min.js?oqe1mv"></script>
+<script type="text/javascript" src="https://static.syosetu.com/novelview/js/novel_bookmarkmenu.js?shf6y0"></script>
+<script type="text/javascript" src="https://static.syosetu.com/view/js/lib/remodal.min.js?oqe1mv"></script>
+
+
+<script type="text/javascript">
+var microadCompass = microadCompass || {};
+microadCompass.queue = microadCompass.queue || [];
+</script>
+<script type="text/javascript" charset="UTF-8" src="//j.microad.net/js/compass.js" onload="new microadCompass.AdInitializer().initialize();" async></script>
+
+
+
+<script>
+window.gnshbrequest = window.gnshbrequest || {cmd:[]};
+window.gnshbrequest.cmd.push(function(){
+  window.gnshbrequest.registerPassback("1571412");
+  window.gnshbrequest.registerPassback("1571413");
+  window.gnshbrequest.registerPassback("1571414");
+  window.gnshbrequest.registerPassback("1571593");
+  window.gnshbrequest.registerPassback("1571594");
+  window.gnshbrequest.registerPassback("1571644");
+  window.gnshbrequest.registerPassback("1571645");
+  window.gnshbrequest.forceInternalRequest();
+});
+  </script>
+  <script async src="https://cpt.geniee.jp/hb/v1/219183/1961/wrapper.min.js"></script>
+
+
+<!--
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+ xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+<rdf:Description
+rdf:about="https://novel18.syosetu.com/n6404hk/
+dc:identifier="https://novel18.syosetu.com/n6404hk/"
+ />
+</rdf:RDF>
+-->
+
+</head>
+<body onload="initRollovers();">
+
+<a id="pageBottom" class="js-navigater-tobottom" href="#footer">↓</a>
+<div id="novel_header">
+<ul id="head_nav">
+<li id="login">
+<a href="https://syosetu.com/login/input/"><span class="attention">ログイン</span></a>
+</li>
+<li><a href="https://novel18.syosetu.com/novelview/infotop/ncode/n6404hk/">作品情報</a></li>
+<li><a href="https://novelcom18.syosetu.com/impression/list/ncode/1926212/">感想</a></li>
+<li><a href="https://novelcom18.syosetu.com/novelreview/list/ncode/1926212/">レビュー</a></li>
+<li>
+<form action="https://novel18.syosetu.com/novelpdf/creatingpdf/ncode/n6404hk/" class="js-pdf-form" method="post">
+<input type="submit" value="縦書きPDF" class="pdflilnk" data-nolock="true">
+<input type="hidden" name="token" value="9769432815cbd429b5ced540b3755549">
+</form>
+</li>
+
+<li class="booklist">
+<span class="button_bookmark logout">Xブックマークに追加</span>
+</li>
+
+
+
+
+
+<li style="padding:5px 0 5px 10px;margin-top:11px;">
+<a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="【R18】王子繁殖促進計画「王子の性欲を刺激せよ」　～よってたかって性欲を刺激される小国王子の異世界奮闘記～" data-url="https://novel18.syosetu.com/n6404hk/" data-hashtags="narou,narouN6404HK" data-lang="ja" data-show-count="false" style="border: none;">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+</li>
+</ul>
+</div><!-- novel_header -->
+
+<div id="container">
+
+
+
+<div class="narou_modal favnovelmain_modal" data-remodal-id="add_bookmark">
+<div class="close js-add_bookmark_modal_close"></div>
+
+<div class="scroll">
+<p class="fav_noveltitle js-add_bookmark_title"></p>
+<p class="mes">Xブックマークに追加しました</p>
+
+<div class="favnovelmain_update">
+<h3>設定</h3>
+<p>
+<input type="checkbox" name="isnotice" value="1" />更新通知
+<span class="left10 js-isnoticecnt">0件登録中（上限400件）</span>
+</p>
+
+<p>
+<label><input type="radio" name="jyokyo" class="bookmark_jyokyo" value="2" checked="checked" />公開</label>
+<label><input type="radio" name="jyokyo" class="bookmark_jyokyo left10" value="1" />非公開</label>
+</p>
+
+<div class="toaster bookmarker_addend js-bookmark_save_toaster" id="bookmark_save_toaster">
+<strong>設定を保存しました</strong>
+</div>
+
+<div class="toaster bookmarker_error js-bookmark_save_err_toaster">
+<strong>エラーが発生しました</strong>
+<div id="bookmark_save_errmsg" class="js-bookmark_save_errmsg"></div>
+<div class="text-right">
+<a href="#" class="toaster_close">閉じる</a>
+</div>
+</div>
+
+<p>
+カテゴリ
+<select name="categoryid" class="js-category_select"></select>
+</p>
+<div class="favnovelmain_bkm_memo">
+<label>メモ</label>
+<div class="favnovelmain_bkm_memo_content">
+<input type="text" maxlength="" class="js-bookmark_memo">
+<span class="favnovelmain_bkm_memo_content_help-text">※文字以内</span>
+</div>
+</div>
+
+<input type="button" class="button js-bookmark_setting_submit" value="設定を保存" />
+<input type="hidden" class="js-bookmark_setting_url" value="https://syosetu.com/favnovelmain/updateajax/" />
+<input type="hidden" class="js-bookmark_setting_useridfavncode" value="" />
+<input type="hidden" class="js-bookmark_setting_xidfavncode" value="" />
+<input type="hidden" class="js-bookmark_setting_token" value="" />
+</div>
+<!-- favnovelmain_update -->
+
+<a href="https://syosetu.com/favnovelmain18/list/" class="button js-modal_bookmark_btn">Xブックマークへ移動</a>
+<input type="hidden" value="//syosetu.com/favnovelmain18/list/" class="js-base_bookmark_url">
+</div><!-- scroll -->
+</div>
+<!-- narou_modal -->
+<div class="toaster bookmarker_addend js-toaster_success" id="toaster_success"></div>
+<div class="toaster bookmarker_error js-toaster_error" id="toaster_error">
+<strong class="js-toaster_error_mes"></strong><br />
+<div class="text-right">
+<a href="#" class="toaster_close">閉じる</a>
+</div>
+</div>
+
+<div class="narou_modal" data-remodal-id="delend_bookmark">
+<div class="close js-delend_bookmark_modal_close"></div>
+<p class="mes">Xブックマークを解除しました。</p>
+</div>
+
+<div class="narou_modal modal_error" data-remodal-id="error_modal">
+<div class="close js-error_modal_close"></div>
+
+<div class="scroll">
+<p class="mes err">エラーが発生しました。</p>
+<div class="err js-modal_err_mes"></div>
+<p class="guide">エラーの原因がわからない場合は<a href="https://syosetu.com/helpcenter/top/" target="_blank">ヘルプセンター</a>をご確認ください。</p>
+</div><!-- scroll -->
+</div>
+
+
+<div class="box_infotop_announce_bookmark announce_bookmark">
+Xブックマーク機能を使うには<a href="https://syosetu.com/login/input/">ログイン</a>してください。
+</div>
+
+
+<div id="contents_main">
+
+<p title="Nコード" id="ncode">N6404HK</p>
+<h1><a href="https://novel18.syosetu.com/n6404hk/">王子繁殖促進計画「王子の性欲を刺激せよ」　～よってたかって性欲を刺激される小国王子の異世界奮闘記～</a></h1>
+
+
+<div class="clearfix">
+<div id="infodata">
+
+<div id="pre_info">
+<span id="age_limit">R18</span>
+<span id="noveltype_notend">連載中</span>全176エピソード
+<a href="https://novel18.syosetu.com/n6404hk/1/">1エピソード目を読む</a>
+
+|<a href="https://novel18.syosetu.com/n6404hk/176/">最新エピソードを読む</a>
+</div>
+
+<table id="noveltable1">
+<tr>
+<th class="ex">あらすじ</th>
+<td class="ex">小国だが王子に転生した俺。　<br />
+意外に甘くない現実に戸惑いつつも、いつかはエロエロハーレムが作れたらいいな、と思っていたが……　<br />
+<br />
+幼馴染が、いとこのお姉ちゃんが、周りの美少女達が、恥じらいながらも一生懸命、俺の性欲を刺激してくる。　<br />
+<br />
+え？　俺の性欲を刺激するために、国家プロジェクトが立ち上がった？　<br />
+<br />
+――大国目指して内政に戦闘にエロに奮闘する、小国王子リヒトベルトの物語。　<br />
+<br />
+※ ♡はエロメイン　<br />
+※ 第四章開始！</td>
+</tr>
+<tr>
+<th>作者名</th>
+<td><a href="https://xmypage.syosetu.com/x7007ca/">ひもの</a>
+</td>
+</tr>
+<tr>
+<th>キーワード</th>
+<td>
+<span>
+残酷な描写あり&nbsp;異世界転生&nbsp;</span>
+男主人公 ハーレム 魔法 オリジナル戦記 戦記 淫語 羞恥 美少女 イチャラブ ♡喘ぎ 孕ませ 巨乳
+</td>
+</tr>
+<tr>
+<th>掲載サイト</th>
+<td>ノクターンノベルズ(男性向け)</td>
+</tr>
+</table>
+
+<div id="qr">
+<img class="images_qrcode" src="https://sbo.syosetu.com/n6404hk/qrcode.png" />
+<a href="https://kasasagi.hinaproject.com/access/top/ncode/n6404hk/">&gt;&gt;アクセス解析</a><br />
+System by <a href="https://kasasagi.hinaproject.com/" target="_blank">ＫＡＳＡＳＡＧＩ</a>
+</div>
+
+<table id="noveltable2">
+<tr>
+<th>掲載日</th>
+<td>2022年 01月10日 20時35分</td>
+</tr>
+<tr>
+<th>最新掲載日</th>
+<td>2024年 11月23日 21時00分</td>
+</tr>
+
+<tr>
+<th>感想</th>
+<td>
+381件
+
+<br /><span class="uketuke">※ログイン必須</span>
+</td>
+</tr>
+<tr>
+<th>レビュー</th>
+<td>
+3件
+</td>
+</tr>
+<tr>
+<th>ブックマーク登録</th>
+<td>8,656件</td>
+</tr>
+<tr>
+<th>総合評価</th>
+<td>31,846pt</td>
+</tr>
+<tr>
+<th>評価ポイント</th>
+<td>
+14,534pt
+
+
+</td>
+</tr>
+<tr>
+<th>誤字報告受付</th>
+<td>
+受け付けています<br /><span class="uketuke">※ログイン必須</span></td>
+</tr>
+<tr>
+<th>開示設定</th>
+<td>開示されています</td>
+</tr>
+<tr>
+<th>文字数</th>
+<td>1,370,741文字</td>
+</tr>
+</table>
+
+</div>
+
+<div id="ad_s_box">
+<a href="https://twitter.com/intent/tweet?text=%E3%80%90R18%E3%80%91%E3%80%8C%E7%8E%8B%E5%AD%90%E7%B9%81%E6%AE%96%E4%BF%83%E9%80%B2%E8%A8%88%E7%94%BB%E3%80%8C%E7%8E%8B%E5%AD%90%E3%81%AE%E6%80%A7%E6%AC%B2%E3%82%92%E5%88%BA%E6%BF%80%E3%81%9B%E3%82%88%E3%80%8D%E3%80%80%EF%BD%9E%E3%82%88%E3%81%A3%E3%81%A6%E3%81%9F%E3%81%8B%E3%81%A3%E3%81%A6%E6%80%A7%E6%AC%B2%E3%82%92%E5%88%BA%E6%BF%80%E3%81%95%E3%82%8C%E3%82%8B%E5%B0%8F%E5%9B%BD%E7%8E%8B%E5%AD%90%E3%81%AE%E7%95%B0%E4%B8%96%E7%95%8C%E5%A5%AE%E9%97%98%E8%A8%98%EF%BD%9E%E3%80%8D%E8%AA%AD%E3%82%93%E3%81%A0%EF%BC%81&url=%3A%2F%2Fnovel18.syosetu.com%2Fn6404hk%2F&hashtags=narou%2CnarouN6404HK" class="twitter-share-button">Tweet</a>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+
+</div><!--ad_s_box-->
+</div><!-- clear -->
+
+<div id="novelindex_button"><a href="https://novel18.syosetu.com/n6404hk/">作品を読む</a></div>
+
+
+
+<div class="koukoku_728">
+
+<div data-cptid="1571594" style="display: block;">
+<script>
+window.gnshbrequest.cmd.push(function() {
+window.gnshbrequest.applyPassback("1571594", "[data-cptid='1571594']");
+});
+</script>
+</div>
+
+
+</div><!--koukoku_728-->
+
+
+
+<div id="onazi">
+<div id="data_link">
+<h2>同一作者の作品</h2>
+<a href="https://xmypage.syosetu.com/mypage/novellist/xid/x7007ca/">&gt;&gt;ひもの&nbsp;先生の作品一覧を見る</a>
+</div><!--data_link-->
+
+<div class="th"><a href="https://novel18.syosetu.com/n6404hk/">王子繁殖促進計画「王子の性欲を刺激せよ」　～よってたかって性欲を刺激される小国王子の異世界奮闘記～</a></div>
+
+<div class="info">
+N6404HK｜
+<a href="https://novel18.syosetu.com/novelview/infotop/ncode/n6404hk/">作品情報</a>｜
+連載(全176エピソード)
+｜
+ノクターンノベルズ(男性向け)
+</div>
+<div class="ex">小国だが王子に転生した俺。　
+意外に甘くない現実に戸惑いつつも、いつかはエロエロハーレムが作れたらいいな、と思っていたが……　
+
+幼馴染が、いとこのお姉ちゃんが、周りの美少女達が、恥じらいながらも一生懸命、俺の性欲を刺激//</div>
+
+</div><!-- onazi -->
+
+
+<div id="novel_attention">
++注意+<br />
+<span class="attention">特に記載なき場合、掲載されている作品はすべてフィクションであり実在の人物・団体等とは一切関係ありません。<br />
+特に記載なき場合、掲載されている作品の著作権は作者にあります(一部作品除く)。<br />
+作者以外の方による作品の引用を超える無断転載は禁止しており、行った場合、著作権法の違反となります。<br />
+</span><br />
+この作品はリンクフリーです。ご自由にリンク(紹介)してください。<br />
+作品の読了時間は毎分500文字を読むと想定した場合の時間です。目安にして下さい。
+</div><!--novel_attention-->
+
+
+<div id="novel_footer">
+<ul class="undernavi">
+<li><a href="https://xmypage.syosetu.com/x7007ca/">作者Xマイページ</a></li>
+
+
+<li><a href="https://syosetu.com/ihantsuhou/input/ncode/1926212/">情報提供</a></li>
+</ul>
+</div><!--novel_footer-->
+
+
+</div><!--contents_main-->
+
+<br />
+
+<div class="koukoku_300x2">
+<div class="koukoku_300x2__ad">
+
+<script type="text/javascript" src="https://js.gsspcln.jp/t/563/322/a1563322.js"></script>
+
+</div><!-- /.koukoku_300x2__ad -->
+<div class="koukoku_300x2__ad">
+
+<script type="text/javascript" src="https://js.gsspcln.jp/t/563/321/a1563321.js"></script>
+
+</div><!-- /.koukoku_300x2__ad -->
+</div><!-- /.koukoku_300x2 -->
+
+
+<a id="pageTop" class="js-navigater-totop pageTop" href="#main">↑ページトップへ</a>
+
+</div><!--container-->
+
+<!-- フッタここから -->
+<div id="footer">
+<ul class="undernavi">
+<li><a href="https://syosetu.com">小説家になろう</a></li>
+<li><a href="https://noc.syosetu.com/">ノクターンノベルズ</a></li>
+<li><a href="https://mnlt.syosetu.com/">ムーンライトノベルズ</a></li>
+<li><a href="https://mid.syosetu.com/">ミッドナイトノベルズ</a></li>
+</ul>
+</div><!--footer-->
+<!-- フッタここまで -->
+
+
+
+
+</body></html>


### PR DESCRIPTION
fix #1323

[作品に含まれる要素](https://syosetu.com/helpcenter/helppage/helppageid/57)によって設定されたキーワードが `&nbsp;` 区切りで出力されていて、うまくタグ分割できていなかったのを修正しました。