### PR TITLE
Docker: restart alwaysを削除

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,6 @@ services:
       - backend
     ports:
       - 4545:80
-    restart: always
     depends_on:
       - db
   db:
@@ -24,7 +23,6 @@ services:
       - ./docker/development/init-test-db.sql:/docker-entrypoint-initdb.d/init-test-db.sql
     networks:
       - backend
-    restart: always
   scheduler:
     <<: *php
     command: php artisan schedule:work
@@ -37,7 +35,6 @@ services:
       - front_node_modules:/var/www/html/node_modules
     ports:
       - 4546:4546
-    restart: always
     depends_on:
       - web
   antlr:


### PR DESCRIPTION
開発環境用のcompose.yamlにそれは要らんやろと今更思ったので消すことにした。

SNSでTissueの開発環境が勝手に起動するという悲鳴を上げてる人もいたことだし。