### PR TITLE
フロントエンドで扱う日時のタイムゾーンを Asia/Tokyo に固定

### DIFF
--- a/frontend/features/checkins/Checkin.tsx
+++ b/frontend/features/checkins/Checkin.tsx
@@ -14,6 +14,7 @@ import { Button } from '../../components/ui/Button';
 import { ProgressButton } from '../../components/ui/ProgressButton';
 import { useDeleteCheckin } from '../../api/mutation';
 import { toast } from 'sonner';
+import { serverTz } from '../../lib/time';
 
 interface Props {
     checkin: components['schemas']['Checkin'];
@@ -67,9 +68,9 @@ export const Checkin: React.FC<Props> = ({
                     <span className="text-xl font-medium mr-2">{formatCheckinInterval(checkin)}</span>
                     <Link to={`/checkin/${checkin.id}`} className="text-secondary hover:underline">
                         {intervalStyle === 'full' && !checkin.discard_elapsed_time && checkin.previous_checked_in_at
-                            ? `${formatDate(checkin.previous_checked_in_at, 'yyyy/MM/dd HH:mm')} 〜 `
+                            ? `${formatDate(checkin.previous_checked_in_at, 'yyyy/MM/dd HH:mm', { in: serverTz })} 〜 `
                             : ''}
-                        {formatDate(checkin.checked_in_at, 'yyyy/MM/dd HH:mm')}
+                        {formatDate(checkin.checked_in_at, 'yyyy/MM/dd HH:mm', { in: serverTz })}
                     </Link>
                 </h5>
             ) : (
@@ -85,7 +86,7 @@ export const Checkin: React.FC<Props> = ({
                         <bdi className="text-xl font-medium">{checkin.user.display_name}</bdi>
                     </Link>
                     <Link to={`/checkin/${checkin.id}`} className="text-secondary hover:underline">
-                        {formatDate(checkin.checked_in_at, 'yyyy/MM/dd HH:mm')}
+                        {formatDate(checkin.checked_in_at, 'yyyy/MM/dd HH:mm', { in: serverTz })}
                     </Link>
                 </h5>
             )}
@@ -216,7 +217,7 @@ export const Checkin: React.FC<Props> = ({
             <Modal isOpen={isOpenDeleteModal} onClose={() => setIsOpenDeleteModal(false)}>
                 <ModalHeader closeButton>削除確認</ModalHeader>
                 <ModalBody>
-                    {formatDate(checkin.checked_in_at, 'yyyy/MM/dd HH:mm ')}
+                    {formatDate(checkin.checked_in_at, 'yyyy/MM/dd HH:mm ', { in: serverTz })}
                     のチェックインを削除してもよろしいですか？
                 </ModalBody>
                 <ModalFooter>

--- a/frontend/features/checkins/CheckinForm.tsx
+++ b/frontend/features/checkins/CheckinForm.tsx
@@ -1,5 +1,6 @@
 import React, { FormEventHandler, Suspense, useEffect, useState } from 'react';
 import { format } from 'date-fns';
+import { TZDate } from '@date-fns/tz';
 import { TagInput } from '../../components/TagInput';
 import { FieldError } from '../../components/ui/FieldError';
 import { cn } from '../../lib/cn';
@@ -9,6 +10,7 @@ import { Checkbox } from '../../components/ui/Checkbox';
 import { Input } from '../../components/ui/Input';
 import { TextArea } from '../../components/ui/TextArea';
 import { FavoriteTags } from './FavoriteTags';
+import { SERVER_TZ } from '../../lib/time';
 
 export interface CheckinFormValues {
     date: string;
@@ -72,7 +74,7 @@ export const CheckinForm: React.FC<CheckinFormProps> = ({ mode, initialValues, o
     useEffect(() => {
         if (mode === 'create' && isRealtime) {
             const id = setInterval(() => {
-                const now = new Date();
+                const now = TZDate.tz(SERVER_TZ);
                 setDate(format(now, 'yyyy-MM-dd'));
                 setTime(format(now, 'HH:mm'));
             }, 500);

--- a/frontend/lib/time.ts
+++ b/frontend/lib/time.ts
@@ -1,0 +1,4 @@
+import { tz } from '@date-fns/tz';
+
+export const SERVER_TZ = 'Asia/Tokyo';
+export const serverTz = tz(SERVER_TZ);

--- a/frontend/pages/CheckinCreate.tsx
+++ b/frontend/pages/CheckinCreate.tsx
@@ -39,7 +39,9 @@ export const CheckinCreate: React.FC = () => {
     const handleSubmit: SubmitHandler = async (values) => {
         try {
             const createdCheckin = await postCheckin.mutateAsync({
-                checked_in_at: `${values.date.replace(/\//g, '-')}T${values.time}:00+09:00`,
+                checked_in_at: values.is_realtime
+                    ? undefined
+                    : `${values.date.replace(/\//g, '-')}T${values.time}:00+09:00`,
                 link: values.link,
                 note: values.note,
                 tags: values.tags,

--- a/frontend/pages/CheckinCreate.tsx
+++ b/frontend/pages/CheckinCreate.tsx
@@ -7,19 +7,21 @@ import {
     SubmitHandler,
 } from '../features/checkins/CheckinForm';
 import { format } from 'date-fns';
+import { TZDate } from '@date-fns/tz';
 import { ExternalLink } from '../components/ui/ExternalLink';
 import { usePostCheckin } from '../api/mutation';
 import { ResponseError } from '../api/errors';
 import { toast } from 'sonner';
 import { useNavigate, useSearchParams } from 'react-router';
 import { Container } from '../components/Container';
+import { SERVER_TZ } from '../lib/time';
 
 export const CheckinCreate: React.FC = () => {
     const [searchParams] = useSearchParams();
     const navigate = useNavigate();
     const postCheckin = usePostCheckin();
 
-    const now = new Date();
+    const now = TZDate.tz(SERVER_TZ);
     const initialValues: Partial<CheckinFormValues> = {
         date: searchParams.get('date')?.replace(/\//g, '-') || format(now, 'yyyy-MM-dd'),
         time: searchParams.get('time') || format(now, 'HH:mm'),

--- a/frontend/pages/CheckinEdit.tsx
+++ b/frontend/pages/CheckinEdit.tsx
@@ -15,6 +15,7 @@ import { LoaderData } from './CheckinEdit.loader';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { getCheckinQuery } from '../api/query';
 import { Container } from '../components/Container';
+import { serverTz } from '../lib/time';
 
 export const CheckinEdit: React.FC = () => {
     const navigate = useNavigate();
@@ -23,8 +24,8 @@ export const CheckinEdit: React.FC = () => {
     const patchCheckin = usePatchCheckin();
 
     const initialValues: Partial<CheckinFormValues> = {
-        date: format(checkin.checked_in_at, 'yyyy-MM-dd'),
-        time: format(checkin.checked_in_at, 'HH:mm'),
+        date: format(checkin.checked_in_at, 'yyyy-MM-dd', { in: serverTz }),
+        time: format(checkin.checked_in_at, 'HH:mm', { in: serverTz }),
         link: checkin.link,
         tags: checkin.tags,
         note: checkin.note,

--- a/frontend/pages/Home.loader.ts
+++ b/frontend/pages/Home.loader.ts
@@ -8,6 +8,8 @@ import {
     getUserStatsTagsQuery,
 } from '../api/query';
 import { endOfMonth, formatDate, startOfMonth, subMonths } from 'date-fns';
+import { TZDate } from '@date-fns/tz';
+import { SERVER_TZ } from '../lib/time';
 
 export interface LoaderData {
     statsCheckinDailyQuery: {
@@ -26,7 +28,7 @@ export const loader = (queryClient: QueryClient) => async () => {
         return;
     }
 
-    const now = new Date();
+    const now = TZDate.tz(SERVER_TZ);
     const statsCheckinDailyQuery = {
         since: formatDate(subMonths(startOfMonth(now), 11), 'yyyy-MM-dd'),
         until: formatDate(endOfMonth(now), 'yyyy-MM-dd'),

--- a/frontend/pages/Home.tsx
+++ b/frontend/pages/Home.tsx
@@ -20,6 +20,7 @@ import { Checkin } from '../features/checkins/Checkin';
 import { Bar } from 'react-chartjs-2';
 
 import { BarController, BarElement, CategoryScale, Chart, LinearScale, Tooltip } from 'chart.js';
+import { serverTz } from '../lib/time';
 
 Chart.register([BarController, BarElement, CategoryScale, LinearScale, Tooltip]);
 
@@ -52,7 +53,7 @@ export const Home: React.FC = () => {
                                             <span className="text-primary">{info.title}</span>
                                             <span className="text-2xs text-secondary">
                                                 {' '}
-                                                - {format(info.created_at, 'M月d日')}
+                                                - {format(info.created_at, 'M月d日', { in: serverTz })}
                                             </span>
                                         </span>
                                     </a>
@@ -93,6 +94,7 @@ const CurrentSession: React.FC<CurrentSessionProps> = ({ user }) => {
                         ? `${format(
                               subSeconds(Date.now(), user.checkin_summary.current_session_elapsed),
                               'yyyy/MM/dd HH:mm',
+                              { in: serverTz },
                           )} にリセット`
                         : '計測がまだ始まっていません'}
                 </p>

--- a/frontend/pages/UserCheckins.tsx
+++ b/frontend/pages/UserCheckins.tsx
@@ -10,6 +10,8 @@ import { cn } from '../lib/cn';
 import { Container } from '../components/Container';
 import { ColumnHeader } from '../components/ColumnHeader';
 import { Checkbox } from '../components/ui/Checkbox';
+import { TZDate } from '@date-fns/tz';
+import { SERVER_TZ } from '../lib/time';
 
 export const UserCheckins: React.FC = () => {
     const params = useParams();
@@ -19,13 +21,18 @@ export const UserCheckins: React.FC = () => {
         data: { data, totalCount },
     } = useSuspenseQuery(getUserCheckinsQuery(username, checkinsQuery));
 
-    let currentDate: Date | undefined;
+    let currentDate: TZDate | undefined;
     if (params.year && params.month && params.date) {
-        currentDate = new Date(parseInt(params.year, 10), parseInt(params.month, 10) - 1, parseInt(params.date, 10));
+        currentDate = new TZDate(
+            parseInt(params.year, 10),
+            parseInt(params.month, 10) - 1,
+            parseInt(params.date, 10),
+            SERVER_TZ,
+        );
     } else if (params.year && params.month) {
-        currentDate = new Date(parseInt(params.year, 10), parseInt(params.month, 10) - 1, 1);
+        currentDate = new TZDate(parseInt(params.year, 10), parseInt(params.month, 10) - 1, 1, SERVER_TZ);
     } else if (params.year) {
-        currentDate = new Date(parseInt(params.year, 10), 0, 1);
+        currentDate = new TZDate(parseInt(params.year, 10), 0, 1, SERVER_TZ);
     }
 
     return (
@@ -123,16 +130,16 @@ export const UserCheckins: React.FC = () => {
 };
 
 interface CalendarParams {
-    initialDate?: Date;
+    initialDate?: TZDate;
 }
 
 const Calendar: React.FC<CalendarParams> = ({ initialDate }) => {
     const [searchParams] = useSearchParams();
     const { username } = useLoaderData<LoaderData>();
-    const [currentDate, setCurrentDate] = useState(initialDate || new Date());
+    const [currentDate, setCurrentDate] = useState(initialDate || TZDate.tz(SERVER_TZ));
 
     useEffect(() => {
-        setCurrentDate(initialDate || new Date());
+        setCurrentDate(initialDate || TZDate.tz(SERVER_TZ));
     }, [initialDate?.getTime()]);
 
     const { data: countByDate } = useQuery({
@@ -143,7 +150,6 @@ const Calendar: React.FC<CalendarParams> = ({ initialDate }) => {
         select: (data) => new Map(data.map((d) => [d.date, d.count])),
     });
 
-    // TODO: この実装だとクライアントのTZの影響を受ける。JST基準で描画したい。
     const cells: React.ReactNode[] = [];
     const startOfMon = startOfMonth(currentDate);
     const days = getDaysInMonth(startOfMon);

--- a/frontend/pages/UserStats.tsx
+++ b/frontend/pages/UserStats.tsx
@@ -5,6 +5,8 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { getUserStatsCheckinOldestQuery } from '../api/query';
 import { ColumnHeader } from '../components/ColumnHeader';
 import { Checkbox } from '../components/ui/Checkbox';
+import { TZDate } from '@date-fns/tz';
+import { SERVER_TZ } from '../lib/time';
 
 export const UserStats: React.FC = () => {
     const navigate = useNavigate();
@@ -17,7 +19,7 @@ export const UserStats: React.FC = () => {
     const months: (number | 'all')[] = ['all'];
     if (oldestData.oldest_checkin_date) {
         const [oldestYear, oldestMonth] = oldestData.oldest_checkin_date.split('-');
-        const now = new Date();
+        const now = TZDate.tz(SERVER_TZ);
 
         // 年セレクタの作成
         for (let y = parseInt(oldestYear, 10); y <= now.getFullYear(); y++) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@bprogress/react": "^1.2.7",
+    "@date-fns/tz": "^1.4.1",
     "@eslint/js": "^10.0.1",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@redocly/cli": "^2.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,6 +135,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz#ef28e27c1ded1d8e5c54879a9399e7055aed1920"
   integrity sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==
 
+"@date-fns/tz@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@date-fns/tz/-/tz-1.4.1.tgz#2d905f282304630e07bef6d02d2e7dbf3f0cc4e4"
+  integrity sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==
+
 "@emnapi/core@1.9.2":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.2.tgz#3870265ecffc7352d01ead62d8d83d8358a2d034"


### PR DESCRIPTION
## 概要
フロントエンドで日時を扱う際、そのタイムゾーンを Asia/Tokyo で固定します。

サーバーサイドのタイムゾーンは常に Asia/Tokyo で固定されており、SPA化以前のHTMLでは全てこれに準じて表示していたので、これにより従来通りの挙動が踏襲されます。

## 変更の背景・Issueへのリンク
- #1708

## 補足情報 (optional)

## チェックリスト
- [x] ローカル環境での動作確認を行いました
- [x] 必要に応じてテストを追加し、全てのテストが成功していることを確認しました
- [ ] (公開APIの変更を行った場合) openapi.yaml を更新しました
- [ ] (開発環境に対する破壊的な変更を行った場合) CHANGELOG_FOR_DEV.md を更新しました
