### PR TITLE
API: GET /api/v1/timelines/public (お惣菜コーナー) の追加, チェックインオブジェクト内にユーザ情報を追加

### DIFF
--- a/app/Http/Controllers/Api/V1/MeController.php
+++ b/app/Http/Controllers/Api/V1/MeController.php
@@ -11,6 +11,6 @@ class MeController extends Controller
 {
     public function show()
     {
-        return new UserResource(Auth::user());
+        return new UserResource(Auth::user(), withCheckinSummary: true);
     }
 }

--- a/app/Http/Controllers/Api/V1/Timelines/PublicTimeline.php
+++ b/app/Http/Controllers/Api/V1/Timelines/PublicTimeline.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Timelines;
+
+use App\Ejaculation;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\EjaculationResource;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+class PublicTimeline extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        $inputs = $request->validate([
+            'per_page' => 'nullable|integer|between:10,100',
+        ]);
+
+        $ejaculations = Ejaculation::join('users', 'users.id', '=', 'ejaculations.user_id')
+            ->where('users.is_protected', false)
+            ->where('ejaculations.is_private', false)
+            ->where('ejaculations.link', '<>', '')
+            ->where('ejaculations.ejaculated_date', '<=', Carbon::now())
+            ->orderBy('ejaculations.ejaculated_date', 'desc')
+            ->select('ejaculations.*')
+            ->with('user', 'tags')
+            ->withLikes()
+            ->withMutedStatus()
+            ->visibleToTimeline()
+            ->paginate($inputs['per_page'] ?? 20);
+
+        return response()->fromPaginator($ejaculations, EjaculationResource::class);
+    }
+}

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -11,6 +11,6 @@ class UserController extends Controller
 {
     public function show(User $user)
     {
-        return new UserResource($user);
+        return new UserResource($user, withCheckinSummary: true);
     }
 }

--- a/app/Http/Resources/EjaculationResource.php
+++ b/app/Http/Resources/EjaculationResource.php
@@ -24,6 +24,7 @@ class EjaculationResource extends JsonResource
             'is_private' => $this->is_private,
             'is_too_sensitive' => $this->is_too_sensitive,
             'discard_elapsed_time' => $this->discard_elapsed_time,
+            'user' => new UserResource($this->user),
         ];
     }
 }

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -6,6 +6,11 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class UserResource extends JsonResource
 {
+    public function __construct($resource, private $withCheckinSummary = false)
+    {
+        parent::__construct($resource);
+    }
+
     /**
      * Transform the resource into an array.
      *
@@ -23,7 +28,7 @@ class UserResource extends JsonResource
             $this->mergeWhen($this->isMe() || !$this->is_protected, [
                 'bio' => $this->bio,
                 'url' => $this->url,
-                'checkin_summary' => $this->checkinSummary(),
+                'checkin_summary' => $this->when($this->withCheckinSummary, fn () => $this->checkinSummary()),
             ]),
         ];
     }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -995,6 +995,8 @@ components:
             - webhook
             - api
           example: api
+        user:
+          $ref: "#/components/schemas/User"
     UpdateCheckin:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21,6 +21,8 @@ tags:
     description: コレクションに関する操作
   - name: user-stats
     description: ユーザーの統計情報
+  - name: timelines
+    description: タイムライン
 paths:
   /webhooks/checkin/{id}:
     post:
@@ -872,6 +874,48 @@ paths:
           description: 自分以外が作成したコレクションに対して操作を試みた場合
         404:
           description: 存在しない場合
+  /v1/timelines/public:
+    get:
+      summary: お惣菜コーナーのチェックイン一覧の取得
+      description: |
+        お惣菜コーナー (公開タイムライン) のチェックイン一覧を取得します。
+
+        このAPIでは以下の条件を満たしたチェックインが新着順に列挙されます。
+
+        - ユーザーがチェックインを公開している
+        - チェックインが公開設定になっている
+        - チェックインにオカズリンクが含まれている
+      tags:
+        - timelines
+      parameters:
+        - name: page
+          in: query
+          description: ページ番号
+          schema:
+            type: integer
+            default: 1
+        - name: per_page
+          in: query
+          description: 1ページあたりのアイテム数
+          schema:
+            type: integer
+            default: 20
+            minimum: 10
+            maximum: 100
+      responses:
+        200:
+          description: 成功
+          headers:
+            X-Total-Count:
+              description: 全体のアイテム数
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Checkin'
 components:
   schemas:
     User:

--- a/routes/api.php
+++ b/routes/api.php
@@ -40,6 +40,8 @@ Route::middleware('stateful')->group(function () {
                 Route::get('/links', 'MostlyUsedLinks')->name('links');
                 Route::get('/tags', 'MostlyUsedCheckinTags')->name('tags');
             });
+
+        Route::get('/timelines/public', 'Api\\V1\\Timelines\\PublicTimeline')->name('timelines.public');
     });
 });
 
@@ -70,4 +72,6 @@ Route::middleware(['throttle:60,1', 'auth:api'])
                 Route::get('/links', 'MostlyUsedLinks')->name('links');
                 Route::get('/tags', 'MostlyUsedCheckinTags')->name('tags');
             });
+
+        Route::get('/timelines/public', 'Timelines\\PublicTimeline')->name('timelines.public');
     });

--- a/tests/Feature/Api/V1/Timelines/PublicTimelineTest.php
+++ b/tests/Feature/Api/V1/Timelines/PublicTimelineTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Tests\Feature\Api\V1\Timelines;
+
+use App\Ejaculation;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class PublicTimelineTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function testDefaultQuery()
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        // オカズ付きの公開チェックインを作成
+        $publicWithLink = Ejaculation::factory()->create([
+            'user_id' => $user->id,
+            'ejaculated_date' => Carbon::create(2020, 7, 1, 0, 0, 0, 'Asia/Tokyo'),
+            'link' => 'http://example.com',
+            'note' => 'public with link',
+            'is_private' => false,
+        ]);
+
+        // オカズなしの公開チェックインを作成（結果に表示されないはず）
+        Ejaculation::factory()->create([
+            'user_id' => $user->id,
+            'ejaculated_date' => Carbon::create(2020, 7, 2, 0, 0, 0, 'Asia/Tokyo'),
+            'link' => '',
+            'note' => 'public without link',
+            'is_private' => false,
+        ]);
+
+        // オカズ付きの非公開チェックインを作成（結果に表示されないはず）
+        Ejaculation::factory()->create([
+            'user_id' => $user->id,
+            'ejaculated_date' => Carbon::create(2020, 7, 3, 0, 0, 0, 'Asia/Tokyo'),
+            'link' => 'http://example.com',
+            'note' => 'private with link',
+            'is_private' => true,
+        ]);
+
+        $response = $this->getJson('/api/v1/timelines/public');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(1);
+        $response->assertJson([
+            [
+                'id' => $publicWithLink->id,
+                'checked_in_at' => '2020-07-01T00:00:00+09:00',
+                'tags' => [],
+                'link' => 'http://example.com',
+                'note' => 'public with link',
+                'is_private' => false,
+                'is_too_sensitive' => false,
+                'discard_elapsed_time' => false,
+                'source' => 'web',
+            ]
+        ], true);
+    }
+
+    public function testPagination()
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        // オカズ付きの公開チェックインを11件作成
+        for ($i = 0; $i < 11; $i++) {
+            Ejaculation::factory()->create([
+                'user_id' => $user->id,
+                'ejaculated_date' => Carbon::create(2020, 7, $i + 1, 0, 0, 0, 'Asia/Tokyo'),
+                'link' => 'http://example.com',
+                'is_private' => false,
+            ]);
+        }
+
+        // 最も古いチェックインを取得（per_page=10の場合、2ページ目に表示されるはず）
+        $oldest = Ejaculation::orderBy('ejaculated_date')->first();
+
+        $response = $this->getJson('/api/v1/timelines/public?page=2&per_page=10');
+
+        $response->assertStatus(200);
+        $response->assertHeader('X-Total-Count', 11);
+        $response->assertJsonCount(1);
+        $response->assertJson([
+            [
+                'id' => $oldest->id,
+            ]
+        ], true);
+    }
+
+    public function testProtectedUserCheckins()
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        // オカズ付きの公開チェックインを持つ公開ユーザーを作成
+        $publicUser = User::factory()->create(['is_protected' => false]);
+        $publicCheckin = Ejaculation::factory()->create([
+            'user_id' => $publicUser->id,
+            'ejaculated_date' => Carbon::create(2020, 7, 1, 0, 0, 0, 'Asia/Tokyo'),
+            'link' => 'http://example.com',
+            'is_private' => false,
+        ]);
+
+        // オカズ付きの公開チェックインを持つ非公開ユーザーを作成
+        $protectedUser = User::factory()->protected()->create();
+        Ejaculation::factory()->create([
+            'user_id' => $protectedUser->id,
+            'ejaculated_date' => Carbon::create(2020, 7, 2, 0, 0, 0, 'Asia/Tokyo'),
+            'link' => 'http://example.com',
+            'is_private' => false,
+        ]);
+
+        $response = $this->getJson('/api/v1/timelines/public');
+
+        $response->assertStatus(200);
+        $response->assertHeader('X-Total-Count', 1);
+        $response->assertJsonCount(1);
+        $response->assertJson([
+            [
+                'id' => $publicCheckin->id,
+            ]
+        ], true);
+    }
+
+    public function testFutureCheckins()
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        // オカズ付きの過去のチェックインを作成
+        $pastCheckin = Ejaculation::factory()->create([
+            'user_id' => $user->id,
+            'ejaculated_date' => Carbon::now()->subDay(),
+            'link' => 'http://example.com',
+            'is_private' => false,
+        ]);
+
+        // オカズ付きの未来のチェックインを作成 (未来のチェックインは表示されないはず)
+        Ejaculation::factory()->create([
+            'user_id' => $user->id,
+            'ejaculated_date' => Carbon::now()->addDay(),
+            'link' => 'http://example.com',
+            'is_private' => false,
+        ]);
+
+        $response = $this->getJson('/api/v1/timelines/public');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(1);
+        $response->assertJson([
+            [
+                'id' => $pastCheckin->id,
+            ]
+        ], true);
+    }
+
+    public function testPerPageValidation()
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $response = $this->getJson('/api/v1/timelines/public?per_page=5');
+        $response->assertStatus(422);
+
+        $response = $this->getJson('/api/v1/timelines/public?per_page=101');
+        $response->assertStatus(422);
+
+        $response = $this->getJson('/api/v1/timelines/public?per_page=10');
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
- GET /api/v1/timelines/public を追加。要するにお惣菜コーナー。
- チェックインオブジェクト内にユーザ情報を含めるようにした。お惣菜コーナーから得られたチェックインで投稿者を確認できるようにするための変更。