### PR TITLE
チェックイン時のノート入力欄で残り入力可能文字数をカウントする

### DIFF
--- a/resources/assets/js/components/CheckinForm.tsx
+++ b/resources/assets/js/components/CheckinForm.tsx
@@ -14,7 +14,7 @@ type CheckinFormProps = {
 export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
     const mode = initialState.mode;
     const MAX_NOTE = 500;
-    const segmenter = new Intl.Segmenter("ja", { granularity: "grapheme" });
+    const segmenter = new Intl.Segmenter('ja', { granularity: 'grapheme' });
     const [date, setDate] = useState<string>(initialState.fields.date || '');
     const [time, setTime] = useState<string>(initialState.fields.time || '');
     const [tags, setTags] = useState<string[]>(initialState.fields.tags || []);
@@ -37,7 +37,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
         }
     }, [mode, isRealtime]);
     useEffect(() => {
-        setRemainingChars(MAX_NOTE - [...segmenter.segment(note)].length)
+        setRemainingChars(MAX_NOTE - [...segmenter.segment(note)].length);
     }, [note]);
 
     return (
@@ -145,14 +145,23 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
                     <textarea
                         id="note"
                         name="note"
-                        className={classNames({ 'form-control': true, 'is-invalid': initialState.errors?.note || remainingChars < 0 })}
+                        className={classNames({
+                            'form-control': true,
+                            'is-invalid': initialState.errors?.note || remainingChars < 0,
+                        })}
                         rows={4}
                         value={note}
                         onChange={(e) => setNote(e.target.value)}
                     />
                     <small
-                        className={classNames({ "form-text": true, "text-muted": remainingChars >= 0, "invalid-feedback": remainingChars < 0 })}
-                    >残り {remainingChars} 文字</small>
+                        className={classNames({
+                            'form-text': true,
+                            'text-muted': remainingChars >= 0,
+                            'invalid-feedback': remainingChars < 0,
+                        })}
+                    >
+                        残り {remainingChars} 文字
+                    </small>
                     <FieldError errors={initialState.errors?.note} />
                 </div>
             </div>

--- a/resources/assets/js/components/CheckinForm.tsx
+++ b/resources/assets/js/components/CheckinForm.tsx
@@ -14,7 +14,6 @@ type CheckinFormProps = {
 export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
     const mode = initialState.mode;
     const MAX_NOTE = 500;
-    const segmenter = new Intl.Segmenter('ja', { granularity: 'grapheme' });
     const [date, setDate] = useState<string>(initialState.fields.date || '');
     const [time, setTime] = useState<string>(initialState.fields.time || '');
     const [tags, setTags] = useState<string[]>(initialState.fields.tags || []);
@@ -37,7 +36,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ initialState }) => {
         }
     }, [mode, isRealtime]);
     useEffect(() => {
-        setRemainingChars(MAX_NOTE - [...segmenter.segment(note)].length);
+        setRemainingChars(MAX_NOTE - [...note].length);
     }, [note]);
 
     return (


### PR DESCRIPTION
フロントでのオンタイムバリデーションはしてない

![スクリーンショット 2025-04-13 16 29 28](https://github.com/user-attachments/assets/1b70407f-c5dd-461a-9f0c-61582f2e9d19)
![スクリーンショット 2025-04-13 16 31 50](https://github.com/user-attachments/assets/8935d402-c5f4-414f-bec1-2a23913c834c)


## 新機能
- #264
- 送信する前の文字列チェックは未実施（他のフォームでもやってないと見受けられるため）

## 確認表
- DBマイグレーションは必要ですか？
  - いいえ
- メタデータの強制失効は必要ですか？
  - no
- その他、デプロイにあたって特別な作業は必要ですか？(例: ワンタイムスクリプトの実行、環境変数の設定)
  - no

## TODO
- [ ] DBのバックアップを取る
- [ ] PRマージ&デプロイ
- [ ] DBマイグレーション
- [ ] メタデータ失効
- [ ] 環境変数設定
- [ ] サーバのメンテナンスモードを解除
