### PR TITLE
protected_only_modeではタグ検索機能を停止する

### DIFF
--- a/resources/views/search/base.blade.php
+++ b/resources/views/search/base.blade.php
@@ -12,9 +12,11 @@
             <li class="nav-item">
                 <a class="nav-link {{ Route::currentRouteName() === 'search.collection' ? 'active' : '' }}" href="{{ route('search.collection', $inputs) }}">コレクション</a>
             </li>
+            @unless (config('app.protected_only_mode'))
             <li class="nav-item">
                 <a class="nav-link {{ Route::currentRouteName() === 'search.related-tag' ? 'active' : '' }}" href="{{ route('search.related-tag', $inputs) }}">関連するタグ</a>
             </li>
+            @endunless
         </ul>
         <div class="tab-content">
             <p class="my-3 text-secondary">{{ $results->total() }} 件見つかりました</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -75,9 +75,9 @@ Route::get('/info/{id}', 'InfoController@show')->where('id', '[0-9]+')->name('in
 Route::redirect('/search', '/search/checkin', 301);
 Route::get('/search/checkin', 'SearchController@index')->name('search');
 Route::get('/search/collection', 'SearchController@collection')->name('search.collection');
-Route::get('/search/related-tag', 'SearchController@relatedTag')->name('search.related-tag');
 
 if (!config('app.protected_only_mode')) {
+    Route::get('/search/related-tag', 'SearchController@relatedTag')->name('search.related-tag');
     Route::get('/tag', 'TagController@index')->name('tag');
 }
 


### PR DESCRIPTION
## 概要
サーバーをprotected_only_modeに設定している場合、タグ検索機能を使用できないようにします。

## 変更の背景・Issueへのリンク
同モードが設定されている状態では公開タグ一覧が閉鎖されているのに、こちらの機能が閉鎖されていないことに関する矛盾を解消するためです。

自分が使用したことのあるタグやオカズメタデータにリンクしているタグは検索できて良いような気がしますが、それを実現するには多少仕様を考えないといけないので、ひとまず矛盾の無い仕様にします。

## 補足情報 (optional)

## チェックリスト
- [x] ローカル環境での動作確認を行いました
- [x] 必要に応じてテストを追加し、全てのテストが成功していることを確認しました
- [ ] (公開APIの変更を行った場合) openapi.yaml を更新しました
- [ ] (開発環境に対する破壊的な変更を行った場合) CHANGELOG_FOR_DEV.md を更新しました
