### PR TITLE
API: GET /api/v1/users/:username/checkins order,since,untilパラメータ追加

### DIFF
--- a/app/Http/Controllers/Api/V1/UserCheckinController.php
+++ b/app/Http/Controllers/Api/V1/UserCheckinController.php
@@ -6,9 +6,11 @@ use App\Ejaculation;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\EjaculationResource;
 use App\User;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class UserCheckinController extends Controller
@@ -21,7 +23,27 @@ class UserCheckinController extends Controller
 
         $inputs = $request->validate([
             'per_page' => 'nullable|integer|between:10,100',
+            'order' => ['nullable', Rule::in(['asc', 'desc'])],
+            'since' => 'nullable|date_format:Y-m-d|after_or_equal:2000-01-01|before_or_equal:2099-12-31',
+            'until' => 'nullable|date_format:Y-m-d|after_or_equal:2000-01-01|before_or_equal:2099-12-31',
         ]);
+
+        if (!empty($inputs['since']) && !empty($inputs['until'])) {
+            $since = CarbonImmutable::createFromFormat('Y-m-d', $inputs['since'])->startOfDay();
+            $until = CarbonImmutable::createFromFormat('Y-m-d', $inputs['until'])->startOfDay()->addDay();
+            if ($until->isBefore($since)) {
+                [$since, $until] = [$until, $since];
+            }
+        } elseif (!empty($inputs['since'])) {
+            $since = CarbonImmutable::createFromFormat('Y-m-d', $inputs['since'])->startOfDay();
+            $until = null;
+        } elseif (!empty($inputs['until'])) {
+            $since = null;
+            $until = CarbonImmutable::createFromFormat('Y-m-d', $inputs['until'])->startOfDay()->addDay();
+        } else {
+            $since = null;
+            $until = null;
+        }
 
         $query = Ejaculation::select(DB::raw(
             <<<'SQL'
@@ -43,7 +65,14 @@ SQL
         if (!Auth::check() || $user->id !== Auth::id()) {
             $query = $query->where('is_private', false);
         }
-        $ejaculations = $query->orderBy('ejaculated_date', 'desc')
+        if ($since !== null) {
+            $query = $query->where('ejaculated_date', '>=', $since);
+        }
+        if ($until !== null) {
+            $query = $query->where('ejaculated_date', '<', $until);
+        }
+        $order = ($inputs['order'] ?? 'desc') === 'asc' ? 'asc' : 'desc';
+        $ejaculations = $query->orderBy('ejaculated_date', $order)
             ->with('tags', 'user')
             ->withLikes()
             ->withMutedStatus()

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -197,6 +197,32 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: since
+          in: query
+          description: 検索範囲の開始日
+          required: false
+          schema:
+            type: string
+            format: date
+            example: 2020-07-01
+        - name: until
+          in: query
+          description: 検索範囲の終了日
+          required: false
+          schema:
+            type: string
+            format: date
+            example: 2021-07-31
+        - name: order
+          in: query
+          description: チェックイン日時の並び順
+          required: false
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+            default: desc
       responses:
         200:
           description: 成功


### PR DESCRIPTION
将来的にチェックインの月単位ビュー (Twilogやnotestockのようなイメージ) を実装したいなと思っての機能追加です。

- since, until
  - 既存のstats APIと同じような仕様です。チェックイン日時の範囲指定。
- order
  - チェックイン日時の並び順です。デフォルトは従来同様の降順。
