### PR TITLE
年間の最も使ったオカズランキングの表示を復旧

### DIFF
--- a/frontend/api/query.ts
+++ b/frontend/api/query.ts
@@ -29,6 +29,18 @@ export const getUserQuery = (username: string) =>
                 .then((response) => ensure(response.data)),
     });
 
+export const getUserStatsLinksQuery = (
+    username: string,
+    query?: paths['/users/{username}/stats/links']['get']['parameters']['query'],
+) =>
+    queryOptions({
+        queryKey: ['/users/{username}/stats/links', username, query],
+        queryFn: () =>
+            fetchClient
+                .GET('/users/{username}/stats/links', { params: { path: { username }, query } })
+                .then((response) => ensure(response.data)),
+    });
+
 export const getUserStatsTagsQuery = (
     username: string,
     query?: paths['/users/{username}/stats/tags']['get']['parameters']['query'],

--- a/frontend/pages/UserStatsYearly.loader.ts
+++ b/frontend/pages/UserStatsYearly.loader.ts
@@ -1,6 +1,11 @@
 import { QueryClient } from '@tanstack/react-query';
 import { LoaderFunctionArgs } from 'react-router';
-import { getUserStatsCheckinDailyQuery, getUserStatsCheckinHourlyQuery, getUserStatsTagsQuery } from '../api/query';
+import {
+    getUserStatsCheckinDailyQuery,
+    getUserStatsCheckinHourlyQuery,
+    getUserStatsLinksQuery,
+    getUserStatsTagsQuery,
+} from '../api/query';
 
 export interface LoaderData {
     username: string;
@@ -37,6 +42,7 @@ export const loader =
             queryClient.ensureQueryData(getUserStatsCheckinHourlyQuery(username, query)),
             queryClient.ensureQueryData(getUserStatsTagsQuery(username, query)),
             queryClient.ensureQueryData(getUserStatsTagsQuery(username, { ...query, includes_metadata: true })),
+            queryClient.ensureQueryData(getUserStatsLinksQuery(username, query)),
         ];
         if (prevQuery) {
             promises.push(queryClient.ensureQueryData(getUserStatsCheckinDailyQuery(username, prevQuery)));

--- a/frontend/pages/UserStatsYearly.tsx
+++ b/frontend/pages/UserStatsYearly.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query';
-import { useLoaderData, useParams } from 'react-router';
-import { getUserStatsCheckinDailyQuery, getUserStatsCheckinHourlyQuery, getUserStatsTagsQuery } from '../api/query';
+import { Link, useLoaderData, useParams } from 'react-router';
+import {
+    getUserStatsCheckinDailyQuery,
+    getUserStatsCheckinHourlyQuery,
+    getUserStatsLinksQuery,
+    getUserStatsTagsQuery,
+} from '../api/query';
 import { LoaderData } from './UserStatsYearly.loader';
 import { MonthlyChart } from '../features/user-stats/MonthlyChart';
 import { HourlyChart } from '../features/user-stats/HourlyChart';
@@ -10,6 +15,8 @@ import { TagRanking } from '../features/user-stats/TagRanking';
 import { Pill } from '../components/ui/Pill';
 import { CheckinHeatmap } from '../features/user-stats/CheckinHeatmap';
 import { ColumnHeader } from '../components/ColumnHeader';
+import { LinkCard } from '../components/LinkCard';
+import { ExternalLink } from '../components/ui/ExternalLink';
 
 export const UserStatsYearly: React.FC = () => {
     const { year } = useParams();
@@ -24,6 +31,7 @@ export const UserStatsYearly: React.FC = () => {
     const { data: mostlyUsedTagsIncludesMeta } = useSuspenseQuery(
         getUserStatsTagsQuery(username, { ...query, includes_metadata: true }),
     );
+    const { data: mostlyUsedLinks } = useSuspenseQuery(getUserStatsLinksQuery(username, query));
 
     return (
         <div className="px-4 lg:w-[480px] xl:w-[740px]">
@@ -71,6 +79,44 @@ export const UserStatsYearly: React.FC = () => {
                             <TagRanking className="w-full" tags={mostlyUsedTagsIncludesMeta} />
                         </div>
                     </div>
+                </div>
+                <div>
+                    <h2 className="text-xl font-bold mb-2">最も使ったオカズ</h2>
+                    <p className="text-secondary text-sm mb-4">2回以上使用したオカズのみ集計しています。</p>
+                    {mostlyUsedLinks.length > 0 ? (
+                        <ul>
+                            {mostlyUsedLinks.map((item, index) => (
+                                <li key={item.link} className="border-b border-gray-border py-3">
+                                    <p className="mb-2">
+                                        <span className="inline-block min-w-13 text-center px-3 py-1 rounded-lg bg-primary text-white text-2xl font-bold mr-3">
+                                            {index + 1}
+                                        </span>
+                                        <span className="text-2xl font-bold mr-1">{item.count}</span>回
+                                    </p>
+                                    <LinkCard className="mb-2" link={item.link} />
+                                    <div className="flex items-center gap-2">
+                                        <ExternalLink className="overflow-hidden text-sm" href={item.link}>
+                                            {item.link}
+                                        </ExternalLink>
+                                        <Link
+                                            to={{
+                                                pathname: '/checkin',
+                                                search: `?link=${encodeURIComponent(item.link)}`,
+                                            }}
+                                            className="shrink-0 px-2 py-1 text-secondary"
+                                            title="同じオカズでチェックイン"
+                                        >
+                                            <i className="ti ti-reload" />
+                                        </Link>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="text-secondary">
+                            この期間のチェックインが無いか、2回以上使用したオカズがありません。
+                        </p>
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/pages/UserStatsYearly.tsx
+++ b/frontend/pages/UserStatsYearly.tsx
@@ -86,24 +86,27 @@ export const UserStatsYearly: React.FC = () => {
                     {mostlyUsedLinks.length > 0 ? (
                         <ul>
                             {mostlyUsedLinks.map((item, index) => (
-                                <li key={item.link} className="border-b border-gray-border py-3">
-                                    <p className="mb-2">
+                                <li key={item.link} className="flex flex-col gap-2 border-b border-gray-border py-3">
+                                    <p>
                                         <span className="inline-block min-w-13 text-center px-3 py-1 rounded-lg bg-primary text-white text-2xl font-bold mr-3">
                                             {index + 1}
                                         </span>
                                         <span className="text-2xl font-bold mr-1">{item.count}</span>回
                                     </p>
-                                    <LinkCard className="mb-2" link={item.link} />
-                                    <div className="flex items-center gap-2">
-                                        <ExternalLink className="overflow-hidden text-sm" href={item.link}>
+                                    <LinkCard link={item.link} />
+                                    <div className="flex items-baseline">
+                                        <i className="ti ti-link mr-1" />
+                                        <ExternalLink className="overflow-hidden" href={item.link}>
                                             {item.link}
                                         </ExternalLink>
+                                    </div>
+                                    <div className="flex">
                                         <Link
                                             to={{
                                                 pathname: '/checkin',
                                                 search: `?link=${encodeURIComponent(item.link)}`,
                                             }}
-                                            className="shrink-0 px-2 py-1 text-secondary"
+                                            className="px-4 py-2 text-xl text-secondary rounded outline-2 outline-primary/0 focus:outline-primary/40 active:outline-primary/40 cursor-pointer"
                                             title="同じオカズでチェックイン"
                                         >
                                             <i className="ti ti-reload" />


### PR DESCRIPTION
## 概要
年間グラフページの「最も使ったオカズ」ランキングがSPA化の際に消失してしまっていたため、復旧しました。

<img width="2784" height="2372" alt="image" src="https://github.com/user-attachments/assets/a515ddcc-1b73-41a8-a5af-9f8ace82a948" />


## 変更の背景・Issueへのリンク
- fix #1741

## 補足情報 (optional)

## チェックリスト
- [x] ローカル環境での動作確認を行いました
- [x] 必要に応じてテストを追加し、全てのテストが成功していることを確認しました
- [ ] (公開APIの変更を行った場合) openapi.yaml を更新しました
- [ ] (開発環境に対する破壊的な変更を行った場合) CHANGELOG_FOR_DEV.md を更新しました
