### PR TITLE
ユーザ入力経由のHTTPリクエストでプライベートIPアドレスへの接続を拒否

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use App\MetadataResolver\Resolver;
 use App\MetadataResolver\TwitterResolver;
 use App\Services\MetadataResolveService;
 use App\Utilities\ApplyProviderPolicyMiddleware;
+use App\Utilities\ValidateHostMiddleware;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\RequestOptions;
@@ -82,15 +83,20 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton('parsedown', function () {
             return Parsedown::instance();
         });
-        $this->app->bind(Client::class, function () {
+        $this->app->bind(Client::class, function ($app) {
+            $stack = HandlerStack::create();
+            $stack->push($app->make(ValidateHostMiddleware::class));
+
             return new Client([
                 RequestOptions::HEADERS => [
                     'User-Agent' => 'TissueBot/1.0'
-                ]
+                ],
+                'handler' => $stack,
             ]);
         });
         $this->app->when(MetadataResolver::class)->needs(Client::class)->give(function ($app) {
             $stack = HandlerStack::create();
+            $stack->push($app->make(ValidateHostMiddleware::class));
             $stack->push($app->make(ApplyProviderPolicyMiddleware::class));
 
             return new Client([

--- a/app/Utilities/ValidateHostMiddleware.php
+++ b/app/Utilities/ValidateHostMiddleware.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Utilities;
+
+use App\MetadataResolver\DeniedHostException;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\HttpFoundation\IpUtils;
+
+/**
+ * プライベート/予約済みIPレンジ等、許可されていないホストへのリクエストをブロックするGuzzle Middleware
+ */
+class ValidateHostMiddleware
+{
+    private const ALLOWED_SCHEMES = ['http', 'https'];
+
+    /** @var callable(string): string[] */
+    private $dnsResolver;
+
+    /** @var string[] */
+    private array $ownAddresses;
+
+    /**
+     * @param callable(string): string[]|null $dnsResolver ホスト名からIPアドレスの配列を返すcallable。nullの場合はdns_get_recordを使用。
+     */
+    public function __construct(?callable $dnsResolver = null)
+    {
+        $this->dnsResolver = $dnsResolver ?? self::defaultDnsResolver(...);
+    }
+
+    public function __invoke(callable $next): callable
+    {
+        return function (RequestInterface $request, array $options) use ($next) {
+            $uri = $request->getUri();
+            $scheme = strtolower($uri->getScheme());
+            $host = $uri->getHost();
+
+            // スキーム検証
+            if (!in_array($scheme, self::ALLOWED_SCHEMES, true)) {
+                throw new DeniedHostException((string) $uri);
+            }
+
+            // IPアドレスの正引き
+            $resolvedIps = $this->resolveHost($host);
+            if (empty($resolvedIps)) {
+                throw new DeniedHostException((string) $uri);
+            }
+
+            // すべての解決済みIPを検証
+            foreach ($resolvedIps as $ip) {
+                if (IpUtils::isPrivateIp($ip)) {
+                    throw new DeniedHostException((string) $uri);
+                }
+                if ($this->isOwnIp($ip)) {
+                    throw new DeniedHostException((string) $uri);
+                }
+            }
+
+            // CURLOPT_RESOLVEで解決済みIPを固定し、DNS rebindingを防止
+            // IPv6アドレスは [] で囲む必要がある (https://curl.se/libcurl/c/CURLOPT_RESOLVE.html)
+            $port = $uri->getPort() ?? ($scheme === 'https' ? 443 : 80);
+            $formattedIps = array_map(
+                fn (string $ip) => filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false ? "[{$ip}]" : $ip,
+                $resolvedIps
+            );
+            $ipsJoined = implode(',', $formattedIps);
+            $options['curl'][CURLOPT_RESOLVE] = [
+                ...($options['curl'][CURLOPT_RESOLVE] ?? []),
+                "{$host}:{$port}:{$ipsJoined}"
+            ];
+
+            return $next($request, $options);
+        };
+    }
+
+    /**
+     * ホスト名またはIPリテラルからIPアドレスの配列を返す。
+     * @return string[]
+     */
+    private function resolveHost(string $host): array
+    {
+        // IPv6
+        $bareHost = trim($host, '[]');
+        if (filter_var($bareHost, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            return [$bareHost];
+        }
+
+        // IPv4
+        if (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+            return [$host];
+        }
+
+        // ホスト名 → DNS解決
+        return ($this->dnsResolver)($host);
+    }
+
+    /**
+     * 指定されたIPがアプリケーション自身を指すかどうかを判定する。
+     * @param string $ip
+     * @return bool
+     */
+    private function isOwnIp(string $ip): bool
+    {
+        if (!isset($this->ownAddresses)) {
+            $appHost = parse_url(config('app.url'), PHP_URL_HOST);
+            if ($appHost === null || $appHost === false) {
+                $this->ownAddresses = [];
+
+                return false;
+            }
+
+            $this->ownAddresses = $this->resolveHost($appHost);
+        }
+
+        foreach ($this->ownAddresses as $ownAddress) {
+            if (IpUtils::checkIp($ip, $ownAddress)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * デフォルトのDNSリゾルバ。A/AAAAレコードを両方取得する。
+     * @return string[]
+     */
+    private static function defaultDnsResolver(string $hostname): array
+    {
+        $records = @dns_get_record($hostname, DNS_A | DNS_AAAA);
+        if ($records === false) {
+            return [];
+        }
+
+        $ips = [];
+        foreach ($records as $record) {
+            if (isset($record['ip'])) {
+                $ips[] = $record['ip'];
+            }
+            if (isset($record['ipv6'])) {
+                $ips[] = $record['ipv6'];
+            }
+        }
+
+        return $ips;
+    }
+}

--- a/tests/Unit/Utilities/ValidateHostMiddlewareTest.php
+++ b/tests/Unit/Utilities/ValidateHostMiddlewareTest.php
@@ -1,0 +1,236 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Utilities;
+
+use App\MetadataResolver\DeniedHostException;
+use App\Utilities\ValidateHostMiddleware;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Tests\TestCase;
+
+class ValidateHostMiddlewareTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['app.url' => '']);
+    }
+
+    private function createMiddleware(callable $dnsResolver): ValidateHostMiddleware
+    {
+        return new ValidateHostMiddleware($dnsResolver);
+    }
+
+    private function sendRequest(ValidateHostMiddleware $middleware, string $url): array
+    {
+        $capturedOptions = null;
+        $mock = new MockHandler([
+            function (Request $request, array $options) use (&$capturedOptions) {
+                $capturedOptions = $options;
+
+                return new Response(200);
+            },
+        ]);
+
+        $stack = HandlerStack::create($mock);
+        $stack->push($middleware);
+
+        $handler = $stack->resolve();
+        $handler(new Request('GET', $url), []);
+
+        return $capturedOptions ?? [];
+    }
+
+    /**
+     * @dataProvider providePrivateIpv4Addresses
+     */
+    public function testBlocksPrivateIpv4(string $ip): void
+    {
+        $this->expectException(DeniedHostException::class);
+
+        $middleware = $this->createMiddleware(fn () => [$ip]);
+        $this->sendRequest($middleware, 'https://example.com/');
+    }
+
+    public static function providePrivateIpv4Addresses(): array
+    {
+        return [
+            'loopback' => ['127.0.0.1'],
+            'loopback high' => ['127.255.255.255'],
+            'class A private' => ['10.0.0.1'],
+            'class B private' => ['172.16.0.1'],
+            'class C private' => ['192.168.1.1'],
+            'link-local' => ['169.254.1.1'],
+            'zero' => ['0.0.0.0'],
+        ];
+    }
+
+    /**
+     * @dataProvider providePrivateIpv6Addresses
+     */
+    public function testBlocksPrivateIpv6(string $ip): void
+    {
+        $this->expectException(DeniedHostException::class);
+
+        $middleware = $this->createMiddleware(fn () => [$ip]);
+        $this->sendRequest($middleware, 'https://example.com/');
+    }
+
+    public static function providePrivateIpv6Addresses(): array
+    {
+        return [
+            'loopback' => ['::1'],
+            'unique local' => ['fc00::1'],
+            'link-local' => ['fe80::1'],
+            'IPv4-mapped loopback' => ['::ffff:127.0.0.1'],
+            'IPv4-mapped class A private' => ['::ffff:10.0.0.1'],
+            'IPv4-mapped class B private' => ['::ffff:172.16.0.1'],
+            'IPv4-mapped class C private' => ['::ffff:192.168.1.1'],
+            'IPv4-mapped link-local' => ['::ffff:169.254.1.1'],
+        ];
+    }
+
+    public function testAllowsPublicIp(): void
+    {
+        $middleware = $this->createMiddleware(fn () => ['93.184.216.34']);
+        $options = $this->sendRequest($middleware, 'https://example.com/path');
+
+        $this->assertArrayHasKey(CURLOPT_RESOLVE, $options['curl']);
+        $this->assertContains('example.com:443:93.184.216.34', $options['curl'][CURLOPT_RESOLVE]);
+    }
+
+    public function testBlocksDualStackWithPrivateAddress(): void
+    {
+        $this->expectException(DeniedHostException::class);
+
+        $middleware = $this->createMiddleware(fn () => ['93.184.216.34', '::1']);
+        $this->sendRequest($middleware, 'https://example.com/');
+    }
+
+    public function testBlocksDnsResolutionFailure(): void
+    {
+        $this->expectException(DeniedHostException::class);
+
+        $middleware = $this->createMiddleware(fn () => []);
+        $this->sendRequest($middleware, 'https://example.com/');
+    }
+
+    /**
+     * @dataProvider provideBlockedSchemes
+     */
+    public function testBlocksNonHttpSchemes(string $url): void
+    {
+        $this->expectException(DeniedHostException::class);
+
+        $middleware = $this->createMiddleware(fn () => ['93.184.216.34']);
+        $this->sendRequest($middleware, $url);
+    }
+
+    public static function provideBlockedSchemes(): array
+    {
+        return [
+            'file' => ['file:///etc/passwd'],
+            'gopher' => ['gopher://evil.com/'],
+            'ftp' => ['ftp://evil.com/'],
+            'data' => ['data://text/plain;base64,SGVsbG8='],
+        ];
+    }
+
+    public function testBlocksIpv4Literal(): void
+    {
+        $this->expectException(DeniedHostException::class);
+
+        // DNSリゾルバは呼ばれないはず
+        $middleware = $this->createMiddleware(function () {
+            $this->fail('DNS resolver should not be called for IP literals');
+        });
+        $this->sendRequest($middleware, 'http://127.0.0.1/admin');
+    }
+
+    public function testBlocksIpv6Literal(): void
+    {
+        $this->expectException(DeniedHostException::class);
+
+        $middleware = $this->createMiddleware(function () {
+            $this->fail('DNS resolver should not be called for IP literals');
+        });
+        $this->sendRequest($middleware, 'http://[::1]/admin');
+    }
+
+    public function testAllowsPublicIpv4Literal(): void
+    {
+        $middleware = $this->createMiddleware(function () {
+            $this->fail('DNS resolver should not be called for IP literals');
+        });
+        $options = $this->sendRequest($middleware, 'http://93.184.216.34/path');
+
+        $this->assertArrayHasKey(CURLOPT_RESOLVE, $options['curl']);
+    }
+
+    public function testBlocksOwnIp(): void
+    {
+        $this->expectException(DeniedHostException::class);
+
+        config(['app.url' => 'https://tissue.example.com']);
+
+        // tissue.example.comとevil.comが同じIPに解決される
+        $middleware = $this->createMiddleware(fn () => ['203.0.113.50']);
+        $this->sendRequest($middleware, 'https://evil.com/');
+    }
+
+    public function testBlocksOwnIpv6(): void
+    {
+        $this->expectException(DeniedHostException::class);
+
+        config(['app.url' => 'https://tissue.example.com']);
+
+        $middleware = $this->createMiddleware(fn (string $host) => match ($host) {
+            'tissue.example.com' => ['2001:db8::1'],
+            default => ['2001:db8::1'],
+        });
+        $this->sendRequest($middleware, 'https://evil.com/');
+    }
+
+    public function testAllowsDifferentIpFromOwn(): void
+    {
+        config(['app.url' => 'https://tissue.example.com']);
+
+        $middleware = $this->createMiddleware(fn (string $host) => match ($host) {
+            'tissue.example.com' => ['203.0.113.50'],
+            default => ['198.51.100.10'],
+        });
+        $options = $this->sendRequest($middleware, 'https://other.com/');
+
+        $this->assertArrayHasKey(CURLOPT_RESOLVE, $options['curl']);
+    }
+
+    public function testOwnAddressCheckSkippedWhenAppUrlNotConfigured(): void
+    {
+        config(['app.url' => '']);
+
+        $middleware = $this->createMiddleware(fn () => ['198.51.100.10']);
+        $options = $this->sendRequest($middleware, 'https://example.com/');
+
+        $this->assertArrayHasKey(CURLOPT_RESOLVE, $options['curl']);
+    }
+
+    public function testSetsCurloptResolveWithCorrectPort(): void
+    {
+        $middleware = $this->createMiddleware(fn () => ['93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946']);
+
+        // HTTP → port 80, カンマ区切りで1エントリ、IPv6は[]で囲む
+        $httpOptions = $this->sendRequest($middleware, 'http://example.com/');
+        $this->assertContains('example.com:80:93.184.216.34,[2606:2800:220:1:248:1893:25c8:1946]', $httpOptions['curl'][CURLOPT_RESOLVE]);
+
+        // HTTPS → port 443
+        $httpsOptions = $this->sendRequest($middleware, 'https://example.com/');
+        $this->assertContains('example.com:443:93.184.216.34,[2606:2800:220:1:248:1893:25c8:1946]', $httpsOptions['curl'][CURLOPT_RESOLVE]);
+
+        // Custom port
+        $customOptions = $this->sendRequest($middleware, 'https://example.com:8443/');
+        $this->assertContains('example.com:8443:93.184.216.34,[2606:2800:220:1:248:1893:25c8:1946]', $customOptions['curl'][CURLOPT_RESOLVE]);
+    }
+}


### PR DESCRIPTION
## 概要
https://github.com/shikorism/tissue/pull/443 の強化版。

Guzzleミドルウェアで接続先のIPアドレスを正引きし、それが[プライベートアドレス](https://www.php.net/manual/ja/filter.constants.php#constant.filter-flag-no-priv-range)や[予約済みアドレス](https://www.php.net/manual/ja/filter.constants.php#constant.filter-flag-no-res-range)、または `APP_URL` から正引きできるアドレスだった場合に接続を拒否します。

## 変更の背景・Issueへのリンク
#219 の開発中にMetadataResolverもこの辺適当だったのを思い出して、個別のパッチとして切り出した。

## 補足情報 (optional)

## チェックリスト
- [x] ローカル環境での動作確認を行いました
- [x] 必要に応じてテストを追加し、全てのテストが成功していることを確認しました
- [ ] (公開APIの変更を行った場合) openapi.yaml を更新しました
- [ ] (開発環境に対する破壊的な変更を行った場合) CHANGELOG_FOR_DEV.md を更新しました
