### PR TITLE
ローカルでのテスト実行に専用のデータベースを使用する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ executors:
           APP_ENV: testing
           APP_KEY: base64:f2tcw34GKT8EOtb5myZxJ8QLdgNivmyPhoQIPY2YfK8=
           DB_CONNECTION: pgsql
+          DB_HOST: 127.0.0.1
           DB_DATABASE: tissue
           DB_USERNAME: tissue
           DB_PASSWORD: tissue

--- a/.env.testing
+++ b/.env.testing
@@ -1,0 +1,87 @@
+APP_NAME=Tissue
+APP_ENV=testing
+APP_KEY=base64:HuWyG6Aq+5xj9DpKerW1EvagdkmvZk9iUD7sJMzOUCs=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+LOG_CHANNEL=stack
+LOG_DEPRECATIONS_CHANNEL=null
+LOG_LEVEL=debug
+
+# テストにモックを使用するか falseの場合は実際のHTML等を取得してテストする
+TEST_USE_HTTP_MOCK=true
+
+# テスト用のスナップショットを更新する場合はtrueにする (TEST_USE_HTTP_MOCKと重複させないよう注意)
+TEST_UPDATE_SNAPSHOT=false
+
+DB_CONNECTION=pgsql
+DB_HOST=db
+DB_PORT=5432
+DB_DATABASE=tissue_test
+DB_USERNAME=tissue
+DB_PASSWORD=tissue
+
+BROADCAST_DRIVER=log
+CACHE_DRIVER=file
+FILESYSTEM_DRIVER=local
+SESSION_DRIVER=file
+QUEUE_DRIVER=sync
+
+REDIS_HOST=127.0.0.1
+REDIS_PASSWORD=null
+REDIS_PORT=6379
+
+MAIL_DRIVER=smtp
+MAIL_HOST=smtp.sparkpostmail.com
+MAIL_PORT=587
+MAIL_USERNAME=SMTP_Injection
+MAIL_PASSWORD=null
+MAIL_ENCRYPTION=tls
+MAIL_FROM_ADDRESS=support@mail.shikorism.net
+MAIL_FROM_NAME=Tissue
+
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_DEFAULT_REGION=us-east-1
+AWS_BUCKET=
+AWS_USE_PATH_STYLE_ENDPOINT=false
+
+SPARKPOST_SECRET=
+
+PUSHER_APP_ID=
+PUSHER_APP_KEY=
+PUSHER_APP_SECRET=
+PUSHER_HOST=
+PUSHER_PORT=443
+PUSHER_SCHEME=https
+PUSHER_APP_CLUSTER=mt1
+
+VITE_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
+VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
+
+# (Optional) reCAPTCHA Key
+# https://www.google.com/recaptcha
+NOCAPTCHA_SECRET=
+NOCAPTCHA_SITEKEY=
+
+SENTRY_LARAVEL_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0
+
+# この回数以上、メタデータの解決に失敗している場合はリトライしない
+# 0以下を指定するとこの機能を無効化する
+METADATA_RESOLVER_CIRCUIT_BREAK_COUNT=5
+
+# (開発用) ContentProviderポリシー情報に基づく連続アクセス制限を無視する
+METADATA_RESOLVER_IGNORE_ACCESS_INTERVAL=false
+
+# (開発用) メタデータをキャッシュしないようにする
+METADATA_NO_CACHE=false
+
+# php artisan passport:install の実行結果から、
+# "Personal access client created successfully." の直後に出力されているClient IDとClient secretをここに設定する
+PASSPORT_PERSONAL_ACCESS_CLIENT_ID=
+PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET=
+
+# TwitterApiResolverで使用するApp-only authenticationのBearer token
+# 未設定の場合はTwitterOGPResolverにフォールバックする
+TWITTER_API_BEARER_TOKEN=

--- a/CHANGELOG_FOR_DEV.md
+++ b/CHANGELOG_FOR_DEV.md
@@ -1,0 +1,53 @@
+# このファイルについて
+
+Tissue開発者向けに、開発環境をバージョンアップする際に留意すべき事項をまとめたドキュメントです。
+
+新規に開発環境を構築、または再構築を行う際には読む必要はありません。
+
+## 読み方
+
+最後に作業をした時期より後のトピックを、古いものから時系列順に読み進めてください。
+
+## 書き方
+
+- トピックは上が最新になるように並べてください。
+- ヘッダーは `${年}-${月}: ${一言程度の概要}` の形式で書いてください。
+- Issueがある場合は必ずリンクを含めてください。
+
+# トピック
+
+## 2025-05: テスト用データベースの追加
+
+- Issue: https://github.com/shikorism/tissue/issues/734
+
+上記IssueのPRマージ以降、開発用データベースが新規作成された際にテスト用データベースが別途作成されるようになりました。  
+ただし、既存の環境については**自動で作成されません**。この状態で `composer test` を実行すると、データベース接続エラーになってしまいます。
+
+下記の手順でテスト用データベースを作成することができます。
+
+```sh
+docker compose exec db psql -U tissue -c "CREATE DATABASE tissue_test"
+```
+
+## 2021-11: PostgreSQL 14へのアップグレード
+
+- Issue: https://github.com/shikorism/tissue/issues/752
+
+Docker Composeを使用して開発環境を構築している場合、下記の手順でデータベースをアップグレードしてください。
+
+```sh
+# 操作前にcompose.yamlのimageタグを10-alpineに変更
+docker compose exec db pg_dump -Fc -U tissue tissue > tissue-pg10
+docker compose down
+docker volume rm tissue_db
+# compose.yamlのimageタグを14-alpineに変更
+docker compose up -d
+docker compose exec db pg_restore -Fc -d tissue -U tissue < tissue-pg10
+```
+
+データを維持する必要がない場合、より簡単な下記の手順を使用することもできます。
+
+```sh
+docker-compose down
+docker volume rm tissue_db
+```

--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ a.k.a. shikorism.net
 - PHP 8.2
 - PostgreSQL 14
 
-> [!WARNING]
-> 2021年11月以前に環境を構築したことがある場合、データベースのバージョンアップ作業が必要です！  
-> [開発環境向けの移行手順](https://github.com/shikorism/tissue/issues/752#issuecomment-939257394) を参考にしてください。
-
 ## 開発環境の構築
+
+> [!IMPORTANT]  
+> すでに開発環境は構築済みですか？ 久しぶりに開発環境を起動する際は CHANGELOG_FOR_DEV.md にも目を通してください。
 
 Docker を用いた開発環境の構築方法です。
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,8 +4,6 @@ services:
     build:
       context: .
       dockerfile: docker/development/web.dockerfile
-    env_file:
-      - .env
     volumes:
       - .:/var/www/html
     networks:
@@ -23,6 +21,7 @@ services:
       POSTGRES_PASSWORD: tissue
     volumes:
       - db:/var/lib/postgresql/data
+      - ./docker/development/init-test-db.sql:/docker-entrypoint-initdb.d/init-test-db.sql
     networks:
       - backend
     restart: always
@@ -33,8 +32,6 @@ services:
   front:
     image: tissue-dev-web
     command: sh -c "yarn && yarn dev --host --port 4546"
-    env_file:
-      - .env
     volumes:
       - .:/var/www/html
       - front_node_modules:/var/www/html/node_modules

--- a/docker/development/init-test-db.sql
+++ b/docker/development/init-test-db.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE tissue_test;


### PR DESCRIPTION
fix #734 

以下の対応を行い、ユニットテスト実行時に専用のデータベースが使われるようにしました。これで `composer test` を実行したら全てのデータが飛ぶことはなくなるはず……！

- env_fileをcompose.yamlで指定するのをやめて、`APP_ENV=testing` の時に `.env.testing` が使われるようにした
- Docker Compose環境でのテスト実行を想定した `.env.testing` を追加
- DBコンテナ初期化時にテスト用のデータベースを作成するようにした