### PR TITLE
/api/likes のレスポンスから不要な内容を削除

### DIFF
--- a/app/Http/Controllers/Api/LikeController.php
+++ b/app/Http/Controllers/Api/LikeController.php
@@ -28,7 +28,11 @@ class LikeController extends Controller
                 'errors' => [
                     ['message' => 'このチェックインはすでにいいね済です。']
                 ],
-                'ejaculation' => $like->ejaculation
+                'ejaculation' => [
+                    'id' => $like->ejaculation->id,
+                    'is_liked' => $like->ejaculation->is_liked,
+                    'likes_count' => $like->ejaculation->likes_count,
+                ]
             ];
 
             return response()->json($data, 409);
@@ -37,7 +41,11 @@ class LikeController extends Controller
         $like = Like::create($keys);
 
         return [
-            'ejaculation' => $like->ejaculation
+            'ejaculation' => [
+                'id' => $like->ejaculation->id,
+                'is_liked' => $like->ejaculation->is_liked,
+                'likes_count' => $like->ejaculation->likes_count,
+            ]
         ];
     }
 
@@ -58,7 +66,11 @@ class LikeController extends Controller
                 'errors' => [
                     ['message' => 'このチェックインはいいねされていません。']
                 ],
-                'ejaculation' => $ejaculation
+                'ejaculation' => [
+                    'id' => $ejaculation->id,
+                    'is_liked' => $ejaculation->is_liked,
+                    'likes_count' => $ejaculation->likes_count,
+                ]
             ];
 
             return response()->json($data, 404);
@@ -67,7 +79,11 @@ class LikeController extends Controller
         $like->delete();
 
         return [
-            'ejaculation' => $like->ejaculation
+            'ejaculation' => [
+                'id' => $like->ejaculation->id,
+                'is_liked' => $like->ejaculation->is_liked,
+                'likes_count' => $like->ejaculation->likes_count,
+            ]
         ];
     }
 }


### PR DESCRIPTION
## 概要
POST /api/likes, DELETE /api/likes/:id のレスポンスから不要な情報を削除し、フロントエンドの動作に必要な情報のみを返すようにしました。

## 変更の背景・Issueへのリンク
特定の条件において、公開すべきでない情報が含まれていたため

## 補足情報 (optional)

## チェックリスト
- [x] ローカル環境での動作確認を行いました
- [x] 必要に応じてテストを追加し、全てのテストが成功していることを確認しました
- [ ] (公開APIの変更を行った場合) openapi.yaml を更新しました
- [ ] (開発環境に対する破壊的な変更を行った場合) CHANGELOG_FOR_DEV.md を更新しました
