### PR TITLE
DLsiteResolver: カップリング設定がある場合にジャンルがタグ抽出できないバグの修正

### DIFF
--- a/app/MetadataResolver/DLsiteResolver.php
+++ b/app/MetadataResolver/DLsiteResolver.php
@@ -33,16 +33,11 @@ class DLsiteResolver implements Resolver
         @$dom->loadHTML(Formatter::htmlEntities($html, 'UTF-8'));
         $xpath = new \DOMXPath($dom);
 
-        $genreNode = $xpath->query("//div[@class='main_genre'][1]");
-        if ($genreNode->length === 0) {
-            return [];
-        }
-
-        $tagsNode = $genreNode->item(0)->getElementsByTagName('a');
+        $tagsNode = $xpath->query("//div[@class='main_genre']/a");
         $tags = [];
 
-        for ($i = 0; $i <= $tagsNode->length - 1; $i++) {
-            $tags[] = $tagsNode->item($i)->textContent;
+        foreach ($tagsNode as $node) {
+            $tags[] = $node->textContent;
         }
 
         // 重複削除

--- a/tests/Unit/MetadataResolver/DLsiteResolverTest.php
+++ b/tests/Unit/MetadataResolver/DLsiteResolverTest.php
@@ -162,6 +162,22 @@ class DLsiteResolverTest extends TestCase
         }
     }
 
+    public function testGirlsCoupling()
+    {
+        $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testGirlsCoupling.html');
+
+        $this->createResolver(DLsiteResolver::class, $responseText);
+
+        $metadata = $this->resolver->resolve('https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html');
+        $this->assertEquals('♂が受け。ネコちゃん×ネコくん', $metadata->title);
+        $this->assertEquals('サークル名: pink carrot' . PHP_EOL . '同級生のネコ♂くんをえっちに攻めるネコ♀ちゃんのすけべ漫画。', $metadata->description);
+        $this->assertEquals('https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_main.jpg', $metadata->image);
+        $this->assertEquals(['フェラチオ', '乳首/乳輪', '制服', '同級生/同僚', '女×男', '焦らし', '獣耳', '男性受け', '逆転無し'], $metadata->tags);
+        if ($this->shouldUseMock()) {
+            $this->assertSame('https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html', (string) $this->handler->getLastRequest()->getUri());
+        }
+    }
+
     public function testBL()
     {
         $responseText = $this->fetchSnapshot(__DIR__ . '/../../fixture/DLsite/testBL.html');

--- a/tests/fixture/DLsite/testGirlsCoupling.html
+++ b/tests/fixture/DLsite/testGirlsCoupling.html
@@ -1,0 +1,2511 @@
+<!DOCTYPE html>
+<html lang="ja-jp">
+
+<head>
+  <meta charset="utf-8">
+<meta name="viewport" content="width=1024">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<meta http-equiv="Content-Script-Type" content="text/javascript">
+<meta name="google-site-verification" content="S2Jzwn_Dm4hGoyTfPnxEUSKnbHSuT73N6SZbTanWbEM">
+<meta name="rating" content="adult">
+<link rel="apple-touch-icon" href="/modpub/images/web/common/apple_touch_icon_girls_57x57.png">
+<link rel="apple-touch-icon" sizes="72x72" href="/modpub/images/web/common/apple_touch_icon_girls_72x72.png">
+<link rel="apple-touch-icon" sizes="76x76" href="/modpub/images/web/common/apple_touch_icon_girls_76x76.png">
+<link rel="apple-touch-icon" sizes="114x114" href="/modpub/images/web/common/apple_touch_icon_girls_114x114.png">
+<link rel="apple-touch-icon" sizes="120x120" href="/modpub/images/web/common/apple_touch_icon_girls_120x120.png">
+<link rel="apple-touch-icon" sizes="144x144" href="/modpub/images/web/common/apple_touch_icon_girls_144x144.png">
+<link rel="apple-touch-icon" sizes="152x152" href="/modpub/images/web/common/apple_touch_icon_girls_152x152.png">
+<meta name="msapplication-config" content="/browserconfig_girls.xml">
+<link rel="shortcut icon" href="/images/web/common/favicon.ico">
+<script src="https://cdn-apac.onetrust.com/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="b3436a95-43c8-4563-b55a-f5f020bd3cc8"></script>
+
+<script type="text/javascript">
+  function OptanonWrapper() { }
+</script>
+
+
+  
+      
+  
+  
+  <link rel="canonical" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html">
+
+  <link rel="alternate" media="only screen and (max-width: 640px)" href="https://www.dlsite.com/girls-touch/work/=/product_id/RJ01008713.html" class="alternate_smartphone" />
+
+  <link rel="alternate" hreflang="ja" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html">
+<link rel="alternate" hreflang="zh-TW" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=zh_TW">
+<link rel="alternate" hreflang="zh-CN" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=zh_CN">
+<link rel="alternate" hreflang="ko" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=ko_KR">
+<link rel="alternate" hreflang="en" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=en_US">
+<link rel="alternate" hreflang="es-ES" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=es_ES">
+<link rel="alternate" hreflang="ar-AE" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=ar_AE">
+<link rel="alternate" hreflang="de-DE" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=de_DE">
+<link rel="alternate" hreflang="fr-FR" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=fr_FR">
+<link rel="alternate" hreflang="id-ID" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=id_ID">
+<link rel="alternate" hreflang="it-IT" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=it_IT">
+<link rel="alternate" hreflang="pt-BR" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=pt_BR">
+<link rel="alternate" hreflang="sv-SE" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=sv_SE">
+<link rel="alternate" hreflang="th-TH" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=th_TH">
+<link rel="alternate" hreflang="vi-VN" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html/?locale=vi_VN">
+
+
+
+<meta name="description" content="同級生のネコ♂くんをえっちに攻めるネコ♀ちゃんのすけべ漫画。「DLsite がるまに」は乙女向け同人・シチュエーションCD・乙女ゲームのダウンロードショップ。お気に入りの作品をすぐダウンロードできてすぐ楽しめる！毎日更新しているのであなたが探している作品にきっと出会えます。国内最大級の二次元総合ダウンロードショップ「DLsite」！">
+<title>【30%OFF】♂が受け。ネコちゃん×ネコくん [pink carrot] | DLsite がるまに</title>
+
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@DLsiteがるまに">
+<meta name="twitter:image:src" content="https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_main.jpg">
+
+<meta property="og:title" content="♂が受け。ネコちゃん×ネコくん [pink carrot] | DLsiteがるまに">
+<meta property="og:type" content="website">
+<meta property="og:description" content="同級生のネコ♂くんをえっちに攻めるネコ♀ちゃんのすけべ漫画。「DLsite がるまに」は乙女向け同人・シチュエーションCD・乙女ゲームのダウンロードショップ。お気に入りの作品をすぐダウンロードできてすぐ楽しめる！毎日更新しているのであなたが探している作品にきっと出会えます。国内最大級の二次元総合ダウンロードショップ「DLsite」！">
+<meta property="og:url" content="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html">
+<meta property="og:image" content="https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_main.jpg">
+<meta property="og:site_name" content="Girls's Maniax">
+<meta property="fb:app_id" content="226115600829997">
+<meta property="mixi:content-rating" content="1">
+<meta property="mixi:device-smartphone" content="https://www.dlsite.com/girls-touch/work/=/product_id/RJ01008713.html">
+
+
+    <script>
+if ( ! /uniqid=/.test(document.cookie)) {
+  document.cookie = 'uniqid=' + Math.random().toString(36) + '; domain=.dlsite.com; path=/; max-age=63072000'
+}
+
+if (/uniqid=\./.test(document.cookie)) {
+  document.cookie = 'uniqid=' + Math.random().toString(36) + '; domain=.dlsite.com; path=/; max-age=63072000'
+}
+</script>
+<!-- A/BテストツールVWOの検証期間中設定 -->
+
+<!-- Start VWO Async SmartCode -->
+<link rel="preconnect" href="https://dev.visualwebsiteoptimizer.com" />
+<script type='text/javascript' id='vwoCode'>
+window._vwo_code || (function() {
+var account_id=855141,
+version=2.0,
+settings_tolerance=2000,
+hide_element='body',
+hide_element_style = 'opacity:0 !important;filter:alpha(opacity=0) !important;background:none !important',
+/* DO NOT EDIT BELOW THIS LINE */
+f=false,w=window,d=document,v=d.querySelector('#vwoCode'),cK='_vwo_'+account_id+'_settings',cc={};try{var c=JSON.parse(localStorage.getItem('_vwo_'+account_id+'_config'));cc=c&&typeof c==='object'?c:{}}catch(e){}var stT=cc.stT==='session'?w.sessionStorage:w.localStorage;code={use_existing_jquery:function(){return typeof use_existing_jquery!=='undefined'?use_existing_jquery:undefined},library_tolerance:function(){return typeof library_tolerance!=='undefined'?library_tolerance:undefined},settings_tolerance:function(){return cc.sT||settings_tolerance},hide_element_style:function(){return'{'+(cc.hES||hide_element_style)+'}'},hide_element:function(){return typeof cc.hE==='string'?cc.hE:hide_element},getVersion:function(){return version},finish:function(){if(!f){f=true;var e=d.getElementById('_vis_opt_path_hides');if(e)e.parentNode.removeChild(e)}},finished:function(){return f},load:function(e){var t=this.getSettings(),n=d.createElement('script'),i=this;if(t){n.textContent=t;d.getElementsByTagName('head')[0].appendChild(n);if(!w.VWO||VWO.caE){stT.removeItem(cK);i.load(e)}}else{n.fetchPriority='high';n.src=e;n.type='text/javascript';n.onerror=function(){_vwo_code.finish()};d.getElementsByTagName('head')[0].appendChild(n)}},getSettings:function(){try{var e=stT.getItem(cK);if(!e){return}e=JSON.parse(e);if(Date.now()>e.e){stT.removeItem(cK);return}return e.s}catch(e){return}},init:function(){if(d.URL.indexOf('__vwo_disable__')>-1)return;var e=this.settings_tolerance();w._vwo_settings_timer=setTimeout(function(){_vwo_code.finish();stT.removeItem(cK)},e);var t=d.currentScript,n=d.createElement('style'),i=this.hide_element(),r=t&&!t.async&&i?i+this.hide_element_style():'',c=d.getElementsByTagName('head')[0];n.setAttribute('id','_vis_opt_path_hides');v&&n.setAttribute('nonce',v.nonce);n.setAttribute('type','text/css');if(n.styleSheet)n.styleSheet.cssText=r;else n.appendChild(d.createTextNode(r));c.appendChild(n);this.load('https://dev.visualwebsiteoptimizer.com/j.php?a='+account_id+'&u='+encodeURIComponent(d.URL)+'&vn='+version)}};w._vwo_code=code;code.init();})();
+</script>
+<!-- End VWO Async SmartCode -->
+
+  <link rel="stylesheet" href="/css/reset.css?1732268357" type="text/css" id="reset" />
+<link rel="stylesheet" href="/css/default.css?1732268357" type="text/css" id="default" />
+<link rel="stylesheet" href="/css/layout_2col_work.css?1732268357" type="text/css" id="layout_2col_work" />
+<link rel="stylesheet" href="/css/common_girls.css?1732268357" type="text/css" id="common" />
+<link rel="stylesheet" href="/css/switch_girls.css?1732268357" type="text/css" id="switch" />
+<link rel="stylesheet" href="/css/suggest.css?1732268357" type="text/css" id="suggest" />
+<link rel="stylesheet" href="/css/header_campaign_banner.css?1732268357" type="text/css" id="header_campaign_banner" />
+<link rel="stylesheet" href="/modpub/universal/css/universal.css?" type="text/css" id="universal" />
+<link rel="stylesheet" href="/css/work_template_girls.css?1732268357" type="text/css" id="work_template" />
+<link rel="stylesheet" href="/css/work_slider.css?1732268357" type="text/css" id="work_slider" />
+<link rel="stylesheet" href="/css/couponget.css?1732268357" type="text/css" id="couponget" />
+
+  <script type="text/javascript" src="/js/libs/libraries-pack.js?1732268225"></script>
+<script type="text/javascript" src="/js/dlsite_util.js?1724742494"></script>
+<script type="text/javascript" src="/js/slide_menu.js?1718605538"></script>
+<script type="text/javascript" src="/js/dlsite_suggest.js?1730769350"></script>
+<script type="text/javascript" src="/js/dlsite_trigger.js?1718605538"></script>
+<script type="text/javascript" src="/js/jquery.slideproduct.js?1718605538"></script>
+<script type="text/javascript" src="/js/dlsite_img_filter.js?1723689994"></script>
+<script type="text/javascript" src="/js/dlsite/work/work_logger.js?1718605538"></script>
+<script type="text/javascript" src="/js/libs/clipboard.min.js?1718605538"></script>
+<script type="text/javascript" src="/js/swiper4.0.7/js/swiper.min.js?1718605538"></script>
+<script type="text/javascript" src="/js/picturefill.min.js?1718605538"></script>
+
+  
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(), event:'gtm.js'}); var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=Z_ubU9a2b3yGEFSh9Hdtkg&gtm_preview=env-12&gtm_cookies_win=x';f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-NTSRG2');</script>
+<!-- End Google Tag Manager -->
+
+
+
+  
+
+
+</head>
+
+<body class="style_girls t_female">
+  
+  
+<script>
+(function(){
+$.extend({
+  useAdultcheck: false,
+  importAdultcheck: function(){
+    if ($.useAdultcheck) return;
+    $.useAdultcheck = true;
+    var s = document.createElement('script');
+    s.src = '/js/adultcheck.js?1718605538';
+    s.defer = true;
+    document.querySelector('head').appendChild(s);
+  }
+});
+if ((dlsite.isAdult() && dlsite.getId() !== 'circle' && !(dlsite.isFemale() && dlsite.isBooks())) || dlsite.forceAdultCheck) {
+  $.importAdultcheck();
+}
+})();
+</script>
+
+
+  <!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NTSRG2&gtm_auth=Z_ubU9a2b3yGEFSh9Hdtkg&gtm_preview=env-12&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+
+
+    <div data-vue-component="header-banner" data-vue-async="true" data-section_name="campaign_header_banner" data-ga4-ref="campaign_header_banner">
+    <div v-if="loading" class="hd_cp_banner type_4bn">
+    <ul class="cp_bn_list">
+            <li class="cp_bn_item" style="background-color: #ee271f;">
+        <a href="https://www.dlsite.com/girls/campaign/discount?key=sale28thankyou&show_type=g&group3%5B0%5D=tl" >
+          <div class="cp_bn_inner">
+                        <div class="cp_bn_reminder " style="background-color: ; color: ;">
+              <div class="cp_bn_reminder_content"><i class="cp_bn_reminder_period type_date">11/28</i><i class="cp_bn_reminder_period type_time">13:59</i>まで</div>
+            </div>
+                        <div class="cp_bn"><img src="https://www.dlsite.com/modpub/images/campaign/set_62838_2411/bn_62838_hd_pc_ja_jp.png" alt="創業28周年ありがとう！セール"></div>
+                      </div>
+        </a>
+      </li>
+            <li class="cp_bn_item" style="background-color: #0052de;">
+        <a href="https://www.dlsite.com/modpub/lp/girls/dlsite-nation-survey-result/" >
+          <div class="cp_bn_inner">
+                        <div class="cp_bn"><img src="https://www.dlsite.com/modpub/lp/home/dlsite-nation-survey-result/assets/img/jp/bn_dls25340_hd_pc_01_ja_jp.png" alt="DLsiteジャンル国民投票 結果発表"></div>
+                      </div>
+        </a>
+      </li>
+            <li class="cp_bn_item" style="background-color: #8D87AE;">
+        <a href="https://www.dlsite.com/home/campaign/founding-festival2024/" >
+          <div class="cp_bn_inner">
+                        <div class="cp_bn"><img src="https://www.dlsite.com/modpub/home/campaign/founding-festival2024/img/banner/bn_hd_pc_ja_jp.png" alt="おかげさまで28周年！『DLsite創業祭2024』キャンペーンページ"></div>
+                      </div>
+        </a>
+      </li>
+            <li class="cp_bn_item" style="background-color: #141414;">
+        <a href="https://www.dlsite.com/girls/work/=/product_id/RJ01244077.html" >
+          <div class="cp_bn_inner">
+                        <div class="cp_bn"><img src="https://www.dlsite.com/modpub/images/works/sl_61675/bn_hd_pc_ja_jp_1_4.png" alt=""></div>
+                      </div>
+        </a>
+      </li>
+          </ul>
+  </div>
+    
+  <div v-else-if="is_show_frame" :class="style" class="hd_cp_banner" v-cloak>
+    <ul class="cp_bn_list">
+      <li v-for="campaign in campaigns" class="cp_bn_item" :data-ab-test="campaign.abTest" :style="{'background-color': campaign.mainColor}">
+        <a :href="campaign.url" :target="campaign.option.includes('target_blank') ? 'blank' : null">
+          <div class="cp_bn_inner">
+            <div class="cp_bn_reminder" v-if="campaign.isShowLimit" :class="{blank: !campaign.isShowLimit}" :style="{'background-color': campaign.periodBgColor, 'color': campaign.periodTextColor}">
+              <div class="cp_bn_reminder_content" v-html="campaign.period"></div>
+            </div>
+            <div class="cp_bn"><img :src="campaign.img" :alt="campaign.alt"></div>
+            <div
+              class="cp_bn_work"
+              v-if="campaign.outline"
+              v-html="campaign.outline"
+              :style="{'background-color': campaign.periodBgColor}"
+            >
+            </div>
+          </div>
+        </a>
+      </li>
+    </ul>
+  </div>
+  
+</div>
+
+  <div data-vue-component="coupon-modal" v-cloak></div>
+
+
+<div data-vue-component="header-locale-suggest-dialog" data-vue-async="true"></div>
+
+<div data-vue-component="ie-alert" v-cloak></div>
+  <!-- container -->
+    <div itemscope itemtype="http://schema.org/Product" id="container" site="girls">
+    
+      <div id="top_header">
+        
+      </div>
+
+      <!-- header -->
+      <div id="header">
+        <header class="l-header" data-vue-component="header" data-search-category="">
+  <div class="headerCore">
+    <div class="headerCore_top" data-ga4-ref="header_menu">
+      <div class="headerCore_top_item">
+        <p class="header_description">
+                                    乙女向け(TL)漫画・シチュエーションボイス・ゲームはDLsiteがるまに                              </p>
+      </div>
+      <div class="headerCore_top_item">
+                <ul v-if="isMemberLogin" v-cloak class="login_information">
+          <li class="login_information_item type_point">
+            <a href="https://www.dlsite.com/girls/mypage/point" class="coupon_text">
+            ポイント<span class="number" v-text="point_str">-</span>pt
+            </a>
+          </li>
+          <li class="login_information_item type_coupon" :class="{ 'is-active': noticeCoupons.length, 'singular-number': coupons.length === 1 }">
+            <a href="https://www.dlsite.com/girls/mypage/coupon/list" class="coupon_text">クーポン<span class="number" v-text="coupons.length">-</span>枚</a>
+          </li>
+        </ul>
+                <header_locale class="header_dropdown_nav type_language">
+          <div class="header_dropdown_nav_Link">Language</div>
+        </header_locale>
+                        <header_service class="header_dropdown_nav type_service">
+          <div class="header_dropdown_nav_Link">関連サービス</div>
+        </header_service>
+              </div>
+    </div>
+
+    <div class="headerCore-sub" data-ga4-ref="header">
+            <a href="https://www.dlsite.com/girls/" class="logo">
+                        <img src="/images/web/common/logo/pc/logo-dlsite-girls.png" alt="DLsiteがるまに 女性向け" width="241" height="25">
+                      </a>
+            <!-- 検索 -->
+              <div class="globalSearch" :class="{active: isFocus}">
+          <form class="globalSearch-form" action="https://www.dlsite.com/girls/fs" method="post">
+            <input name="_qf__fulltext_search" type="hidden" value="">
+            <input name="_layout" type="hidden" value="fs">
+            <input name="_site" type="hidden" value="girls">
+            <input name="_form_id" type="hidden" value="FulltextSearchProductForm">
+            <input name="_view" type="hidden" value="input">
+            <input name="from" type="hidden" value="fs.header" id="header_search_from">
+
+                                        <input type="hidden" name="site_category" :value="selected" v-if="!/drama$/.test(selected)">
+                            <input type="hidden" name="work_category" :value="'drama'" v-if="/drama$/.test(selected)">
+                            <input type="hidden" name="work_category" :value="'all'" v-if="site.gender === 'female' && !selected">
+                            <input type="hidden" name="is_tl"  :value="1" v-if="/^girls/.test(selected)">
+              <input type="hidden" name="is_bl"  :value="1" v-if="/^bl/.test(selected)">
+              <input type="hidden" name="is_gay" :value="1" v-if="/^bl/.test(selected)">
+            
+            <div class="globalSearchSelect">
+              <div class="globalSearchSelect-lable">
+                <span v-text="searchCategories[selected]">すべて</span>
+              </div>
+              <select v-model="selected" class="globalSearchSelect-list is-active">
+                <option value="">すべて</option>
+                                <option value="girls">乙女向け同人</option>
+                <option value="girlspro">TLコミック</option>
+                <option value="girlsdrama">乙女向けドラマCD</option>
+                <option value="bl">BL同人</option>
+                <option value="blpro">BLコミック</option>
+                <option value="bldrama">BLドラマCD</option>
+                              </select>
+            </div>
+            <div class="globalSearchForm">
+              <input
+                name="keyword"
+                type="search"
+                id="search_text"
+                ref="keyword"
+                maxlength="255"
+                autocomplete="off"
+                aria-autocomplete="list"
+                                placeholder="キーワードから探す（作品名、サークル名など）"                @focus="isFocus = true"
+                @blur="isFocus = false"
+              >
+            </div>
+            <button id="search_button" class="globalSearchBtn" type="submit" @click="saveSelected()"><i>検索</i></button>
+          </form>
+        </div>
+        <div
+          class="globalSearchBg"
+          :class="{active: isFocus}"
+        ></div>
+        <div class="detailedSearch">
+          <a href="https://www.dlsite.com/girls/fs">こだわり条件</a>
+        </div>
+            <!-- /検索 -->
+      <!-- アイコンメニュー -->
+      <ul class="globalNav">
+        <li v-if="!isMemberLogin && !isCircleLogin" class="globalNav-item type-register" v-cloak>
+          <a href="https://www.dlsite.com/girls/regist/user"><i>新規登録</i></a>
+        </li>
+        <li v-if="!isMemberLogin && !isCircleLogin" class="globalNav-item type-login" v-cloak>
+          <a href="https://www.dlsite.com/girls/login/=/skip_register/1" referrerpolicy="no-referrer-when-downgrade"><i>ログイン</i></a>
+        </li>
+        <li v-if="isMemberLogin" class="globalNav-item type-favorite">
+          <a  :href="hasUnboughtFavorites ? 'https://www.dlsite.com/girls/mypage/wishlist' : 'https://www.dlsite.com/girls/mypage/wishlist'"><i>お気に入り</i></a><template v-if="hasUnboughtFavorites" v-cloak><a href="https://www.dlsite.com/girls/mypage/wishlist/=/discount/1" class="notificationBadge" >割引作品あり</a></template>
+        </li>
+        <li class="globalNav-item type-cart"><a href="https://www.dlsite.com/girls/cart"><i>カート</i></a><span v-if="cartActives.length" v-cloak class="cartBadge" v-text="Math.min(cartActives.length, 100)"></span></li>
+        <li v-if="isMemberLogin" class="globalNav-item type-play">
+          <a rel="noopener" href="https://play.dlsite.com/" target="_blank" v-cloak><i>購入済作品</i></a>
+        </li>
+        <!-- メンバーアカウント登録の場合　-->
+        <li v-if="isMemberLogin" class="globalNav-item type-circle">
+          <a v-cloak><i>アカウント</i></a>
+          <div class="dropdown_list type_account" v-cloak>
+            <div class="dropdown_list_inner">
+              <ul class="globalNav">
+                <li class="globalNav-item type-review">
+                  <a href="https://www.dlsite.com/girls/mypage/short-review">
+                    <i>評価・レビュー</i>
+                  </a>
+                </li>
+                <li class="globalNav-item type-coupon">
+                  <a href="https://www.dlsite.com/girls/mypage/coupon/list">
+                    <i>クーポン管理</i>
+                  </a>
+                </li>
+                <li class="globalNav-item type-userbuy">
+                  <a href="https://www.dlsite.com/girls/mypage/userbuy">
+                    <i>購入履歴</i>
+                  </a>
+                </li>
+              </ul>
+              <ul class="menu_list">
+                <li class="menu_list_item type-mypage">
+                  <a href="https://www.dlsite.com/girls/mypage" class="link">
+                    <i>マイページ</i>
+                    <span v-if="mypageNotices > 0" class="count" v-cloak>{{ noticesBadge(mypageNotices) }}</span>
+                  </a>
+                  <div v-if="mypageNotices > 0" class="notice">
+                                        重要なお知らせが<span>{{ mypageNotices }}件</span>あります。                  </div>
+                </li>
+                <li v-if="isCircleLogin" class="menu_list_item type-circle" v-cloak>
+                  <a href="https://www.dlsite.com/circle/" class="link">
+                    <i>サークル管理</i>
+                    <span v-if="circleNotices > 0" class="count" v-cloak>{{ noticesBadge(circleNotices) }}</span>
+                  </a>
+                  <div v-if="circleNotices > 0" class="notice">
+                                        重要なお知らせが<span>{{ circleNotices }}件</span>あります。                  </div>
+                </li>
+                <li v-if="is_translator" class="menu_list_item" v-cloak>
+                  <a href="https://www.dlsite.com/translator/work" class="link">
+                    <i>みんなで翻訳管理</i>
+                  </a>
+                </li>
+                <li class="menu_list_item">
+                  <a href="https://login.dlsite.com/user/self?lang=ja&redirect_uri=https%3A%2F%2Fwww.dlsite.com%2Fgirls%2F&cancel_uri=https://www.dlsite.com/girls/" class="link" target="_blank">
+                    <i>アカウント管理</i>
+                  </a>
+                </li>
+              </ul>
+              <div class="login_account">
+                <div class="login_account_item">
+                  <p v-if="login_id" v-cloak class="account_name">
+                                                            <span>{{ login_id.substr(0, 30) }}{{ login_id.length > 30 ? '...' : '' }}</span>
+                    さん                  </p>
+                </div>
+                <div class="login_account_item">
+                  <a href="https://www.dlsite.com/girls/logout" class="logout">ログアウト</a>
+                </div>
+              </div>
+            </div>
+          </div>
+          <span v-if="(mypageNotices + circleNotices) > 0 " class="accountBadge" v-text="noticesBadge(mypageNotices + circleNotices)" v-cloak></span>
+        </li>
+        <!-- サークルアカウントのみ登録の場合　-->
+        <li v-if="isCircleLogin && !isMemberLogin" class="globalNav-item type-circle">
+          <a v-cloak><i>アカウント</i></a>
+          <div class="dropdown_list type_account" v-cloak>
+            <div class="dropdown_list_inner">
+              <ul class="menu_list">
+                <li v-if="isCircleLogin" class="menu_list_item type-circle" v-cloak>
+                  <a href="https://www.dlsite.com/circle/" class="link">
+                    <i>サークル管理</i>
+                    <span v-if="circleNotices > 0" class="count" v-cloak>{{ noticesBadge(circleNotices) }}</span>
+                  </a>
+                  <div v-if="circleNotices > 0" class="notice">
+                                        重要なお知らせが<span>{{ circleNotices }}件</span>あります。                  </div>
+                </li>
+                <li v-if="is_translator" class="menu_list_item" v-cloak>
+                  <a href="https://www.dlsite.com/translator/work" class="link">
+                    <i>みんなで翻訳管理</i>
+                  </a>
+                </li>
+                <li class="menu_list_item">
+                  <a href="https://login.dlsite.com/user/self?lang=ja&redirect_uri=https%3A%2F%2Fwww.dlsite.com%2Fgirls%2F&cancel_uri=https://www.dlsite.com/girls/" class="link" target="_blank">
+                    <i>アカウント管理</i>
+                  </a>
+                </li>
+              </ul>
+              <div class="login_account">
+                <div class="login_account_item">
+                  <p v-if="login_id" v-cloak class="account_name">
+                                                            <span>{{ login_id.substr(0, 30) }}{{ login_id.length > 30 ? '...' : '' }}</span>
+                    さん                  </p>
+                </div>
+                <div class="login_account_item">
+                  <a href="https://www.dlsite.com/girls/logout" class="logout">ログアウト</a>
+                </div>
+              </div>
+            </div>
+          </div>
+          <span v-if="(circleNotices) > 0 " class="accountBadge" v-text="noticesBadge(circleNotices)" v-cloak></span>
+        </li>
+        <li class="globalNav-item type-guide">
+          <a href="#"><i>ガイド</i></a>
+          <div class="dropdown_list type_guide">
+            <div class="dropdown_list_inner">
+              <ul class="menu_list">
+                <li class="menu_list_item"><a rel="noopener" href="https://www.dlsite.com/girls/faq/=/type/user" target="_blank" class="link">ヘルプ</a></li>
+                <li class="menu_list_item"><a href="https://www.dlsite.com/girls/welcome" class="link">初めての方へ</a></li>
+                                <li class="menu_list_item"><a href="https://www.dlsite.com/girls/circle/invite" class="link">サークル登録について</a></li>
+                                <li class="menu_list_item"><a href="https://www.dlsite.com/girls/guide/payment" class="link">お支払方法について</a></li>
+                <li class="menu_list_item"><a href="https://www.dlsite.com/girls/mypage/aboutpoint" class="link">ポイントについて</a></li>
+              </ul>
+            </div>
+          </div>
+        </li>
+      </ul>
+      <!-- /ガイドメニュー -->
+    </div>
+
+        <div class="headerCore-main">
+        <div class="headerCore-mainInner " :class="{ couponShow: isAccountLogin }" data-ga4-ref="floor_navi">
+                  <ul class="floorTab type-girls" role="navigation">
+                                                                                            <li class="floorTab-item type-tl is-active"><a href="https://www.dlsite.com/girls/">乙女向け/TL</a></li>
+            <li class="floorTab-item type-bl "><a href="https://www.dlsite.com/bl/">BL</a></li>
+          </ul>
+        
+                <div class="floorNavLink type-girls">
+                    <div class="floorNavLink-item type-general"><a href="https://www.dlsite.com/home/">全年齢へ</a></div>
+                    <div class="floorNavLink-item type-adult"><a href="https://www.dlsite.com/maniax/">男性 R18へ</a></div>
+        </div>
+              </div>
+            <div class="floorSubNav" data-ga4-ref="floor_sub_navi">
+        <div class="floorSubNav-item">
+          <ul class="headerNav">
+
+      
+                                                                                              <li class="headerNav-item"><a href="https://www.dlsite.com/girls/" class="doujin">同人</a></li>
+            <li class="headerNav-item"><a href="https://www.dlsite.com/girls-pro/" class="comic">コミック</a></li>
+            <li class="headerNav-item"><a href="https://www.dlsite.com/girls-drama/" class="drama">ドラマCD</a></li>
+            <li class="headerNav-item"><a href="https://www.dlsite.com/girls-pro/girlsgame" class="game">動画・ゲーム</a></li>
+            <li class="headerNav-item"><a href="https://www.dlsite.com/girls-pro/promo/works/=/key/tl-webtoon" class="webtoon" :class="{'is-active': currentPromoKeyEquals('tl-webtoon') || currentPromoKeyEquals('bl-webtoon')}">WEBTOON</a></li>
+                        <li class="headerNav-item">
+                                                        <a href="                                  https://www.dlsite.com/girls/ranking
+                              " class="ranking">ランキング</a>
+            </li>
+                        <li class="headerNav-item"><a href="https://www.dlsite.com/girls/announce/list/day" class="announce">発売予告作品</a></li>
+                        <li class="headerNav-item"><a href="https://www.dlsite.com/girls/new" class="calendar">発売カレンダー</a></li>
+            
+            
+            
+                </ul>
+        </div>
+      </div>
+      
+    </div>
+      </div>
+</header>
+
+
+
+
+        <script type="text/javascript">
+var loginchecked = document.getCookie('loginchecked');
+
+if (loginchecked & 1) {
+  // ユーザがログイン中の表示
+  $("li#nav_login a").attr("title", "ログアウト").attr("href", "https://www.dlsite.com/girls/logout/=/type/member");
+  $("li#nav_login").attr("id", "nav_logout");
+} else {
+  // ユーザがログアウト中の表示
+//  $("li#nav_logout a").attr("title", "ログイン").attr("href", "https://www.dlsite.com/girls/login/=/type/member");
+//  $("li#nav_logout").attr("id", "nav_login");
+}
+</script>
+
+        
+      </div>
+      <!-- /header -->
+
+            <!-- top_wrapper -->
+      <div id="top_wrapper" class="clearfix" data-section_name="top_wrapper">
+        <ul class="topicpath" itemscope="" itemtype="https://schema.org/BreadcrumbList">
+  <li class="topicpath_item" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+    <a itemtype="https://schema.org/Thing" itemprop="item" href="https://www.dlsite.com/girls/">
+    <span itemprop="name">
+              乙女向け同人          </span>
+    </a>
+    <meta itemprop="position" content="1">
+      </li>
+                          <li class="topicpath_item" itemprop="itemListElement" itemscope="" itemtype="http://schema.org/ListItem">
+        <a itemtype="http://schema.org/Thing" itemprop="item" href="https://www.dlsite.com/girls/circle/list">
+    <span itemprop="name">
+                                      サークル一覧          </span>
+        </a>
+        <meta itemprop="position" content="2">
+              </li>
+                  <li class="topicpath_item" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+        <a itemtype="https://schema.org/Thing" itemprop="item"
+           href="https://www.dlsite.com/girls/circle/profile/=/maker_id/RG67243.html">
+          <span itemprop="name">pink carrot</span>
+        </a>
+        <meta itemprop="position" content="3">
+              </li>
+                                          <li class="topicpath_item" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+            <a itemtype="https://schema.org/Thing" itemprop="item" href="https://www.dlsite.com/girls/fsr/=/title_id/SRI0000046090/order/release_d/from/work.series">
+              <span itemprop="name">「♂が受け。ネコちゃん×ネコくん」シリーズ</span>
+            </a>
+            <meta itemprop="position" content="4">
+                      </li>
+                    <li class="topicpath_item" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+        <a itemtype="https://schema.org/Thing" itemprop="item" href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html">
+          <span itemprop="name">♂が受け。ネコちゃん×ネコくん</span>
+        </a>
+        <meta itemprop="position" content="5">
+              </li>
+                            
+      </ul>
+<div class="base_title_br clearfix">
+
+<div class="icon_wrap">
+
+
+
+<span class="icon_lead_01 type_exclusive" title="専売">専売</span>
+
+
+
+
+
+
+</div>
+<h1 itemprop="name" id="work_name">♂が受け。ネコちゃん×ネコくん</h1>
+
+<template data-vue-component="dlchannel-topic" data-product-id="RJ01008713" data-product-name="♂が受け。ネコちゃん×ネコくん" data-maker-name="pink carrot"></template>
+
+
+  
+    
+  
+        
+                
+  
+
+<template data-vue-component="share-button" data-twitter-share-url="https://twitter.com/intent/tweet?url=https%3A%2F%2Fdlsite.jp%2Fgiwot%2FRJ01008713%2F%3Futm_content%3DRJ01008713%26locale%3Dja_JP%0A&text=%E2%99%82%E3%81%8C%E5%8F%97%E3%81%91%E3%80%82%E3%83%8D%E3%82%B3%E3%81%A1%E3%82%83%E3%82%93%C3%97%E3%83%8D%E3%82%B3%E3%81%8F%E3%82%93%2Fpink%20carrot%2030%25OFF%2011%2F28%2013%E6%99%8259%E5%88%86%E3%81%BE%E3%81%A7&hashtags=DLsiteがるまに&lang=ja
+" data-award-share-url="https://twitter.com/intent/tweet?text=DLsite%E3%82%A2%E3%83%AF%E3%83%BC%E3%83%892022%0A%E3%81%93%E3%81%AE%E4%BD%9C%E5%93%81%E3%81%AB%E6%8A%95%E7%A5%A8%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F%EF%BC%81%F0%9F%92%8C%0A%0A%E3%80%90%E4%BD%9C%E5%93%81%E5%90%8D%E3%80%91%0A%E2%99%82%E3%81%8C%E5%8F%97%E3%81%91%E3%80%82%E3%83%8D%E3%82%B3%E3%81%A1%E3%82%83%E3%82%93%C3%97%E3%83%8D%E3%82%B3%E3%81%8F%E3%82%93%0A%0Ahttps%3A%2F%2Fwww.dlsite.com%2Fmodpub%2Flp%2Fhome%2Fdlsiteawards2022%2Fvote%2F%0A%0A%23DLsite%E3%82%A2%E3%83%AF%E3%83%BC%E3%83%89&lang=ja
+" data-share-url="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html" data-share-title="♂が受け。ネコちゃん×ネコくん" data-share-maker-name="pink carrot"></template>
+</div>
+      </div>
+      <!-- /top_wrapper -->
+      
+      <!-- wrapper -->
+      <div id="wrapper">
+
+        <template data-vue-component="share-group"></template>
+
+        
+        <!-- main -->
+        <div id="main" data-section_name="main">
+
+          <!-- main_inner -->
+          <div id="main_inner">
+            
+
+
+
+<!-- work_header -->
+<div id="work_header" data-section_name="work_header">
+<!-- work_left -->
+<div id="work_left">
+
+<div data-vue-component="product-slider" data-product-id="RJ01008713">
+
+<div class="product-slider">
+  <!-- Sample image data -->
+  <div ref="product_slider_data" class="product-slider-data">
+    <div data-src="//img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_main.jpg" data-width="560" data-height="420" data-thumb="//img.dlsite.jp/resize/images2/work/doujin/RJ01009000/RJ01008713_img_main_240x240.jpg"></div>
+    <div data-src="//img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_smp1.jpg" data-width="2000" data-height="1417" data-thumb="//img.dlsite.jp/resize/images2/work/doujin/RJ01009000/RJ01008713_img_smp1_100x100.jpg"></div>
+    <div data-src="//img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_smp2.jpg" data-width="2000" data-height="1417" data-thumb="//img.dlsite.jp/resize/images2/work/doujin/RJ01009000/RJ01008713_img_smp2_100x100.jpg"></div>
+    <div data-src="//img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_smp3.jpg" data-width="2000" data-height="1417" data-thumb="//img.dlsite.jp/resize/images2/work/doujin/RJ01009000/RJ01008713_img_smp3_100x100.jpg"></div>
+    <div data-src="//img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_smp4.jpg" data-width="2000" data-height="1417" data-thumb="//img.dlsite.jp/resize/images2/work/doujin/RJ01009000/RJ01008713_img_smp4_100x100.jpg"></div>
+    <div data-src="//img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_smp5.jpg" data-width="2000" data-height="1417" data-thumb="//img.dlsite.jp/resize/images2/work/doujin/RJ01009000/RJ01008713_img_smp5_100x100.jpg"></div>
+    <div data-src="//img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_smp6.jpg" data-width="2000" data-height="1417" data-thumb="//img.dlsite.jp/resize/images2/work/doujin/RJ01009000/RJ01008713_img_smp6_100x100.jpg"></div>
+    <div data-src="//img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_smp7.jpg" data-width="2000" data-height="1417" data-thumb="//img.dlsite.jp/resize/images2/work/doujin/RJ01009000/RJ01008713_img_smp7_100x100.jpg"></div>
+    <div data-src="//img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_smp8.jpg" data-width="2000" data-height="1417" data-thumb="//img.dlsite.jp/resize/images2/work/doujin/RJ01009000/RJ01008713_img_smp8_100x100.jpg"></div>
+    <div data-src="//img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_smp9.jpg" data-width="2000" data-height="1417" data-thumb="//img.dlsite.jp/resize/images2/work/doujin/RJ01009000/RJ01008713_img_smp9_100x100.jpg"></div>
+    <div data-src="//img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_smp10.jpg" data-width="1300" data-height="1845" data-thumb="//img.dlsite.jp/resize/images2/work/doujin/RJ01009000/RJ01008713_img_smp10_100x100.jpg"></div>
+  </div>
+
+
+  <!-- Sample viewer -->
+  <div class="work_slider male">
+    <div class="work_slider_container">
+      <div class="slider_body">
+        <div ref="swiper" class="slider_body_inner">
+          <ul class="slider_items trans" ref="body_items" @click="showPopup">
+            <li v-if="items.length === 0" class="slider_item active">
+
+              <picture>
+                <source
+                  srcset="//img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_main.webp"
+                  type="image/webp"
+                >
+                <img
+                  srcset="//img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008713_img_main.jpg"
+                  width="auto"
+                  height="420"
+                  alt="♂が受け。ネコちゃん×ネコくん [pink carrot]"
+                  itemprop="image"
+                >
+              </picture>
+
+            </li>
+          <template v-for="(item, index) in items">
+            <li v-if="index === 0" class="slider_item active">
+
+              <picture>
+                <source
+                  :srcset="item.src.replace('.jpg', '.webp')"
+                  type="image/webp"
+                >
+                <img
+                  :srcset="item.src"
+                  alt="♂が受け。ネコちゃん×ネコくん [pink carrot]"
+                  itemprop="image"
+                >
+              </picture>
+
+            </li>
+            <li v-else class="slider_item">
+
+              <picture>
+                <source
+                  :srcset="item.src.replace('.jpg', '.webp')"
+                  type="image/webp"
+                >
+                <img
+                  :srcset="item.src"
+                  class="swiper-lazy"
+                  alt="♂が受け。ネコちゃん×ネコくん [pink carrot]"
+                >
+              </picture>
+
+            </li>
+          </template>
+          </ul>
+        </div>
+        <div v-cloak v-if="items.length > 1" class="slider_prev" @click="slideTo('prev')"></div>
+        <div v-cloak v-if="items.length > 1" class="slider_next" @click="slideTo('next')"></div>
+      </div>
+
+      <div v-cloak v-if="items.length > 1" ref="ctrl" @wheel="slideScroll" class="slider_controller">
+        <div class="controller_body">
+          <ul ref="ctrl_items" class="controller_items">
+          <template v-for="(item, index) in items">
+            <li class="controller_item" :class="{active:(index === swiper.realIndex)}" @click="slideTo(index)">
+              <div class="thumb_box">
+
+                <picture>
+                  <source
+                    :srcset="item.thumb.src.replace('.jpg', '.webp')"
+                    type="image/webp"
+                  >
+                  <img
+                    :srcset="item.thumb.src"
+                    :v-lazy="item.thumb.src"
+                    :width="item.thumb.width"
+                    :height="item.thumb.height"
+                    alt="♂が受け。ネコちゃん×ネコくん [pink carrot]"
+                  >
+                </picture>
+
+              </div>
+            </li>
+          </template>
+          </ul>
+        </div>
+        <div class="controller_prev" @click="slideTo('prev')"></div>
+        <div class="controller_next" @click="slideTo('next')"></div>
+      </div>
+    </div>
+  </div>
+  <div v-cloak class="work_slider_comp" v-if="items.length > 1">
+    <!-- 枚数 -->
+    <span v-t="{ path: 'product.slider.totalImages', args: [items.length] }"></span>
+  </div>
+
+
+
+  <!-- Popup viewer -->
+  <div v-if="popupVisible" class="slider_popup_overlay" @click="hidePopup">
+    <div class="slider_popup" @click.stop>
+      <span class="slider_popup_close" @click="hidePopup"></span>
+      <div class="slider_popup_rightpane">
+        <div class="slider_popup_sidebar">
+        <template v-for="(item, index) in items">
+          <div rel="noopener" target="_blank" :class="{active:(index === swiper.realIndex)}" @click="slideTo(index, false)">
+
+            <picture>
+              <source
+                :srcset="item.thumb.src.replace('.jpg', '.webp')"
+                type="image/webp"
+              >
+              <img
+                :src="item.thumb.src"
+                :v-lazy="item.thumb.src"
+                alt="♂が受け。ネコちゃん×ネコくん [pink carrot]"
+              >
+            </picture>
+
+          </div>
+        </template>
+        </div>
+        <div class="slider_popup_arrows">
+          <div class="slider_popup_button">
+            <div class="slider_popup_prev" @click="slideTo('prev', false)"></div>
+            <div class="slider_popup_next" @click="slideTo('next', false)"></div>
+          </div>
+          <div class="slider_popup_count">{{ swiper.realIndex + 1 }} / {{ items.length }}</div>
+        </div>
+      </div>
+      <div class="slider_popup_leftpane">
+        <div ref="mainbox" class="slider_popup_mainbox" @wheel.prevent="slideScroll">
+          <div class="slider_zoom_container" ref="zoom_container" @mousemove.prevent="setPopupPosition" @click="setPopupImage(true)">
+
+            <picture>
+              <source
+                :srcset="items[swiper.realIndex].src.replace('.jpg', '.webp')"
+                type="image/webp"
+              >
+              <img
+                :src="items[swiper.realIndex].src"
+                ref="zoom_container_image"
+                alt="♂が受け。ネコちゃん×ネコくん [pink carrot]"
+              >
+            </picture>
+
+          </div>
+        </div>
+        <div class="slider_popup_tool">
+          <input id="target1" class="checkbox" name="target" type="checkbox" value="1" v-model="alwaysActualSize" @change="toggleActualSize" @click="toggleActualSize">
+          <label for="target1" class="checkbox-label" v-t="'product.slider.alwaysActual'"></label>
+          <span class="slider_popup_description" v-t="'product.slider.tools'"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+</div>
+
+
+
+
+</div>
+<!-- /work_left -->
+
+<!-- work_right -->
+<div id="work_right">
+<div
+  class="work_right_info"
+  data-vue-component="product-price"
+  data-product-id="RJ01008713"
+  data-is-check="false"
+  data-is-comingsoon="false"
+>
+  <template v-if="(product.dl_count !== undefined && product.dl_count > 0) || (!isFemale() && product.wishlist_count !== undefined && product.wishlist_count > 0) || product.rate_count > 0 || product.review_count" v-cloak>
+    <product-rank product-id="RJ01008713"></product-rank>
+
+    <div v-if="(product.dl_count !== undefined && product.dl_count > 0) || product.rate_count > 0" v-cloak class="work_right_info_item">
+      <dl class="work_right_info_title value">
+                                <template v-if="product.dl_count_items !== undefined && product.dl_count_items.length >= 2" v-cloak>
+          <dt v-if="isFemale()" class="work_dl_label" v-t="'product.evaluate.total_download_label'"></dt>
+          <dt v-else class="work_dl_label" v-t="'product.evaluate.total_purchase_label'"></dt>
+          <dd class="work_dl_details point">
+            {{ product.dl_count_total|number_format }}
+            <div class="light_popover">
+              <div class="light_popover_inner">
+                <table class="work_dl_table">
+                  <tbody>
+                  <tr>
+                    <th v-t="'product.evaluate.purchase_item_language_label'"></th>
+                    <th v-if="isFemale()" v-t="'product.evaluate.download_label_short'"></th>
+                    <th v-else v-t="'product.evaluate.purchase_label_short'"></th>
+                  </tr>
+                  <tr v-for="item in product.dl_count_items">
+                    <td class="language" v-text="item.display_label"></td>
+                    <td class="total">{{ item.dl_count|number_format }}</td>
+                  </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </dd>
+        </template>
+                <template v-else-if="product.dl_count !== undefined && product.dl_count > 0" v-cloak>
+          <dt v-if="isFemale()" v-t="'product.evaluate.download_label'"></dt>
+          <dt v-else v-t="'product.evaluate.purchase_label'"></dt>
+          <dd class="point">{{ product.dl_count|number_format }}</dd>
+        </template>
+                
+                <template v-if="product.rate_count > 0" v-cloak>
+          <dt v-t="'product.evaluate.rating_label'"></dt>
+          <dd class="star_box" @mouseenter="showRateDetail" @mouseleave="hideRateDetail">
+            <span class="point average_count">{{ product.rate_average_2dp }}</span>
+            <div class="star_wrap">
+              
+              <span class="rate" :class="'rate' + product.rate_average_star"></span>
+
+              <div class="rating_popup" :class="{ open: is_open_rate }" v-if="is_display_rate">
+                <div class="rating_popup_inner">
+                  <div class="rating_content">
+                    <dl class="rating_content_inner">
+                      <dt class="rating_itemTitle" v-t="'product.rating.average'"></dt>
+                      <dd><p class="rating_score">{{ product.rate_average_2dp }}</p></dd>
+                    </dl>
+                    <dl class="rating_content_inner">
+                      <dt class="rating_itemTitle" v-t="'product.rating.ratings'"></dt>
+                      <dd><p class="">{{ product.rate_count|number_format }}</p></dd>
+                    </dl>
+                  </div>
+
+                  <div class="rating_content">
+                    <dl class="rating_content_inner">
+                      <dt class="rating_itemTitle" v-t="'product.rating.rating'"></dt>
+                      <dd>
+                        <dl class="rating_map">
+                          <dt class="rating_map_label">
+                            <p v-t="'product.rating.star_5'"></p>
+                          </dt>
+                          <dd class="rating_map_body">
+                            <div class="rating_meter">
+                              <div class="rating_bar" :style="{ width: is_open_rate ? Math.floor(product.rate_count_detail[4].ratio * 0.8) + 'px' : 0 }"></div>
+                            </div>
+                            ({{ product.rate_count_detail ? product.rate_count_detail[4].count : 0|number_format }})
+                          </dd>
+                          <dt class="rating_map_label">
+                            <p v-t="'product.rating.star_4'"></p>
+                          </dt>
+                          <dd class="rating_map_body">
+                            <div class="rating_meter">
+                              <div class="rating_bar" :style="{ width: is_open_rate ? Math.floor(product.rate_count_detail[3].ratio * 0.8) + 'px' : 0 }"></div>
+                            </div>
+                            ({{ product.rate_count_detail ? product.rate_count_detail[3].count : 0|number_format }})
+                          </dd>
+                          <dt class="rating_map_label">
+                            <p v-t="'product.rating.star_3'"></p>
+                          </dt>
+                          <dd class="rating_map_body">
+                            <div class="rating_meter">
+                              <div class="rating_bar" :style="{ width: is_open_rate ? Math.floor(product.rate_count_detail[2].ratio * 0.8) + 'px' : 0 }"></div>
+                            </div>
+                            ({{ product.rate_count_detail ? product.rate_count_detail[2].count : 0|number_format }})
+                          </dd>
+                          <dt class="rating_map_label">
+                            <p v-t="'product.rating.star_2'"></p>
+                          </dt>
+                          <dd class="rating_map_body">
+                            <div class="rating_meter">
+                              <div class="rating_bar" :style="{ width: is_open_rate ? Math.floor(product.rate_count_detail[1].ratio * 0.8) + 'px' : 0 }"></div>
+                            </div>
+                            ({{ product.rate_count_detail ? product.rate_count_detail[1].count : 0|number_format }})
+                          </dd>
+                          <dt class="rating_map_label">
+                            <p v-t="'product.rating.star_1'"></p>
+                          </dt>
+                          <dd class="rating_map_body">
+                            <div class="rating_meter">
+                              <div class="rating_bar" :style="{ width: is_open_rate ? Math.floor(product.rate_count_detail[0].ratio * 0.8) + 'px' : 0 }"></div>
+                            </div>
+                            ({{ product.rate_count_detail ? product.rate_count_detail[0].count : 0|number_format }})
+                          </dd>
+                        </dl>
+                      </dd>
+                    </dl>
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <span class="count">({{ product.rate_count|number_format }})</span></p>
+          </dd>
+        </template>
+              </dl>
+    </div>
+
+    <div v-if="(!isFemale() && product.wishlist_count !== undefined && product.wishlist_count > 0) || product.review_count" v-cloak class="work_right_info_item">
+      <dl class="work_right_info_title">
+                <!-- お気に入り数 / DL数 [home, maniax, girls, bl] ここから -->
+        <template v-if="!isFemale() && product.wishlist_count !== undefined && product.wishlist_count > 0" v-cloak>
+          <dt v-t="'product.evaluate.favorite_works_label'"></dt>
+          <dd class="position_fix">{{ product.wishlist_count|number_format }}</dd>
+
+        </template>
+        <!-- お気に入り数 ここまで -->
+        
+        <!-- レビュー ここから -->
+        <template v-if="product.review_count" v-cloak>
+          <dt v-t="'product.evaluate.review_number_label'"></dt>
+          <dd class="position_fix"><span>{{ product.review_count|number_format }}</span><span class="count"></span>&nbsp;(<a href="#review_link" v-html="$t('product.evaluate.to_rating_label')"></a>)</span></dd>
+        </template>
+        <!-- レビュー ここまで -->
+      </dl>
+    </div>
+    <!--  -->
+  </template>
+</div>
+<div id="work_right_inner">
+
+<div id="work_right_name">
+  <table id="work_maker">
+        
+        <tr>
+      <th>サークル名</th>
+            <td>
+        <span itemprop="brand" class="maker_name">
+          <a href="https://www.dlsite.com/girls/circle/profile/=/maker_id/RG67243.html">pink carrot</a>
+        </span>
+        <span class="add_follow" data-vue-component="follow-button" data-follow-key="RG67243" data-follow-name="pink carrot" v-cloak>
+        </span>
+      </td>
+    </tr>
+
+          </table>
+
+    <span data-vue-component="cien-creator-link" data-vue-async="true" data-maker-id="RG67243"></span>
+</div>
+
+<table cellspacing="0" id="work_outline">
+    <tr>
+    <th>販売日</th>
+    <td><a href="https://www.dlsite.com/girls/new/=/year/2022/mon/12/day/26/cyear/2022/cmon/12">2022年12月26日</a></td>  </tr>
+
+        <tr>
+      <th>更新情報</th>
+      <td>
+        2023年01月06日
+                  <div class="btn_ver_up">
+            <a href="#version_up">更新情報</a>
+          </div>
+              </td>
+    </tr>
+  
+        <tr>
+      <th>シリーズ名</th>
+      <td>
+        <a href="https://www.dlsite.com/girls/fsr/=/title_id/SRI0000046090/order/title_d/from/work.titles">♂が受け。ネコちゃん×ネコくん</a></td>
+    </tr>
+  
+        <tr>
+      <th>カップリング</th>
+      <td>
+        <div class="main_genre"><a href="https://www.dlsite.com/girls/fsr/=/coupling/CP0005736">女×男</a></div>
+      </td>
+    </tr>
+  
+                                        
+<tr>
+  <th>作者</th>
+    <td>
+          <a
+                  href="https://www.dlsite.com/girls/fsr/=/work_category/all/keyword_creater/%22usachanGET%22"
+              >usachanGET</a>        </td>
+</tr>
+
+  
+          <tr>
+      <th>年齢指定</th>
+      <td>
+        <div class="work_genre">
+                      <a href="https://www.dlsite.com/girls/fsr/=/work_category%5B0%5D/doujin/age_category/3/from/icon.work"><span class="icon_ADL" title="R18">R18</span></a>
+                  </div>
+      </td>
+    </tr>
+  
+    <tr>
+    <th>作品形式</th>
+    <td>
+      <div class="work_genre" id="category_type">
+        <a href="https://www.dlsite.com/girls/works/type/=/work_type/MNG/from/icon.work"><span class="icon_MNG" title="マンガ">マンガ</span></a>
+              </div>
+    </td>
+  </tr>
+
+        <tr>
+      <th>ファイル形式</th>
+      <td>
+        <div class="work_genre">
+          <a href="https://www.dlsite.com/girls/fsr/=/work_category%5B0%5D/doujin/file_type/IJP/from/icon.work"><span class="icon_IJP" title="JPEG">JPEG</span></a><a href="https://www.dlsite.com/girls/fsr/=/work_category%5B0%5D/doujin/options/WPD/from/icon.work"><span class="icon_WPD" title="PDF同梱">PDF同梱</span></a>
+                  </div>
+      </td>
+    </tr>
+  
+                                      <tr>
+        <th>その他</th>
+        <td>
+          <div class="work_genre">
+            <a href="https://www.dlsite.com/girls/fsr/=/work_category%5B0%5D/doujin/coupling_option/OTM/from/icon.work"><span class="icon_OTM" title="乙女向け">乙女向け</span></a>
+          </div>
+        </td>
+      </tr>
+    
+          
+    
+    
+        <tr>
+      <th>ジャンル</th>
+      <td>
+        <div class="main_genre">
+                    <a href="https://www.dlsite.com/girls/fsr/=/genre/433/from/work.genre">逆転無し</a>
+                    <a href="https://www.dlsite.com/girls/fsr/=/genre/281/from/work.genre">同級生/同僚</a>
+                    <a href="https://www.dlsite.com/girls/fsr/=/genre/074/from/work.genre">制服</a>
+                    <a href="https://www.dlsite.com/girls/fsr/=/genre/138/from/work.genre">フェラチオ</a>
+                    <a href="https://www.dlsite.com/girls/fsr/=/genre/152/from/work.genre">焦らし</a>
+                    <a href="https://www.dlsite.com/girls/fsr/=/genre/156/from/work.genre">男性受け</a>
+                    <a href="https://www.dlsite.com/girls/fsr/=/genre/176/from/work.genre">獣耳</a>
+                    <a href="https://www.dlsite.com/girls/fsr/=/genre/185/from/work.genre">乳首/乳輪</a>
+                    
+        </div>
+      </td>
+    </tr>
+  
+          <tr>
+    <th>ファイル容量</th>
+    <td>
+      <div class="main_genre">
+                              161.61MB
+                        </div>
+    </td>
+  </tr>
+  
+    </table>
+
+
+<ul class="work_feature">
+  <li data-vue-component="user" v-cloak v-if="is_translator">
+    <div id="work_trans">
+      <strong>この作品は「みんなで翻訳」の翻訳許可作品です。</strong>
+            <span>[&nbsp;<a href="https://www.dlsite.com/modpub/lp/overseas/translator/index.html">みんなで翻訳について</a>&nbsp;]</span>
+    </div>
+  </li>
+
+
+
+
+
+
+
+
+
+</ul>
+
+
+<script>
+  jQuery(function ($) {
+    var dl_format = '0';
+    var is_dlsiteplay_work = '1';
+
+    if (/Mac/.test(navigator.userAgent) && (dl_format == 10 || dl_format == 9)) {
+      if (is_dlsiteplay_work) {
+        $('._no_mac_viewer').remove();
+      } else {
+        $('._no_mac_protect').remove();
+      }
+    }
+  });
+</script>
+
+
+<div data-vue-component="product-sales-end" data-product-id="RJ01008713" data-is-sp-site="" v-cloak></div>
+
+</div>
+
+
+  <div class="work_streaming" data-ga4-ref="work_banner">
+          <a href="https://www.dlsite.com/girls-pro/work/=/product_id/BJ01162205.html"><img src="https://media.dlsite.com/bcs/girlsmaniax/1693407600/bn_08b11d559bdef8cf6c490dffd65d4cd2a619319e.jpg" alt="商業作品はコチラ"></a>
+      </div>
+
+
+
+
+
+    
+  
+<div
+  class="work_streaming translator"
+  data-vue-component="product"
+  data-product_id="RJ01008713"
+  data-cacheable="true"
+  style="display: none;"
+  v-cloak
+>
+  <template v-if="is_translator">
+    <a
+      v-if="is_bought"
+      href="/translator/work"
+      target="_blank"
+      rel="noopener"
+    >
+      <img
+        src="/modpub/images/banner/translator_wanted/bn_translator_wanted_ja_jp.jpg"
+        alt="翻訳者募集中！"
+      />
+    </a>
+    <a
+      v-else
+      href="https://www.dlsite.com/girls/works/translatable?keyword=RJ01008713"
+      target="_blank"
+      rel="noopener"
+    >
+      <img
+        src="/modpub/images/banner/translator_wanted/bn_translator_wanted_ja_jp.jpg"
+        alt="翻訳者募集中！"
+      />
+    </a>
+  </template>
+  <a
+    v-else
+    href="https://min-hon.net/"
+    target="_blank"
+    rel="noopener"
+  >
+    <img
+      src="/modpub/images/banner/translator_wanted/bn_translator_wanted_ja_jp.jpg"
+      alt="翻訳者募集中！"
+    />
+  </a>
+</div>
+
+<script async>
+  
+  jQuery(function(){
+    var lang = (navigator.languages && navigator.languages[0] || navigator.language || navigator.userLanguage);
+    var is_ja = /^ja/.test(lang);
+
+    if(!is_ja) {
+      $('.work_streaming.translator').show();
+    }
+  });
+  
+</script>
+
+
+
+<div class="trial_download mb30">
+</div>
+
+<ul class="work_edition">
+  
+      <li>
+      <p class="work_label">言語の選択</p>
+      <div class="work_edition_linklist type_trans">
+                  <a href="https://www.dlsite.com/girls/work/=/product_id/RJ01008713.html" class="work_edition_linklist_item current">
+            日本語
+          </a>
+                  <a href="https://www.dlsite.com/girls/work/=/product_id/RJ01056478.html" class="work_edition_linklist_item">
+            英語
+          </a>
+                  <a href="https://www.dlsite.com/girls/work/=/product_id/RJ01055442.html" class="work_edition_linklist_item">
+            繁体中文
+          </a>
+                  <a href="https://www.dlsite.com/girls/work/=/product_id/RJ01072648.html" class="work_edition_linklist_item">
+            韓国語
+          </a>
+              </div>
+    </li>
+  
+  
+  </ul>
+
+</div>
+<!-- /work_right-->
+</div>
+<!-- /work_header -->
+
+
+
+<div id="intro-title" class="title_01 clearfix"><h2>作品内容</h2></div>
+    
+        <div itemprop="description" class="work_parts_container">
+                  
+  
+<div class="work_parts type_text">
+
+              <h3 class="work_parts_heading">▶︎あらすじ</h3>
+    
+    
+          <div class="work_parts_area">
+        <p>同級生のネコくんから毎日チビチビとバカにされるネコちゃん。<br />
+<br />
+「おいチビ」<br />
+「チビがうつったらどうしよ〜」<br />
+「密室でチビの空気吸いたくないな〜」<br />
+<br />
+その日、ついに堪忍袋の緒が切れた!<br />
+<br />
+「あんたなんなの!?」<br />
+<br />
+ネコくんに掴みかかったらバランスを崩して二人で転倒!<br />
+罵倒されるかと思ったら、下敷きになったネコくんの様子がなんだかおかしくて…………?<br />
+<br />
+生意気な同級生に煽られてあれよあれよと初えっち!</p>
+      </div>
+
+    
+</div>
+            
+  
+<div class="work_parts type_text">
+
+              <h3 class="work_parts_heading">▶︎作品紹介</h3>
+    
+    
+          <div class="work_parts_area">
+        <p>女性攻め、男性受け、ケモ耳えっち。<br />
+女の子が終始脱ぎません。<br />
+逆転なし/フェラ/本番なし 等<br />
+全77ページ(オマケページ含)<br />
+<br />
+※2023/01/04<br />
+・twitterに投稿した「DLありがとう漫画」を2p追加しました。<br />
+※2023/01/09<br />
+・34ページ抜けを修正しました。<br />
+<br />
++ + + + + + + + + + + + + + +<br />
+<br />
+オリジナル漫画2作目になります。<br />
+よろしくお願いします。<br />
+twitter : usachanGET@USC_GT</p>
+      </div>
+
+    
+</div>
+            
+  
+<div class="work_parts type_multiimages">
+
+              <h3 class="work_parts_heading">▶︎登場人物</h3>
+    
+    
+          <div class="work_parts_area">
+        <ul class="work_parts_multiimage ">
+                          <li class="work_parts_multiimage_item">
+                <div class="image">
+                                            <a href="//img.dlsite.jp/modpub/images2/parts/RJ01009000/RJ01008713/ee57fc7b3b6516eee8d414ccd8f482a0.jpg" target="blank"><img src="//img.dlsite.jp/modpub/images2/parts/RJ01009000/RJ01008713/ee57fc7b3b6516eee8d414ccd8f482a0.jpg" alt="♂が受け。ネコちゃん×ネコくん [pink carrot]" title="♂が受け。ネコちゃん×ネコくん [pink carrot]" /></a>
+                                    </div>
+                                <div class="text">
+                  <p>【サチ】マンチカンロングヘア<br />
+つい手が出てしまったためえっちなことになってしまう♀。<br />
+生意気なヤツがかわいく見えてきて困った。</p>
+                </div>
+                              </li>
+                          <li class="work_parts_multiimage_item">
+                <div class="image">
+                                            <a href="//img.dlsite.jp/modpub/images2/parts/RJ01009000/RJ01008713/b458b8f98e4ff9041dab5b657a23c10a.jpg" target="blank"><img src="//img.dlsite.jp/modpub/images2/parts/RJ01009000/RJ01008713/b458b8f98e4ff9041dab5b657a23c10a.jpg" alt="♂が受け。ネコちゃん×ネコくん [pink carrot]" title="♂が受け。ネコちゃん×ネコくん [pink carrot]" /></a>
+                                    </div>
+                                <div class="text">
+                  <p>【ハル】アメリカンショートヘア<br />
+白猫は独占欲が強いそうですねえ!<br />
+その上警戒心も高いとくれば、アプローチは遠回しになるでしょうねえ!<br />
+そうなる他ないでしょうねえ!!</p>
+                </div>
+                              </li>
+                          <li class="work_parts_multiimage_item">
+                <div class="image">
+                                            <a href="//img.dlsite.jp/modpub/images2/parts/RJ01009000/RJ01008713/5cccb6199b590505c972b4aea5e113e6.jpg" target="blank"><img src="//img.dlsite.jp/modpub/images2/parts/RJ01009000/RJ01008713/5cccb6199b590505c972b4aea5e113e6.jpg" alt="♂が受け。ネコちゃん×ネコくん [pink carrot]" title="♂が受け。ネコちゃん×ネコくん [pink carrot]" /></a>
+                                    </div>
+                                <div class="text">
+                  <p>【サチの友達】キツネ<br />
+次の漫画の攻め。</p>
+                </div>
+                              </li>
+                    </ul>
+      </div>
+
+    
+</div>
+            
+    </div>
+    
+<!-- spec -->
+<!-- /spec -->
+
+<!-- version up -->
+<div class="title_01 clearfix" id="version_up"><h2>更新情報</h2></div>
+  
+<div class="work_article version_up">
+<ul class="_version_up">
+
+<li class="odd">
+<dl>
+<dt>2023年01月06日</dt>
+<dd><span>内容追加</span></dd>
+<dd class="ver_up_comment">2023.01.04 DLありがとう漫画を2p追加しました!</dd></dl>
+</li>
+
+</ul>
+
+<div class="version_up_more" style="display: none">
+<p><a href="#" class="_version_up_more"><span>更新情報履歴をもっと見る</span></a></p>
+</div>
+
+</div>
+<!-- /version up -->
+
+<script type="text/javascript">
+//<!CDATA[
+
+jQuery(function($){
+    "use strict";
+    var page = 2;
+    var product_id = 'RJ01008713';
+    var wait = false;
+    $('._version_up_more').bind('click', function() {
+        if(wait){
+            return false;
+        }
+        wait = true;
+        var $version_up = $('._version_up');
+        var length = $version_up.find('li').length;
+        $.post('https://www.dlsite.com/girls/product/revision/ajax', {act: 'show', product_id: product_id, page: page++}, function(data){
+            wait = false;
+            if(!data.success){
+                $('.version_up_more').hide();
+                return;
+            }
+            if(!data.more){
+                $('.version_up_more').hide();
+            }
+
+            for(var i = 0; i < data.list.length; i++){
+                var row = data.list[i];
+
+                var content_update_type = '';
+                for(var j = 0; j < row.content_update_type.length; j++){
+                    content_update_type += '<span>'+ row.content_update_type[j] +'</span>';
+                }
+
+                var comment = '';
+                if(row.info){
+                    comment = '<dd class="ver_up_comment">' + $.escapeHTML(row.info).replace(/\r?\n/g, '<br>') +'</dd>';
+                }
+
+                var odd_even = (length + i + 1) % 2 === 0 ? 'even' : 'odd';
+                $version_up.append('<li class="'+ odd_even +'">'
+                    + '<dl>'
+                    + '<dt>'+ row.release_date +'</dt>'
+                    + '<dd>'+ content_update_type +'</dd>'
+                    + comment
+                    + '</dl>'
+                    + '</li>');
+            }
+        }, 'json');
+        return false;
+    });
+});
+
+//]]>
+</script>
+
+
+<script>
+jQuery(function($){
+    $('._to_out').click(function(){
+        ga('send', 'event', 'girls', $(this).data('action'), $(this).data('label'), {'nonInteraction': 1});
+    });
+});
+</script>
+
+
+
+
+            
+            
+<!-- same_series -->
+<div class="work_series">
+  <div class="title_01">
+    <h2><span class="title">同一シリーズ作品</span></h2>
+        <template data-vue-component="product-bulk-cart" data-product-id="RJ01008713" data-series-id="SRI0000046090" v-cloak></template>
+      </div>
+    <div class="recommend_list "
+    data-href="https://www.dlsite.com/girls/load/recommend/detail/v2/=/type/same_series/workno/RJ01259667%2C"
+    data-type="same_series">
+  </div>
+  <div class="work_series_other_box">
+    <p class="work_series_other">
+      <span class="series"><a
+          href="https://www.dlsite.com/girls/fsr/=/title_id/SRI0000046090/order/release_d/from/work.series">作品をもっと見る</a></span>
+    </p>
+  </div>
+</div>
+<!-- /same_series -->
+
+<!-- 同一メーカー作品（サークル作品一覧・著者作品一覧・サークル／ブランド作品一覧・ブランド作品一覧） -->
+<div class="work_series">
+  <div class="title_01 clearfix">
+    <h2>
+      <span class="title">
+                サークル作品一覧              </span>
+    </h2>
+        <p class="move"><span><a
+          href="https://www.dlsite.com/girls/fsr/=/keyword_maker_name/pink+carrot+RG67243/ana_flg/all/from/work.same_maker">作品をもっと見る</a></span>
+    </p>
+      </div>
+      <div class="sub_title"><span class="ml10">販売作品</span></div>
+    <div class="recommend_list "
+    data-href="https://www.dlsite.com/girls/load/recommend/detail/v2/=/type/maker_works/workno/RJ01259667%2CRJ01215728%2CRJ01143087%2CRJ01083815%2CRJ01045580%2CRJ403763%2C"
+    data-type="maker_works"></div>
+  </div>
+<!-- maker_works -->
+
+<!-- label_works -->
+<!-- /label_works -->
+
+<!-- relation -->
+<!-- /relation -->
+
+<!-- same_voice -->
+<!-- /same_voice -->
+
+            <!-- recommend -->
+<div data-ga4-ref="similer_recommend">
+<div class="title_01 clearfix" data-download-threshold="5"><h2>この作品を買った人はこんな作品も買っています</h2></div>
+<div
+  class="recommend_list "
+  data-section-name="work_recommend_history"
+  data-href="https://www.dlsite.com/girls/load/recommend/v2/=/type/viewsales2/reject/RG67243/product_id/RJ01008713.html"
+  data-type="viewsales2"
+></div>
+</div>
+
+<!-- /recommend -->
+
+<div data-ga4-ref="recent_recommend">
+<div class="title_01 clearfix"><h2>最近チェックした作品</h2></div>
+<div
+  class="recommend_list "
+  data-section-name="work_recommend_history"
+  data-href="https://www.dlsite.com/girls/load/recommend/v2/=/type/history/product_id/RJ01008713.html"
+  data-type="history"
+></div>
+</div>
+
+
+<script>
+$(function() {
+  // 未ログイン時の挙動対応
+  var islogin = false;
+  if (['1', '3'].indexOf(document.getCookie('loginchecked')) !== -1) {
+    islogin = true;
+  }
+
+  // サムネイルポップアップ
+  $(document).bind('ajaxSuccess', function() {
+        var $target_blocks = $('.work_main_list_ncol');
+        $target_blocks.each(function () {
+            if ($(this).thumbImgPopup !== undefined) {
+                $(this).thumbImgPopup();
+                $(this).setBlockViewSetting('mheight_01','__sp_detail','end');
+            };
+        });
+    }
+  );
+
+  $.getJSON('https://www.dlsite.com/girls/load/member/uninterest').then(
+    function (res) {
+      var rejects = [].concat(res['reason_1'], res['reason_2'])
+
+      $('.recommend_list').each(function(i, element){
+        var href = element.dataset.href
+        var type = element.dataset.type
+        href && $.get(href).then(function(res){
+          // html適応
+          $(element).html(res)
+
+          // イベント設定
+          $(element).find('li.swiper-slide').each(function(i, li){
+            var $li = $(li)
+
+            // 不要な作品
+            if (~rejects.indexOf($li.data('prod'))) {
+              return $li.remove()
+            }
+
+            // miniメニュー開閉
+            $li.find('.mini_menu').bind('click', function (e) {
+              $li.find('.mini_menu_dropdown').toggleClass('open');
+            })
+
+            // 非表示設定
+            $li.find('.mini_menu_dropdown_inner').bind('click', function() {
+              // 未ログイン時は新規ユーザ登録ページに遷移
+              if (islogin) {
+                $.get('https://www.dlsite.com/girls/cart/ajax/=/mode/nothanks/product_id/' + $li.data('prod'))
+                  .done(() => $li.find('.recommend_work_item').addClass('hidden'))
+                  .fail(() => window.location.href = 'https://www.dlsite.com/girls/regist/user');
+              } else {
+                window.location.href = 'https://www.dlsite.com/girls/regist/user';
+              }
+            })
+
+            // Vueの拡大ポップアップロジックを利用するためVueのinit処理を行い、コンポーネントをマウントする
+            $(window).triggerHandler('initialize.vue');
+
+            // レコメンド結果通知
+            $li.delegate('a', 'click', function (e) {
+              var $self = $(e.currentTarget);
+
+              //GAイベント送信
+              try {
+                window.ga('send', 'event', dlsite.getName(), 'recommend_' + $li.data('category'), $self[0].pathname);
+              } catch (ex) {
+                //
+              }
+
+              var param = {
+                prod: $li.data('prod'),
+                merch: 'dlsite',
+                spec: $li.data('spec'),
+                cref: $li.data('cref'),
+                cookie: document.getCookie('uniqid')
+              };
+
+              if (!param['prod'] || !param['spec'] || !param['cref']) {
+                return true;
+              }
+
+              var url = 'https://dlsite.silveregg.net/pycre5/click?' + $.param(param);
+
+              // クリックイベントを送出
+              if (!navigator.sendBeacon || !navigator.sendBeacon(url)) {
+                $.ajax(url, {
+                  async: false,
+                  timeout: 2000,
+                });
+              }
+
+              return true;
+            });
+          });
+
+          // 表示NG設定に基づいたフィルターの適用
+          $.filterImage();
+
+          // Swiper
+          new Swiper(element.firstChild, {
+            navigation: {
+              nextEl: '.swiper-button-next.type-' + type,
+              prevEl: '.swiper-button-prev.type-' + type,
+              disabledClass: 'disable',
+            },
+            slidesPerColumn: type === 'viewsales2' ? 2 : 1,
+            slidesPerView: Math.floor($(element).find('.swiper-container').width() / 200),
+            slidesPerGroup: Math.floor($(element).find('.swiper-container').width() / 200),
+            spaceBetween: 10,
+            breakpoints: {
+              1194: {
+                slidesPerView: 3,
+                slidesPerGroup: 3,
+              },
+              1364: {
+                slidesPerView: 4,
+                slidesPerGroup: 4,
+              },
+              1534: {
+                slidesPerView: 5,
+                slidesPerGroup: 5,
+              },
+              1704: {
+                slidesPerView: 6,
+                slidesPerGroup: 6,
+              },
+              1874: {
+                slidesPerView: 7,
+                slidesPerGroup: 7,
+              },
+              max: {
+                slidesPerView: 8,
+                slidesPerGroup: 8,
+              }
+            },
+          })
+        });
+      })
+    }
+  )
+})
+</script>
+
+            <!-- review -->
+
+<div class="title_01 clearfix" id="review_link">
+  <h2>ユーザーレビュー</h2>
+</div>
+
+<div data-vue-component="review" id="work_review" class="work_article">
+  
+  <product-review-list
+    product-id="RJ01008713"
+    parent-product-id=""
+    is-translation-parent=""
+    more-load=""
+    sort-in-page=""
+    is-simplified="true"
+  >
+  </product-review-list>
+  
+</div>
+
+
+<div data-vue-component="review">
+  <review-modal v-show="$store.getters.onReviewModal" is-minhon="true"></review-modal>
+</div>
+
+            <div class="_work_matome"></div>
+
+
+<script>
+    $(function () {
+        var endpoint = 'https://www.dlsite.com/girls/work/matome/ajax/=/product_id/RJ01008713.html';
+        $.get(endpoint).then(function(res){
+            // html適用
+            $('._work_matome').html(res);
+
+            //要素表示時読み込み
+            if (document.getElementById('matome-swiper') != null) {
+                // Swiper4系
+                var swiper = new Swiper('#matome-swiper', {
+                    slidesPerView: 6,
+                    slidesPerGroup: 6,
+                    spaceBetween: 20,
+                    watchSlidesVisibility: true,
+                    navigation: {
+                        nextEl: '.swiper-button-next.type-matome',
+                        prevEl: '.swiper-button-prev.type-matome',
+                    },
+                    preloadImages: false,
+                    lazy: true,
+                    breakpoints: {
+                        1900: {
+                            slidesPerView: 5,
+                            slidesPerGroup: 5,
+                        },
+                        1620: {
+                            slidesPerView: 4,
+                            slidesPerGroup: 4,
+                        },
+                        1390: {
+                            slidesPerView: 3,
+                            slidesPerGroup: 3,
+                        },
+                        1150: {
+                            slidesPerGroup: 2,
+                            slidesPerView: 2,
+                        }
+                    }
+                });
+
+                $('.matome_box').show();
+
+                var scrollIn = function(event) {
+                    var target_rect = document.getElementById('matome-swiper').getBoundingClientRect();
+                    if (0 < target_rect.top && target_rect.bottom <= window.innerHeight) {
+                        swiper.lazy.load();
+                        window.removeEventListener('scroll', scrollIn, false);
+                    }
+                };
+                window.addEventListener('scroll', scrollIn, false);
+            }
+        });
+    });
+</script>
+
+            
+            
+            
+            
+          </div>
+          <!-- /main_inner -->
+        </div>
+        <!-- /main -->
+
+        <template data-vue-component="restriction-of-countries"></template>
+        <template data-vue-component="notice"></template>
+
+      </div>
+      <!-- /wrapper -->
+
+      <!-- right -->
+      <div id="right" data-section_name="right">
+        
+        
+        
+        <div id="work_buy_box_wrapper" data-vue-component="product-price" data-product-id="RJ01008713" data-is-check="" data-is-comingsoon="0" data-section_name="right_work_price">
+  <div hidden class="ga4_event_item_RJ01008713"
+  data-product_id="RJ01008713"
+  data-work_name="♂が受け。ネコちゃん×ネコくん"
+  data-maker_id="RG67243"
+  data-work_type="MNG"
+  data-options="OTM#JPN#WPD#DLP#REV"
+  data-price="616"
+  data-official_price="880"
+></div>
+  <div v-if="typeof product.price !== 'undefined' && (product.translation_info.is_parent || product.on_sale || product.is_rental || is_bought || rentaled)" v-cloak class="work_buy_main">
+    
+    <div id="work_price">
+      <div v-if="product.translation_info.is_parent || product.on_sale" class="work_buy_type" :class="class_buy_type_sell" @click.stop="buy_type = 'sell'">
+        
+
+        <div v-if="product.voice_pack && product.is_discount" class="campaign_info">
+          <!-- 割引中 -->
+          <p v-if="product.is_discount" class="type_sale"><span v-t="'product.price.sale_now'"></span></p>
+        </div>
+        <div v-else-if="product.is_discount || product.is_pointup || product.is_limit_work || rentaled" class="campaign_info">
+          <p v-if="product.is_limit_work" class="type_quantity"><span v-t="'product.title_works.limit_sales'"></span></p>
+          <!-- タイムセール -->
+          <p v-if="product.is_timesale" class="type_sale">
+            <span>{{$t('product.title_works.limit_sales')}} {{ product.discount_rate == 100 ? $t('product.title_works.only_now_free') : product.discount_rate + '%OFF' }}</span>
+          </p>
+          <!-- 割引・無料販売 -->
+          <template v-else-if="product.is_discount">
+            <div v-if="product.discount_to && !dlsite.isComipo()">
+              <div class="work_border">
+                <p class="type_sale" data-toggle="found">
+                  <span>{{ product.discount_rate == 100 ? $t('product.title_works.only_now_free') : product.discount_rate + '%OFF' }}</span>
+                </p>
+                <span class="type_date" v-if="product.discount_end_date">{{ $t('product.price.til', [product.discount_end_date]) }}</span>
+              </div>
+            </div>
+            <div v-else>
+              <div class="work_border">
+                <p class="type_sale" data-toggle="found">
+                  <span>{{ product.discount_rate == 100 ? $t('product.title_works.only_now_free') : product.discount_rate + '%OFF' }}</span>
+                </p>
+                <span class="type_date" v-if="product.discount_end_date">{{ $t('product.price.til', [product.discount_end_date]) }}</span>
+              </div>
+            </div>
+          </template>
+          <!-- ポイント還元 -->
+          <p v-if="product.is_pointup && (product.product_point || product.default_point)" class="type_point">
+            <span>{{ $t('product.price.point_return', [product.product_point_rate]) }}<span v-if="product.pointup_end_date" class="period">{{ $t('product.price.til', [product.pointup_end_date]) }}</span></span>
+          </p>
+        </div>
+
+        <div class="work_buy_container">
+          
+                    <div v-if="limited_free_end_time" class="free_limited_btn">
+            <p v-if="!(product.is_free && !product.sales_end_info && limited_free_end_time)" v-html="$t('limited_free.end_date_text.pc', [format_free_end_time])"></p>
+            <p class="work_stream free_limited"><a href="https://play.dlsite.com/?" class="btn_st" target="_blank">無料で読む</a></p>
+          </div>
+                    
+          <template v-if="product.voice_pack">
+            <div class="price_inner_comipo">
+              <div class="work_buy_body">
+                <div class="work_buy_label label_comipo" v-t="'product.price.comic_main'"><!-- コミック本体 --></div>
+                <div class="work_buy_content">
+                  <div class="work_buy_content_right">
+                    <span v-if="product.voice_pack.parent_official_price" class="price strike">{{ product.voice_pack.parent_official_price | number_format }}<i v-html="yen_symbol_label"></i></span>
+                    <strong class="price comipo_price_black"><span>{{ product.voice_pack.parent_price | number_format }}<i v-html="yen_symbol_label"></i></span></strong>
+                  </div>
+                </div>
+              </div>
+              <div class="work_buy_body">
+                <div class="work_buy_label label_comipo" v-t="'product.price.additional_voice'"><!-- 追加ボイス --></div>
+                <div class="work_buy_content">
+                  <div class="work_buy_content_right">
+                    <span v-if="product.voice_pack.child_official_price" class="price strike">{{ product.voice_pack.child_official_price | number_format }}<i v-html="yen_symbol_label"></i></span>
+                    <strong class="price comipo_price_black"><span>{{ product.voice_pack.child_price | number_format }}<i v-html="yen_symbol_label"></i></span></strong>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="work_buy_body" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+              <meta itemprop="price" :content="real_price">
+              <meta itemprop="priceCurrency" content="JPY">
+              <div class="work_buy_label" v-t="'product.price.price'"><!-- 価格 --></div>
+              <div class="work_buy_content">
+                <span class="price">{{ product.voice_pack.sum_price | number_format  }}<i v-html="yen_symbol_label"></i></span>
+              </div>
+            </div>
+
+            <div v-if="real_point" class="work_buy_body">
+              <div class="work_buy_label" v-t="'product.price.point'"><!-- ポイント --></div>
+              <div class="work_buy_content">
+                <span class="work_point point_up">{{ product.voice_pack.sum_point | number_format }}<i>pt</i></span>
+              </div>
+            </div>
+          </template>
+          <template v-else>
+            <div v-if="product.is_discount" class="work_buy_body">
+              <div v-if="['home', 'maniax', 'girls', 'bl'].includes(dlsite.getId())" class="work_buy_label" v-t="'product.price.circle_price'"><!-- サークル設定価格 --></div>
+              <div v-else-if="['pro', 'soft', 'girlsdrama', 'bldrama', 'app', 'appx'].includes(dlsite.getId())" class="work_buy_label" v-t="'product.price.maker_price'"><!-- メーカー設定価格 --></div>
+              <div v-else class="work_buy_label" v-t="'product.price.normal_price'"><!-- 通常価格 --></div>
+              <div class="work_buy_content">
+                <span v-if="product.official_price" v-html="currencyFormatWithSymbolTag(product.official_price)" class="strike"></span>
+                <span v-else v-html="currencyFormatWithSymbolTag(product.price)" class="strike"></span>
+              </div>
+            </div>
+
+            <div class="work_buy_body" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+              <meta itemprop="price" :content="real_price">
+              <meta itemprop="priceCurrency" content="JPY">
+              <div v-if="product.is_discount" class="work_buy_label" v-t="'product.price.special_price'"><!-- セール特価 --></div>
+              <div v-else class="work_buy_label" v-t="'product.price.price'"><!-- 価格 --></div>
+              <div class="work_buy_content">
+                <strong v-if="product.is_discount" class="price" v-html="currencyFormatWithSymbolTag(real_price)"></strong>
+                <span v-else class="price" v-html="currencyFormatWithSymbolTag(product.price)"></span>
+              </div>
+            </div>
+
+            <!-- 日本円以外は通貨ヘルプページのリンクを表示 -->
+            <div v-if="dlsite.getCurrency() != 'JPY'" class="work_buy_body">
+              <p>[&nbsp;<a :href="estimation_link" v-t="'product.price.estimation'"></a>&nbsp;]</p>
+            </div>
+
+            <div class="work_buy_body">
+              <div class="work_buy_label" v-t="'product.price.point'"><!-- ポイント --></div>
+              <div class="work_buy_content">
+                <strong class="work_point point_up">
+                  {{ real_point | number_format }}
+                  <i v-if="real_point">pt ({{ $t('product.price.point_return', [real_point_rate]) }})</i>
+                  <i v-else>pt ({{ $t('product.price.noreduction') }})</i>
+                </strong>
+              </div>
+            </div>
+          </template>
+        
+                                        
+          <div v-if="bestCouponDiscount" v-cloak class="coupon_available">
+            <span class="coupon_available_head">会員登録でクーポンを複数プレゼント！</span>
+            <div class="coupon_available_inner">
+              <dl class="coupon_detail">
+                <dt class="ex">一番お得なクーポン利用価格</dt>
+                <dd class="total type_jpy" v-html="currencyDiscountFormat(product.currency_price)"></dd>
+              </dl>
+              <dl>
+                <dd v-if="product.price < 301" class="coupon_note">301円以上の購入で利用可能</dd>
+              </dl>
+            </div>
+          </div>
+          
+          <div v-else-if="bestUserCoupon" v-cloak class="coupon_available">
+            <div class="coupon_available_inner">
+              <dl class="coupon_detail">
+                <dt class="ex">一番お得なクーポン利用価格</dt>
+                <dd class="total type_jpy" v-html="currencyDiscountFormat(product.currency_price)"></dd>
+              </dl>
+            </div>
+            <span class="attended">対象クーポン</span>
+            <p class="coupon_name" v-text="bestUserCoupon.coupon_name"></p>
+            <div class="coupon_detail">
+              <a href="https://www.dlsite.com/girls/mypage/coupon/list">利用条件の確認はこちら</a>
+            </div>
+          </div>
+          
+          <div v-else-if="real_point === 0" class="coupon_available_inner">
+            <dl class="coupon_detail">
+              <dt class="ex">クーポンは利用できません</dt>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <div id="work_buy_btn">
+      <!-- ダウンロード -->
+      <template v-if=" ! product.is_sale && is_comingsoon && !is_check">
+        <div class="pre_work_message">
+          <span class="title">販売開始予定</span>
+          <span class="date">12月26日 0時</span>
+          <span class="note">※状況により販売延期される<br>場合もあります</span>
+        </div>
+      </template>
+      <template v-else-if=" ! product.is_sale && product.on_sale && ! is_check">
+        <p class="work_sales_end">販売終了しました</p>
+      </template>
+      <template v-else>
+        <template v-if="is_bought">
+          
+                                                
+              <p class="work_stream"><a rel="noopener" href="https://play.dlsite.com/?workno=RJ01008713" class="btn_st" :class="{ disabled: ! product.dlsiteplay_work || product.dl_format == 16 }" title="ブラウザ視聴" target="_blank">ブラウザ視聴</a></p>
+              <p v-if="![20, 21, 22, 24, 26, 27, 28].includes(product.dl_format)" class="work_cart">
+                <a :href="product.down_url" class="btn_dl" :class="{ disabled: product.dl_format == 17 }">ダウンロード</a>
+              </p>
+              
+                                
+        </template>
+        <template v-else-if="is_already">
+          <p class="work_already">既に持っています</p>
+        </template>
+
+        <template v-if="rentaled">
+          <p class="work_cart"><a href="https://www.dlsite.com/girls/download/rental/=/product_id/RJ01008713.html" class="btn_dl">ダウンロード</a></p>
+        </template>
+
+        <transition name="popup" mode="out-in">
+        <p v-if="product.is_rental && ! rentaled && ((product.work_rentals || []).length + ( ! is_bought && product.on_sale ? 1 : 0) > 1) && carted" class="message_cart_in" :key="carted.rental_id"><span>{{ carted.name }}</span>追加済み</p>
+        </transition>
+
+        <template v-if="is_check">
+          <p class="work_cart">
+            <a class="btn_cart" v-t="'cart.add_cart'"><!-- カートに入れる --></a>
+          </p>
+        </template>
+        <template v-else-if="buy_type == 'rental' || ! is_bought && ! rentaled && ! product.on_sale">
+          <p v-if="carted && carted.rental_id == rental.id" class="work_cart">
+            <a :href="makeUrl('/cart', { rental_id: rental_id, product_id: product.product_id })" class="btn_cart_in" v-t="'cart.in_cart'"><!-- カートに入っています--></a>
+          </p>
+          <p v-else class="work_cart">
+            <a @click.prevent="addCart({ product_id:product.product_id, rental_id: rental.id }); showCartPopup()" :href="makeUrl('/cart', { rental_id: rental_id, product_id: product.product_id })" class="btn_cart" v-t="'cart.add_cart'"><!-- カートに入れる --></a>
+          </p>
+        </template>
+        <template v-else-if=" ! is_bought && product.on_sale">
+          <p v-if="product.is_sold_out" class="work_cart">
+            <a href="#" class="btn_cart disabled" v-t="'product.item.sold_out'"></a>
+          </p>
+          <p v-else-if="carted && ! carted.rental_id" class="work_cart">
+            
+                          <a :href="makeUrl('/cart', { product_id: product.product_id })" class="btn_cart_in" v-t="'cart.in_cart'"><!-- カートに入っています --></a>
+                      
+          </p>
+          <template v-else>
+          
+                          
+              <p class="work_cart" v-if="!isAccountLogin">
+                <a v-if="product.voice_pack" :href="makeUrl('/pay/member', { relayout:'cart', buynow:1, 'product_ids[]': product.voice_pack.product_ids })" class="btn_buy">会員登録して購入</a>
+                <a v-else href="https://www.dlsite.com/girls/pay/member/=/relayout/cart/buynow/1/product_id/RJ01008713.html" class="btn_buy">会員登録して購入</a>
+              </p>
+              <p class="work_cart">
+                <a v-if="product.voice_pack" @click.prevent="addSeriesToCart({ product_ids:product.voice_pack.product_ids }); showCartPopup()" :href="makeUrl('/cart', { product_id: product.product_id })" class="btn_cart" v-t="'cart.add_cart'"><!-- カートに入れる --></a>
+                <a v-else @click.prevent="addCart({ product_id:product.product_id }); showCartPopup()" :href="makeUrl('/cart', { product_id: product.product_id })" class="btn_cart" v-t="'cart.add_cart'"><!-- カートに入れる --></a>
+              </p>
+              <p class="work_cart" v-if="isAccountLogin">
+                <a v-if="product.voice_pack" :href="makeUrl('/pay/member', { relayout:'cart', buynow:1, 'product_ids[]': product.voice_pack.product_ids })" class="btn_buy">すぐに購入</a>
+                <a v-else href="https://www.dlsite.com/girls/pay/member/=/relayout/cart/buynow/1/product_id/RJ01008713.html" class="btn_buy">すぐに購入</a>
+              </p>
+              
+                      
+          </template>
+        </template>
+
+        <!-- セット割 -->
+        
+        <sets-list product-id="RJ01008713"></sets-list>
+        
+
+        <!-- お気に入り -->
+        <p v-if="is_check" class="work_favorite"><a class="btn_favorite" v-t="favorite.add_fav"><!-- お気に入りに追加 --></a></p>
+        <p v-else-if="product.is_sold_out" class="work_favorite"><a href="#" class="btn_favorite disabled" v-t="'favorite.add_fav'"><!-- お気に入りに追加 --></a></p>
+        <p v-else-if="! user.customer_id && ! is_favorite" class="work_favorite"><a :href="link.favorite" class="btn_favorite" :class="{ btn_favorite_in: is_favorite }">{{ is_favorite ? $t('favorite.in_fav') : $t('favorite.add_fav') }}</a></p>
+        <p v-else-if="user.customer_id && ! is_favorite" class="work_favorite"><a @click.prevent="addFavorite({ product_id:product.product_id })" href="https://www.dlsite.com/girls/mypage/wishlist/=/product_id/RJ01008713.html" class="btn_favorite" :class="{ btn_favorite_in: is_favorite }">{{ is_favorite ? $t('favorite.in_fav') : $t('favorite.add_fav') }}</a></p>
+        <p v-else class="work_favorite"><a href="https://www.dlsite.com/girls/mypage/wishlist/=/product_id/RJ01008713.html" class="btn_favorite" :class="{ btn_favorite_in: is_favorite }">{{ is_favorite ? $t('favorite.in_fav') : $t('favorite.add_fav') }}</a></p>
+
+        <!-- 購入済み作品の場合、作品評価ページへのリンクを表示する -->
+        <template v-if="is_bought" v-cloak>
+          <div v-if="is_myrated" class="work_rating" v-cloak><a href="https://www.dlsite.com/girls/mypage/short-review" class="btn_rating_in">作品評価済み</a></div>
+          <div v-else class="work_rating" v-cloak><a href="https://www.dlsite.com/girls/mypage/short-review" class="btn_rating">作品を評価する</a></div>
+        </template>
+
+        
+        <!-- 多言語の場合、ポイント購入へのリンクを表示する -->
+                
+
+        <!-- カートボタン押下時にレコメンドのモーダル表示 -->
+        <div v-show="this.$store.state.is_carted" class="add_cart_overlay" @click.stop.prevent="function(){ closeRecommend(); $(document.body).removeClass('scrolling_stop'); }">
+          <div class="add_cart_modal" @click.stop>
+            <span class="add_cart_close" @click.stop.prevent="function(){ closeRecommend(); $(document.body).removeClass('scrolling_stop'); }"></span>
+            <div class="add_cart_btn_inner">
+              <p class="add_cart_note">作品をカートに追加しました</p>
+              <a v-if="user.customer_id" :href="makeUrl('/cart', { product_id: product.product_id })" v-t="'cart.go_buy'" class="add_cart_btn"><!-- 購入手続きへ --></a>
+              <a v-else :href="makeUrl('/cart', { product_id: product.product_id })" v-t="'cart.go_cart'" class="add_cart_btn"><!-- カートを見る --></a>
+            </div>
+            <cart_recommend v-bind:on_display="this.$store.state.is_carted" :product_id="product_id"></cart_recommend>
+          </div>
+        </div>
+        <!-- /カートボタン押下時にレコメンドのモーダル表示 -->
+      </template>
+
+    </div>
+      </div>
+  <div v-else-if="typeof product.price === 'undefined'" class="work_buy_main">
+    <!-- IE8 or noscript -->
+    <div id="work_price">
+      <div class="work_buy_type">
+        <div class="work_buy_container">
+          <div class="work_buy_body">
+            <div class="work_buy_label">価格</div>
+            <div class="work_buy_content"><span class="price">616<i>円</i></span></div>
+          </div>
+                    <div class="work_buy_body">
+            <div class="work_buy_label">ポイント</div>
+            <div class="work_buy_content">
+              <strong class="work_point">
+                56<i>pt (10%還元)</i>
+              </strong>
+            </div>
+          </div>
+                  </div>
+      </div>
+    </div>
+    
+    <sets-list product-id="RJ01008713"></sets-list>
+    
+    <div id="work_buy_btn">
+              <p class="work_cart _work_cart" id="_work_cart_RJ01008713"><a href="https://www.dlsite.com/girls/cart/=/product_id/RJ01008713.html" class="btn_cart _btn_cart" id="_btn_cart_RJ01008713">カートに入れる</a></p>
+        <p class="work_favorite _work_favorite" id="_work_favorite_RJ01008713"><a href="https://www.dlsite.com/girls/mypage/wishlist/=/product_id/RJ01008713.html" class="btn_favorite _btn_favorite" id="_btn_favorite_RJ01008713">お気に入りに追加</a></p>
+          </div>
+  </div>
+
+      <div v-if="product.is_sale && ! is_bought && ! product.is_sold_out && (product.on_sale || product.is_rental)" v-cloak class="floating_cart_box" :class="class_floating_cart_box">
+    <div class="cart_box_header" @click.prevent="toggleDisplayFloat">{{$t('cart.buy_this')}}<div class="hide" v-t="'cart.hide'"></div></div>
+    <div class="cart_box_body">
+      <div class="cart_box_body_inner">
+        <div class="work_info_wrap">
+          <div class="work_thumb">
+            <img src="//img.dlsite.jp/resize/images2/work/doujin/RJ01009000/RJ01008713_img_main_240x240.jpg" alt="♂が受け。ネコちゃん×ネコくん [pink carrot]" class="target_type">
+          </div>
+          
+          <div class="work_buy_body_wrap">
+            <div class="work_buy_body">
+              <div class="work_buy_label" v-t="'product.price.price'"><!-- 価格 --></div>
+              <div class="work_buy_content">
+                <strong v-if="product.voice_pack" class="price">{{ product.voice_pack.sum_price | number_format }}<i v-t="'product.price.yen'"></i></strong>
+                <strong v-else class="price" v-html="currencyFormatWithSymbolTag(real_price)"></strong>
+              </div>
+            </div>
+            <div v-if="product.product_point || product.default_point" class="work_buy_body">
+              <div class="work_buy_label" v-t="'product.price.point'"><!-- ポイント --></div>
+              <div class="work_buy_content">
+                <strong v-if="product.voice_pack" class="work_point">{{ product.voice_pack.sum_point | number_format }}<i>pt</i></strong>
+                <strong v-else class="work_point">{{ (product.product_point || product.default_point) | number_format }}<i>pt</i></strong>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="btn_wrap">
+          <div class="btn_wrap_inner">
+          <template v-if="buy_type == 'rental' || ! is_bought && ! rentaled && ! product.on_sale">
+            <p v-if="carted && carted.rental_id == rental.id" class="work_cart">
+              <a :href="'https://www.dlsite.com/girls/cart/=/rental_id/_rental_/product_id/RJ01008713.html'.replace('_rental_', rental_id)" class="btn_cart_in" v-t="'product.item.into_cart_result'"></a>
+            </p>
+            <p v-else class="work_cart">
+              <a @click.prevent="addCart({ product_id:product.product_id, rental_id: rental.id }); showCartPopup()" :href="'https://www.dlsite.com/girls/cart/=/rental_id/_rental_/product_id/RJ01008713.html'.replace('_rental_', rental_id)" class="btn_cart" data-link-name="float" v-t="'product.item.into_cart'"></a>
+            </p>
+          </template>
+
+          <template v-else-if=" ! is_bought && product.on_sale">
+          
+            <p v-if="carted && ! carted.rental_id" class="work_cart">
+              <a href="https://www.dlsite.com/girls/cart/=/product_id/RJ01008713.html" class="btn_cart_in" v-t="'cart.in_cart_s'"><!-- カートに追加済み --></a>
+            </p>
+            <template v-else>
+              <p class="work_cart" v-if="!isAccountLogin">
+                <a v-if="product.voice_pack" :href="makeUrl('/pay/member', { relayout:'cart', buynow:1, 'product_ids[]': product.voice_pack.product_ids })" class="btn_buy">会員登録して購入</a>
+                <a v-else href="https://www.dlsite.com/girls/pay/member/=/relayout/cart/buynow/1/product_id/RJ01008713.html" class="btn_buy">会員登録して購入</a>
+              </p>
+              <p class="work_cart">
+                <a v-if="product.voice_pack" @click.prevent="addSeriesToCart({ product_ids:product.voice_pack.product_ids }); showCartPopup()" href="https://www.dlsite.com/girls/cart/=/product_id/RJ01008713.html" class="btn_cart" data-link-name="float" v-t="'cart.add_cart_s'"><!-- カートに追加 --></a>
+                <a v-else @click.prevent="addCart({ product_id:product.product_id }); showCartPopup()" href="https://www.dlsite.com/girls/cart/=/product_id/RJ01008713.html" class="btn_cart" data-link-name="float" v-t="'cart.add_cart_s'"><!-- カートに追加 --></a>
+              </p>
+              <p class="work_cart" v-if="isAccountLogin">
+                <a v-if="product.voice_pack" :href="makeUrl('/pay/member', { relayout:'cart', buynow:1, 'product_ids[]': product.voice_pack.product_ids })" class="btn_buy">すぐに購入</a>
+                <a v-else href="https://www.dlsite.com/girls/pay/member/=/relayout/cart/buynow/1/product_id/RJ01008713.html" class="btn_buy">すぐに購入</a>
+              </p>
+            </template>
+          
+          </template>
+
+          <p v-if="user.customer_id && ! is_favorite" class="work_favorite">
+            <a @click.prevent="addFavorite({ product_id:product.product_id })" href="https://www.dlsite.com/girls/mypage/wishlist/=/product_id/RJ01008713.html" class="btn_favorite" v-t="'favorite.add_fav'"><!-- お気に入りに追加 --></a>
+          </p>
+          <p v-else class="work_favorite">
+            <a href="https://www.dlsite.com/girls/mypage/wishlist/=/product_id/RJ01008713.html" :class="{ btn_favorite_in: is_favorite, btn_favorite: !is_favorite }" data-link-name="float">{{ is_favorite ? $t('favorite.in_fav') : $t('favorite.add_fav') }}</a>
+          </p>
+          </div>
+        </div>
+        
+      </div>
+    </div>
+  </div>
+    
+    <coupon-obtain
+    link-coupons="https://www.dlsite.com/girls/coupon/=/ajax/1/product_id/RJ01008713.html/?cdn_cache_min=1&locale=ja_JP"
+    link-obtain="https://www.dlsite.com/girls/get/coupon/=/ajax/1/code/"
+  >
+  </coupon-obtain>
+
+  
+    
+    <div class="work_privilege_guide" v-if="gift && gift.title || coupons.length || bonuses.length" v-cloak>
+    <p class="separate_title"><span>購入特典</span></p>
+    
+    <div class="work_privilege_guide_inner">
+      <ul>
+        
+        <li v-if="gift && gift.title">
+          <p class="label bonus_code">{{ gift.title }}</p>
+          <p v-if="gift.distribute_end_str" class="distribution_period">
+          
+                        {{ gift.distribute_end_str }}まで配布中          
+          </p>
+          <p class="body" v-html="gift.description"></p>
+        </li>
+
+        
+        <li v-for="coupon in coupons">
+          <p class="label coupon" :class="{ type_work: coupon.issue.product_id, type_maker: coupon.issue.maker_id, type_price: ! coupon.issue.product_id && ! coupon.issue.maker_id }">{{ coupon.coupon_name }}</p>
+          <p v-if="coupon.end_date_str" class="distribution_period" :class="{ type_work: coupon.issue.product_id, type_maker: coupon.issue.maker_id, type_price: ! coupon.issue.product_id && ! coupon.issue.maker_id }">{{ coupon.end_date_str }}まで配布中</p>
+          <p class="body" v-html="coupon.info"></p>
+          <p v-if="coupon.user_limit_date" class="period"><span>有効期限：</span>{{ coupon.user_limit_date }}</p>
+          <p v-else-if="coupon.limit_days_day" class="period">
+          
+                        <span>有効期限：</span>取得から{{ coupon.limit_days_day }}日後          
+          </p>
+        </li>
+
+        
+        <li v-for="bonus in bonuses">
+          <p class="label limited_benefit">{{ bonus.title }}</p>
+          <p v-if="bonus.end_date_str" class="distribution_period type_work">
+          
+                        {{ bonus.end_date_str }}まで配布中          
+          </p>
+          <p class="body" v-html="bonus.description"></p>
+        </li>
+      </ul>
+    </div>
+    
+    <p v-if="product.is_rental" class="guide_message">レンタルでは購入特典は<br>付与されません。</p>
+  </div>
+
+  <div id="work_device_guide">
+    <p class="separate_title">
+    <span>閲覧可能な環境</span>
+  </p>
+    <div class="work_device_table_wrap">
+  <table class="work_device_table">
+    <thead>
+      <tr>
+        <th class="dev"></th>
+        <th class="dl"><span>ダウンロード</span></th>
+        <th class="st"><span>ブラウザ</span></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="label icon_pc">PC</td>
+        <td v-if="user.os == 'Mac'" v-cloak><span class="dev_play"></span></td>
+        <td v-else><span class="dev_play"></span></td>
+        <td><span class="dev_play"></span></td>
+      </tr>
+      <tr>
+        <td class="label icon_sp">スマホ</td>
+        <td>
+                        <span class="dev_play"></span>
+                    </td>
+        <td><span class="dev_play"></span></td>
+      </tr>
+    </tbody>
+  </table>
+  </div>
+    
+    
+  <div class="os_popup" :class="{ active: is_display_machine_list }">
+    <div class="os_popup_header">対応OS</div>
+    <div class="os_popup_body">
+      <table>
+        <tbody>
+          <tr>
+            <td>Windows</td>
+            <td>-            </td>
+          </tr>
+                    <tr>
+            <td>Mac</td>
+            <td>-</td>
+          </tr>
+          <tr>
+                      <td>iOS</td>
+            <td>-</td>
+          </tr>
+          <tr>
+            <td>Android</td>
+            <td>-</td>
+          </tr>
+          <tr>
+            <td>その他</td>
+            <td>-</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+  
+
+  <div class="work_buy_guide type_affiliate" v-if="!is_comingsoon && !product.affiliate_deny" v-cloak>
+    <ul class="guide_list">
+      <li>
+        <a href="https://www.dlsite.com/girls/circle/affiliate/link/work/=/product_id/RJ01008713.html" v-if="isCircleLogin">アフィリエイトリンク作成</a>
+        <a href="https://www.dlsite.com/girls/user/affiliate/link/work/=/product_id/RJ01008713.html" v-else>アフィリエイトリンク作成</a>
+      </li>
+    </ul>
+  </div>
+</div>
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+      </div>
+      <!-- /right -->
+
+            
+      
+      
+      
+      <!-- footer -->
+      <div id="footer" data-section_name="footer">
+        
+        <div class="pagetop_block" data-ga4-ref="to_top_button">
+  <p class="pagetop"><a href="#header">PAGE TOP</a></p>
+</div>
+<div class="footer_floor_nav">
+<ul class="floor_list">
+<li class="floor_list_item"><a href="https://www.dlsite.com">総合トップ</a></li>
+<li class="floor_list_item"><a href="https://www.dlsite.com/girls/">同人</a></li>
+<li class="floor_list_item"><a href="https://www.dlsite.com/girls-pro/">コミック</a></li>
+<li class="floor_list_item"><a href="https://www.dlsite.com/girls-drama/">ドラマCD</a></li>
+<li class="floor_list_item"><a href="https://www.dlsite.com/girls-pro/girlsgame">PCゲーム</a></li>
+<li class="floor_list_item sp_switch"><a id="_touch_link" href="https://www.dlsite.com/girls-touch/work/=/product_id/RJ01008713.html" data-platform="touch">スマホ版DLsiteへ</a></li>
+</ul>
+</div>
+
+
+  
+<div class="footer_section">
+  <div class="footer_section_inner">
+    <div class="link_list_wrap">
+      <div class="link_list_box col_2">
+                <div class="label">DLsiteについて</div>
+                <ul class="link_list">
+                    <li class="link_list_item"><a rel="noopener" href="https://www.eisys.co.jp/company/information" target="_blank">会社概要</a></li>
+                              <li class="link_list_item"><a rel="noopener" href="https://www.eisys.co.jp/recruit" target="_blank">採用情報</a></li>
+                    <li class="link_list_item"><a href="https://www.dlsite.com/girls/user/regulations">利用規約</a></li>
+          <li class="link_list_item"><a href="https://www.dlsite.com/girls/guide/law">特定商取引法に基づく表示</a></li>
+          <li class="link_list_item"><a href="https://www.dlsite.com/girls/guide/settlement">資金決済法に基づく表記</a></li>
+          <li class="link_list_item"><a href="https://www.dlsite.com/girls/guide/privacy">個人情報の取扱いについて</a></li>
+                    <li class="link_list_item"><a href="https://www.eisys.co.jp/cookie/policy" rel="noopener" target="_blank">外部送信規律に関する公表</a></li>
+                    <li class="link_list_item"><a href="https://www.dlsite.com/girls/mosaic">コンプライアンスポリシー</a></li>
+          <li class="link_list_item"><a href="https://www.dlsite.com/girls/guide/copy">著作権</a></li>
+                    <li class="link_list_item"><a href="https://www.dlsite.com/girls/banners">リンクについて</a></li>
+          <li class="link_list_item"><a href="https://www.dlsite.com/girls/sitemap">サイトマップ</a></li>
+                  </ul>
+      </div>
+      <div class="link_list_box">
+        <div class="label">ヘルプ&amp;ガイド</div>
+        <ul class="link_list">
+                    <li class="link_list_item"><a href="https://www.dlsite.com/girls/welcome">初めての方へ</a></li>
+                    <li class="link_list_item"><a rel="noopener" href="https://www.dlsite.com/girls/faq/=/type/user" target="_blank">よくある質問</a></li>
+                    <li class="link_list_item"><a href="https://www.dlsite.com/girls/opinion/contribution">作品リクエスト</a></li>
+                  </ul>
+      </div>
+      <div class="link_list_box">
+                <div class="label">DLsiteのサービス</div>
+                <ul class="link_list">
+                    <li class="link_list_item"><a href="https://www.dlsite.com/girls/circle/invite">作品を販売したい方へ</a></li>
+                              <li class="link_list_item"><a rel="noopener" target="_blank" href="https://min-hon.net/">みんなで翻訳</a></li>
+          <li class="link_list_item"><a href="https://www.dlsite.com/girls/guide/affiliate">アフィリエイト</a></li>
+                    <li class="link_list_item"><a href="https://www.dlsite.com/girls/mypage/setting/mail">メールマガジン</a></li>
+                    <li class="link_list_item"><a rel="noopener" href="https://play.dlsite.com/ja" target="_blank">Webビューア DLsite Play</a></li>
+          <li class="link_list_item"><a href="https://www.dlsite.com/girls/guide/dlnest">PCクライアント DLsite Nest</a></li>
+                  </ul>
+      </div>
+    </div>
+  </div>
+  <div class="footer_section_inner payment">
+    <div class="label">お支払い&amp;ポイント</div>
+    <div class="footer_payment_box">
+      <ul class="link_list">
+        <li class="link_list_item"><a href="https://www.dlsite.com/girls/guide/creditcard">お支払い方法</a></li>
+                        <li class="link_list_item"><a href="https://www.dlsite.com/girls/mypage/aboutpoint">ポイントについて</a></li>
+                <li class="link_list_item"><a href="https://www.dlsite.com/girls/guide/payment#link_point">ポイント購入方法</a></li>
+      </ul>
+      <a href="https://www.dlsite.com/girls/guide/creditcard" class="footer_payment_img">
+        <div class="img_lists">
+          <div class="img_list_item">
+            <p class="img_list_text">クレジットカード</p>
+            <div class="img_list">
+              <img src="/modpub/images/web/common/payment/logo_jcb.png" alt="JCB">
+            </div>
+          </div>
+          <div class="img_list_item">
+            <p class="img_list_text">コンビニ・ネットバンク</p>
+            <div class="img_list">
+              <img src="/modpub/images/web/common/payment/logo_lawson.png" alt="Lawson">
+              <img src="/modpub/images/web/common/payment/logo_familymart.png" alt="Familymart">
+              <img src="/modpub/images/web/common/payment/logo_payeasy.png" alt="Pay-easy">
+            </div>
+          </div>
+          <div class="img_list_item">
+            <p class="img_list_text">電子マネー</p>
+            <div class="img_list">
+                            <img src="/modpub/images/web/common/payment/logo_redy.png" alt="楽天Edy">
+              <img src="/modpub/images/web/common/payment/logo_bitcash.png" alt="BitCash">
+              <img src="/modpub/images/web/common/payment/logo_linepay.png" alt="linepay">
+                          </div>
+            <div class="img_list">
+              <img src="/modpub/images/web/common/payment/logo_webmoney.png" alt="WebMoney">
+              <img src="/modpub/images/web/common/payment/logo_paypay.png" alt="PayPay">
+              <img src="/modpub/images/web/common/payment/logo_famipay.png" alt="FamiPay">
+            </div>
+          </div>
+          <div class="img_list_item">
+            <p class="img_list_text">後払い</p>
+            <div class="img_list">
+              <img src="/modpub/images/web/common/payment/logo_paidy.png" alt="paidy">
+              <img src="/modpub/images/web/common/payment/logo_atone.png" alt="atone">
+            </div>
+                      </div>
+        </div>
+      </a>
+    </div>
+  </div>
+      <div class="footer_section_inner sns">
+        <div class="label">Twitter公式アカウント</div>
+    <ul class="footer_sns">
+      <li class="footer_sns_item"><a rel="noopener" href="https://twitter.com/DLsite" target="_blank" class="twitter_g">全年齢</a></li>
+      <li class="footer_sns_item"><a rel="noopener" href="https://twitter.com/GirlsManiax" target="_blank" class="twitter_bl">BL</a></li>
+      <li class="footer_sns_item"><a rel="noopener" href="https://twitter.com/girlsmaniax_OTM" target="_blank" class="twitter_otm">乙女</a></li>
+      <li class="footer_sns_item"><a rel="noopener" href="https://twitter.com/DLsiteR18" target="_blank" class="twitter_comic_r18">Comic R18</a></li>
+      <li class="footer_sns_item"><a rel="noopener" href="https://twitter.com/DLsiteEnglish" target="_blank" class="twitter_eng">English</a></li>
+      <li class="footer_sns_item"><a rel="noopener" href="https://twitter.com/DLsite_info" target="_blank" class="twitter_info">広報</a></li>
+    </ul>
+    <div class="label">Youtube公式アカウント</div>
+    <ul class="footer_sns">
+      <li class="footer_sns_item"><a rel="noopener" href="https://www.youtube.com/channel/UCQEN3LsNnqottC2mXx3tAjA" target="_blank" class="youtube_info">広報</a></li>
+    </ul>
+          </div>
+  <div class="footer_section_inner recruit">
+    <div class="label">採用情報（グループ一括採用）</div>
+    <template data-vue-component="footer-recruit-links"></template>
+    <a rel="noopener" href="https://www.eisys.co.jp/recruit" class="recruit_more" target="_blank">採用サイトへ</a>
+  </div>
+  </div>
+
+<div id="copyright">
+  <div class="container clearfix">
+    <div id="system">推奨環境：最新版のMicrosoft Edge、Safari、Chrome、Firefox（JavaScript・Cookieを許可）</div>
+        <p>&copy; 1996 DLsite</p>
+      </div>
+</div>
+
+<div data-vue-component="thumb-img-popup-in-swiper"></div>
+      </div>
+      <!-- /footer -->
+
+    </div>
+    <!-- /container -->
+
+        <!-- script_footer -->
+    
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "DLsite",
+  "alternateName": "DLsite",
+  "url": "https://www.dlsite.com/"
+}
+</script>
+
+
+<div data-vue-component="cookie-policy" data-async="true"></div>
+
+<script type="text/javascript" src="/vue/js/pc/vendor.js?cdn_cache=1&v=0.1.2&_=1732268149"></script>
+<script type="text/javascript" src="/vue/js/pc/app.js?cdn_cache=1&v=0.1.2&_=1732268211"></script>
+
+
+
+
+
+<script type="text/javascript">
+(function(document, undefined) {
+  "use strict";
+  var $script = document.createElement('script');
+  $script.src = document.location.protocol + '//banner.eisys-bcs.jp/js/bcs.min.js';
+  document.body.appendChild($script);
+
+  $(window).bind('guestbannerDelete', function(){
+    var $guest_banner = $('.bcs_viewer').find('.__guest');
+    if (document.getCookie('loginchecked') >= 1 && $guest_banner.length > 0 ) {
+      $guest_banner.remove();
+    }
+  });
+
+  // フッターリンクQRコードのモーダル
+  // 開き
+  $('.qr-modal-open-link').bind('click', function(e) {
+    e.preventDefault();
+    var targetModal = $(this).attr('data-modal-open');
+    $('[data-modal-type =' + targetModal + ']').addClass('is-show');
+  })
+  // 閉じ（ボタン）
+  $('.global_modal_content_close').bind('click', function(e) {
+    $('[data-modal-type]').removeClass('is-show');
+  })
+  // 閉じ（オーバーレイ）
+  $('.global_modal_overlay.type_qr').bind('click', function(e) {
+    $('[data-modal-type]').removeClass('is-show');
+  })
+  $('.global_modal_content.type_qr').bind('click', function(e) {
+    e.stopPropagation();
+  })
+})(document);
+</script>
+
+
+
+<style>
+div.measure_tag {
+  height: 0 !important;
+  width: 0 !important;
+  line-height: 0 !important;
+  font-size: 0 !important;
+  margin-top: -10000px;
+  margin-left: -10000px;
+  float: left;
+}
+</style>
+
+<div class="measure_tag"></div>
+    <!-- /script_footer -->
+        <script type="text/javascript">var contents = {"impression":[],"detail":[{"id":"RJ01008713","name":"\u2642\u304c\u53d7\u3051\u3002\u30cd\u30b3\u3061\u3083\u3093\u00d7\u30cd\u30b3\u304f\u3093","category":"girls","brand":"RG67243","price":560,"regist_date":"2022\/12\/26","image_main":"\/\/img.dlsite.jp\/modpub\/images2\/work\/doujin\/RJ01009000\/RJ01008713_img_main.jpg","official_price":880,"series_id":"SRI0000046090","series_name":"\u2642\u304c\u53d7\u3051\u3002\u30cd\u30b3\u3061\u3083\u3093\u00d7\u30cd\u30b3\u304f\u3093","title_id":"SRI0000046090","title_name":"\u2642\u304c\u53d7\u3051\u3002\u30cd\u30b3\u3061\u3083\u3093\u00d7\u30cd\u30b3\u304f\u3093","discount":616,"work_type":"MNG","lang_options":"JPN","price_with_tax":880}],"time":0.0012049674987792969};</script>
+</body>
+
+</html>


### PR DESCRIPTION
fix #1322 

作品情報にカップリング設定が含まれているとそれだけがタグとして扱われてしまい、ジャンルがタグとして抽出されなくなるバグを修正しました。

おそらく `div.main_genre > a` はいずれもタグとして抽出して良いだろうという想定で実装していますが、余計なメタデータが含まれてしまう可能性がありましたら教えてください。