### PR TITLE
年間グラフに「去年のデータも表示」オプションを追加

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -93,7 +93,7 @@ SQL
         if (empty($user)) {
             abort(404);
         }
-        $compare = $request->query('compare') === '1';
+        $comparePrev = $request->query('compare') === 'prev';
 
         $validator = Validator::make(compact('year'), [
             'year' => 'required|date_format:Y'
@@ -115,7 +115,7 @@ SQL
         $mostFrequentlyUsedRanking = collect($this->countMostFrequentlyUsedOkazu($user, $dateSince, $dateUntil));
 
         $compareData = null;
-        if ($compare) {
+        if ($comparePrev) {
             $compareDateSince = Carbon::createFromDate($year - 1, 1, 1, config('app.timezone'))->startOfDay();
             $compareDateUntil = Carbon::createFromDate($year - 1, 1, 1, config('app.timezone'))->addYear()->startOfDay();
             $compareData = $this->makeGraphData($user, $compareDateSince, $compareDateUntil);

--- a/resources/assets/js/user/stats.ts
+++ b/resources/assets/js/user/stats.ts
@@ -220,8 +220,8 @@ if (document.getElementById('dow-graph')) {
 const compare = document.getElementById('compare') as HTMLInputElement | null;
 if (compare) {
     const params = new URLSearchParams(location.search);
-    compare.checked = params.get('compare') === '1';
+    compare.checked = params.get('compare') === 'prev';
     compare.addEventListener('change', () => {
-        location.search = compare.checked ? '?compare=1' : '';
+        location.search = compare.checked ? '?compare=prev' : '';
     });
 }

--- a/resources/views/user/stats/yearly.blade.php
+++ b/resources/views/user/stats/yearly.blade.php
@@ -6,7 +6,13 @@
     <h5 class="my-4">Shikontribution graph</h5>
     <div id="cal-heatmap" class="tis-contribution-graph"></div>
     <hr class="my-4">
-    <h5 class="my-4">月間チェックイン回数</h5>
+    <div class="my-4 d-flex justify-content-between">
+        <h5 class="my-0">月間チェックイン回数</h5>
+        <div class="custom-control custom-switch">
+            <input type="checkbox" class="custom-control-input" id="compare">
+            <label class="custom-control-label" for="compare">去年のデータも表示</label>
+        </div>
+    </div>
     <canvas id="monthly-graph" class="w-100"></canvas>
     <hr class="my-4">
     <h5 class="my-4">時間別チェックイン回数</h5>
@@ -46,5 +52,8 @@
 
 @push('script')
 <script id="graph-data" type="application/json">@json($graphData)</script>
+@if ($compareData !== null)
+<script id="compare-data" type="application/json">@json($compareData)</script>
+@endif
 @vite('resources/assets/js/user/stats.ts')
 @endpush


### PR DESCRIPTION
年間グラフページに「去年のデータも表示」というスイッチを追加し、オンにしたら前年分のデータも併せて表示する機能を追加しました。  
任意の年と比較できたほうが便利だと思うけど、とりあえずあったら面白いかなの精神で実装してみました。

<img width="848" alt="image" src="https://github.com/user-attachments/assets/2d530eca-bfda-4ab6-927c-a35d6d6876eb">
