### PR TITLE
「その他」以外の理由で詳細付きの報告をすると500エラーになるバグを修正

### DIFF
--- a/app/Http/Requests/EjaculationReportRequest.php
+++ b/app/Http/Requests/EjaculationReportRequest.php
@@ -32,7 +32,7 @@ class EjaculationReportRequest extends FormRequest
 
     public function withValidator(Validator $validator)
     {
-        $validator->sometimes('comment', 'exists:rules,id', function ($input) {
+        $validator->sometimes('violated_rule', 'exists:rules,id', function ($input) {
             return $input->violated_rule !== 'other';
         });
     }


### PR DESCRIPTION
このコードの意図は「violated_ruleがother以外だったら、選択されたviolated_ruleが実在することを確認」だったはず。

なぜか `comment` を第1引数に書いてしまっていて `select count(*) as aggregate from "rules" where "id" = :comment`  みたいなSQLが発行されて死んでいた。