### PR TITLE
GET /api/v1/me, GET /api/v1/users/{user} の checkin_summary.current_session_elapsed の型を整数に修正

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -111,8 +111,7 @@ class User extends Authenticatable
             ->orderByDesc('ejaculated_date')
             ->first();
         if (!empty($latestEjaculation)) {
-            $currentSession = $latestEjaculation->ejaculated_date
-                ->diffInSeconds(Carbon::now());
+            $currentSession = (int) $latestEjaculation->ejaculated_date->diffInSeconds(Carbon::now());
         } else {
             $currentSession = null;
         }


### PR DESCRIPTION
#1363 のCarbon v3更新による不具合。

公開API `GET /api/v1/me`, `GET /api/v1/users/{user}` のレスポンス `checkin_summary.current_session_elapsed` が、バージョンアップ以降意図せず浮動小数点数になっていた。

ここの型を変えるつもりはなかったので、バージョンアップ前と同様に整数で出力されるようにする。