### PR TITLE
Shikontributions: JST00:00から09:00の間に閲覧すると、日付が1日ずれるのを修正

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -63,7 +63,7 @@ SQL
         $countByDay = [];
         foreach ($countByDayQuery as $data) {
             $countByDay[] = [
-                't' => Carbon::createFromFormat('Y/m/d', $data->date)->timestamp,
+                't' => Carbon::createFromFormat('Y/m/d', $data->date, 'UTC')->startOfDay()->timestamp,
                 'count' => $data->count
             ];
         }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -290,7 +290,7 @@ SQL
         }
 
         foreach ($groupByDay as $data) {
-            $date = Carbon::createFromFormat('Y/m/d', $data->date);
+            $date = Carbon::createFromFormat('Y/m/d', $data->date, 'UTC')->startOfDay();
             $yearAndMonth = $date->format('Y/m');
 
             $dailySum[] = ['t' => $date->timestamp, 'count' => $data->count];

--- a/tests/Unit/Http/Controllers/UserControllerTest.php
+++ b/tests/Unit/Http/Controllers/UserControllerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\Http\Controllers;
+
+use App\Ejaculation;
+use App\Http\Controllers\UserController;
+use App\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class UserControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+        Carbon::setTestNow('2020-07-21 19:00:00');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Carbon::setTestNow();
+    }
+
+    public function testProfileShikontributions()
+    {
+        $user = User::factory()->create()->fresh();
+
+        $ejaculation = Ejaculation::factory()->create([
+            'user_id' => $user->id,
+            'ejaculated_date' => Carbon::create(2020, 7, 1, 19, 19, 0, 'Asia/Tokyo'),
+            'link' => '',
+            'note' => 'world biggest boob',
+        ]);
+
+        foreach (['2020-07-21 00:00:00', '2020-07-21 09:00:00', '2020-07-21 19:00:00'] as $time) {
+            Carbon::setTestNow($time);
+            $response = $this->get('/user/' . $user->name);
+            // シコ草における日付を表すタイムスタンプがチェックイン・プロフィール閲覧の時刻によらずUTCで00:00に揃えられることを確認する
+            // UNIX時間 1593561600 = 2020-07-01 00:00:00 UTC
+            $response->assertSee('<script id="count-by-day" type="application/json">[{"t":1593561600,"count":1}]</script>', false);
+        }
+    }
+}

--- a/tests/Unit/Http/Controllers/UserControllerTest.php
+++ b/tests/Unit/Http/Controllers/UserControllerTest.php
@@ -46,4 +46,24 @@ class UserControllerTest extends TestCase
             $response->assertSee('<script id="count-by-day" type="application/json">[{"t":1593561600,"count":1}]</script>', false);
         }
     }
+
+    public function testStatsYearlyShikontributions()
+    {
+        $user = User::factory()->create()->fresh();
+
+        $ejaculation = Ejaculation::factory()->create([
+            'user_id' => $user->id,
+            'ejaculated_date' => Carbon::create(2020, 7, 1, 19, 19, 0, 'Asia/Tokyo'),
+            'link' => '',
+            'note' => 'world biggest boob',
+        ]);
+
+        foreach (['2020-07-21 00:00:00', '2020-07-21 09:00:00', '2020-07-21 19:00:00'] as $time) {
+            Carbon::setTestNow($time);
+            $response = $this->get('/user/' . $user->name . '/stats/2020');
+            // シコ草における日付を表すタイムスタンプがチェックイン・プロフィール閲覧の時刻によらずUTCで00:00に揃えられることを確認する
+            // UNIX時間 1593561600 = 2020-07-01 00:00:00 UTC
+            $response->assertSee('"dailySum":[{"t":1593561600,"count":1}]', false);
+        }
+    }
 }


### PR DESCRIPTION
楽しく本アプリケーションを利用しております、いつもありがとうございます！

## 概要
JST00:00から09:00の間にプロフィール画面のShikontributionsを閲覧すると、日付が実際にチェックインを行った日付から1日ずれて表示されます。

<img width="1084" alt="2月14日にチェックインしたが、ヒートマップ上では2月13日のチェックインと記録されている" src="https://github.com/user-attachments/assets/9e830e4f-a2da-414b-818d-8f64e4658943" />

これは

- `Carbon::createFromFormat` に年月日のみ渡した場合、時分以降の値は現時刻が用いられる
  - たとえば、2025/02/14 01:23 JSTに2025/01/14のチェックイン記録を参照すると、`createFromFormat('Y/m/d', '2025/01/14')`は2025/01/14 **01:23 JST**のインスタンスを生成する
  - これがそのまま`count-by-day`にUNIX時間1736785380として渡され、フロントエンドがこのタイムスタンプを解釈する
- 正確には未検証ですが、CalHeatmapがタイムスタンプの解釈にあたってタイムゾーンを無視してUTCにおける日付を参照している気がする
  - 前項の例に従えば、CalHeatmapはUNIX時間1736785380を2025/01/13 16:23 UTCとして解釈する
  - この日付部分2025/01/13を用いてヒートマップが描画されるので、意図した2025/01/14から日付が1日ずれる（JST09:00以降はJSTの日付とUTCの日付は一致するので問題なし）

という要因によるものだと思われます。

これを修正する実装の案になります。

## 実装
日付を示すタイムスタンプを生成する際、現時刻によらずUTC 00:00に揃えることで齟齬をなくすよう試みています。

作法に不整合があれば、指摘いただければ幸いです。