### PR TITLE
タグ候補リストのCSSクラス名の間違いを修正

### DIFF
--- a/resources/assets/js/components/MetadataPreview.tsx
+++ b/resources/assets/js/components/MetadataPreview.tsx
@@ -98,7 +98,7 @@ export const MetadataPreview: React.FC<MetadataPreviewProps> = ({ link, tags, on
             badge: true,
             'badge-primary': !s.used,
             'badge-secondary': s.used,
-            'metadata-tag-item': true,
+            'tis-metadata-preview-tag-item': true,
         });
     const suggestions =
         metadata?.tags.map((t) => ({


### PR DESCRIPTION
Sassで `&` を使ってprefixを書くのをサボるのはやめたほうがいいと思いました。grepに引っかからん。