### PR TITLE
normalizeUrl()がUTF-8以外を受け取った時にエラー落ちしていた不具合への対応

### DIFF
--- a/app/Utilities/Formatter.php
+++ b/app/Utilities/Formatter.php
@@ -50,7 +50,7 @@ class Formatter
         $url = urldecode($url);
 
         // Remove Hashbang
-        $url = preg_replace('~/#!/~u', '/', $url);
+        $url = str_replace('/#!/', '/', $url);
 
         // Sort query parameters
         $parts = parse_url($url);

--- a/tests/Unit/Utilities/FormatterTest.php
+++ b/tests/Unit/Utilities/FormatterTest.php
@@ -67,6 +67,14 @@ class FormatterTest extends TestCase
         $this->assertEquals('http://example.com/path/to?foo=bar&hoge=fuga', $formatter->normalizeUrl($url));
     }
 
+    public function testNormalizeUrlWithShiftJisFormat()
+    {
+        $formatter = new Formatter();
+
+        $url = 'http://example.com/?q=%82%B5%82%B1%82%B5%82%B1'; // 「しこしこ」のShift_JIS表現
+        $this->assertEquals($url, $formatter->normalizeUrl($url));
+    }
+
     public function testProfileImageSrcSet()
     {
         $formatter = new Formatter();


### PR DESCRIPTION
#836 で問題になっていたpreg_replace()の後段の処理でクエリが再パースされているので、Tissue全体としては単純文字列置換に差し替えても問題がないのではないかと思います。用例さえあればテスト増やして信頼性を上げられると思うので、よしなに願います。