### PR TITLE
docker: web/frontコンテナ間でnode_modulesを共有

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -3,8 +3,6 @@ services:
     env_file: !reset []
     environment:
       APP_DEBUG: true
-    volumes:
-      - front_node_modules:/var/www/html/node_modules
   scheduler:
     env_file: !reset []
   front:

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -3,6 +3,8 @@ services:
     env_file: !reset []
     environment:
       APP_DEBUG: true
+    volumes:
+      - front_node_modules:/var/www/html/node_modules
   scheduler:
     env_file: !reset []
   front:

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,7 @@ services:
       dockerfile: docker/development/web.dockerfile
     volumes:
       - .:/var/www/html
+      - front_node_modules:/var/www/html/node_modules
     networks:
       - backend
     ports:


### PR DESCRIPTION
Codespacesで遊んでいたらwebコンテナのnode_modulesが空のままで、git commitしようとしたらhuskyがなくて困った。

多分、frontコンテナと共有しておいたほうが都合が良い。