### PR TITLE
メタデータ取得時、時々 sleep() にfloatが渡されてエラーになるのを修正

### DIFF
--- a/app/Utilities/ApplyProviderPolicyMiddleware.php
+++ b/app/Utilities/ApplyProviderPolicyMiddleware.php
@@ -66,7 +66,7 @@ class ApplyProviderPolicyMiddleware
 
             // 連続アクセス制限
             if ($lastAccess !== null) {
-                $elapsedSeconds = $lastAccess->diffInSeconds(now(), false);
+                $elapsedSeconds = (int) $lastAccess->diffInSeconds(now());
                 if ($elapsedSeconds < $contentProvider->access_interval_sec) {
                     if ($elapsedSeconds < 0) {
                         $wait = abs($elapsedSeconds) + $contentProvider->access_interval_sec;


### PR DESCRIPTION
#1363 のCarbon v3更新による不具合。

- `sleep()` は整数しか受け付けないので、`diffInSeconds()` の戻り値を整数にキャストしてから処理するようにした
- 第2引数はv3でfalseがデフォルトになったので消した