### PR TITLE
鍵垢またはいいね非公開のユーザーからいいねされたチェックインのレスポンス中にクラッシュするバグを修正

### DIFF
--- a/app/Ejaculation.php
+++ b/app/Ejaculation.php
@@ -99,19 +99,7 @@ class Ejaculation extends Model
     public function scopeWithLikes(Builder $query)
     {
         if (Auth::check()) {
-            // TODO - このスコープを使うことでlikesが常に直近10件で絞られるのは汚染されすぎ感がある。別名を付与できないか？
-            //      - (ejaculation_id, user_id) でユニークなわけですが、is_liked はサブクエリ発行させるのとLeft JoinしてNULLかどうかで結果を見るのどっちがいいんでしょうね
             return $query
-                ->with([
-                    'likes' => function ($query) {
-                        $query->latest()->take(10);
-                    },
-                    'likes.user' => function ($query) {
-                        $query->where('is_protected', false)
-                            ->where('private_likes', false)
-                            ->orWhere('id', Auth::id());
-                    }
-                ])
                 ->withCount([
                     'likes',
                     'likes as is_liked' => function ($query) {
@@ -120,15 +108,6 @@ class Ejaculation extends Model
                 ]);
         } else {
             return $query
-                ->with([
-                    'likes' => function ($query) {
-                        $query->latest()->take(10);
-                    },
-                    'likes.user' => function ($query) {
-                        $query->where('is_protected', false)
-                            ->where('private_likes', false);
-                    }
-                ])
                 ->withCount('likes')
                 ->addSelect(DB::raw('0 as is_liked'));
         }

--- a/app/Http/Resources/EjaculationResource.php
+++ b/app/Http/Resources/EjaculationResource.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Resources;
 
-use App\Like;
 use Carbon\Carbon;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -30,7 +29,6 @@ class EjaculationResource extends JsonResource
 
             // scopeWithLikes 使用時のみ
             'is_liked' => $this->whenHas('is_liked'), // private
-            'likes' => $this->whenLoaded('likes', fn ($likes) => UserResource::collection($likes->pluck('user'))), // private
             'likes_count' => $this->whenHas('likes_count'), // private
 
             // scopeWithInterval 使用時のみ

--- a/frontend/api/schema.ts
+++ b/frontend/api/schema.ts
@@ -411,7 +411,6 @@ export interface components {
             /** @enum {string} */
             source: "web" | "csv" | "webhook" | "api";
             user: components["schemas"]["User"];
-            likes?: components["schemas"]["User"][];
             likes_count?: number;
             is_liked?: boolean;
             checkin_interval?: number;

--- a/frontend/features/checkins/Checkin.tsx
+++ b/frontend/features/checkins/Checkin.tsx
@@ -168,7 +168,7 @@ export const Checkin: React.FC<Props> = ({
                 }
             })()}
 
-            {checkin.likes?.length ? (
+            {checkin.likes_count ? (
                 <div className="text-sm text-secondary">
                     <i className="ti ti-heart-filled text-danger" /> <strong>{checkin.likes_count}</strong> 件のいいね
                 </div>

--- a/tsp/models/Checkin.tsp
+++ b/tsp/models/Checkin.tsp
@@ -14,7 +14,6 @@ model Checkin {
   discard_elapsed_time: boolean = false;
   source: "web" | "csv" | "webhook" | "api";
   user: User;
-  likes?: User[];
   likes_count?: integer;
   is_liked?: boolean;
   checkin_interval?: integer;


### PR DESCRIPTION
## 概要
チェックインをEjaculationResourceでJSON化する際、鍵垢またはいいね非公開のユーザーからのいいねが含まれているとeager loadされた `checkin.likes.user` がnullになります。  
これをUserResourceでJSON化を試みてクラッシュしてしまうため、そもそも `checkin.likes` を廃止することで対処しました。

現在のTissueフロントエンドではいいね一覧は廃止されており、過去にいいねされた件数だけを表示しています。そのため、この対応で影響が発生する機能はおそらくありません。

## 変更の背景・Issueへのリンク
- Sentry [TISSUE-AV](https://shikorism.sentry.io/issues/7403907587/events/371a80d7dc8a407b844575916deac5f9/)

## 補足情報 (optional)

## チェックリスト
- [x] ローカル環境での動作確認を行いました
- [x] 必要に応じてテストを追加し、全てのテストが成功していることを確認しました
- [ ] (公開APIの変更を行った場合) openapi.yaml を更新しました
- [ ] (開発環境に対する破壊的な変更を行った場合) CHANGELOG_FOR_DEV.md を更新しました
