### PR TITLE
Outgoing Webhook

### DIFF
--- a/app/Events/CheckinCreated.php
+++ b/app/Events/CheckinCreated.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Ejaculation;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CheckinCreated
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public readonly Ejaculation $ejaculation)
+    {
+    }
+}

--- a/app/Events/CheckinDeleted.php
+++ b/app/Events/CheckinDeleted.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Ejaculation;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CheckinDeleted
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public readonly Ejaculation $ejaculation)
+    {
+    }
+}

--- a/app/Events/CheckinUpdated.php
+++ b/app/Events/CheckinUpdated.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Ejaculation;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CheckinUpdated
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public readonly Ejaculation $ejaculation)
+    {
+    }
+}

--- a/app/Http/Controllers/Api/V1/CheckinController.php
+++ b/app/Http/Controllers/Api/V1/CheckinController.php
@@ -3,6 +3,9 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Ejaculation;
+use App\Events\CheckinCreated;
+use App\Events\CheckinDeleted;
+use App\Events\CheckinUpdated;
 use App\Events\LinkDiscovered;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\CheckinStoreRequest;
@@ -57,6 +60,8 @@ class CheckinController extends Controller
 
             return $ejaculation;
         });
+
+        CheckinCreated::dispatch($ejaculation);
 
         if (!empty($ejaculation->link)) {
             event(new LinkDiscovered($ejaculation->link));
@@ -131,6 +136,8 @@ class CheckinController extends Controller
             }
         });
 
+        CheckinUpdated::dispatch($checkin);
+
         if (!empty($checkin->link)) {
             event(new LinkDiscovered($checkin->link));
         }
@@ -149,6 +156,8 @@ class CheckinController extends Controller
                 $ejaculation->tags()->detach();
                 $ejaculation->delete();
             });
+
+            CheckinDeleted::dispatch($ejaculation);
         }
 
         return response()->noContent();

--- a/app/Http/Controllers/Api/WebhookController.php
+++ b/app/Http/Controllers/Api/WebhookController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\CheckinWebhook;
 use App\Ejaculation;
+use App\Events\CheckinCreated;
 use App\Events\LinkDiscovered;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\EjaculationResource;
@@ -92,6 +93,8 @@ class WebhookController extends Controller
 
             return $ejaculation;
         });
+
+        CheckinCreated::dispatch($ejaculation);
 
         if (!empty($ejaculation->link)) {
             event(new LinkDiscovered($ejaculation->link));

--- a/app/Http/Controllers/Setting/OutgoingWebhookController.php
+++ b/app/Http/Controllers/Setting/OutgoingWebhookController.php
@@ -56,11 +56,15 @@ class OutgoingWebhookController extends Controller
 
     public function edit(OutgoingWebhook $webhook)
     {
+        $this->authorize('view', $webhook);
+
         return view('setting.outgoing-webhook.edit')->with(compact('webhook'));
     }
 
     public function update(OutgoingWebhook $webhook, Request $request)
     {
+        $this->authorize('update', $webhook);
+
         $validated = $request->validate([
             'name' => [
                 'required',
@@ -87,6 +91,7 @@ class OutgoingWebhookController extends Controller
 
     public function destroy(OutgoingWebhook $webhook)
     {
+        $this->authorize('delete', $webhook);
         $webhook->delete();
 
         return redirect()->route('setting.outgoing-webhooks')->with('status', '削除しました。');

--- a/app/Http/Controllers/Setting/OutgoingWebhookController.php
+++ b/app/Http/Controllers/Setting/OutgoingWebhookController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers\Setting;
+
+use App\Http\Controllers\Controller;
+use App\OutgoingWebhook;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+
+class OutgoingWebhookController extends Controller
+{
+    public function index()
+    {
+        $webhooks = Auth::user()->outgoingWebhooks;
+        $webhooksLimit = OutgoingWebhook::PER_USER_LIMIT;
+
+        return view('setting.outgoing-webhook.index')->with(compact('webhooks', 'webhooksLimit'));
+    }
+
+    public function create()
+    {
+        return view('setting.outgoing-webhook.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('outgoing_webhooks', 'name')->where(function ($query) {
+                    return $query->where('user_id', Auth::id());
+                })
+            ],
+            'url' => 'required|url|max:2000',
+            'is_active' => 'nullable|boolean',
+            'on_checkin_created' => 'nullable|boolean',
+            'on_checkin_updated' => 'nullable|boolean',
+            'on_checkin_deleted' => 'nullable|boolean',
+        ], [], [
+            'name' => '名前',
+            'url' => 'URL',
+        ]);
+
+        if (Auth::user()->outgoingWebhooks()->count() >= OutgoingWebhook::PER_USER_LIMIT) {
+            return redirect()->route('setting.outgoing-webhooks.create')
+                ->with('status', OutgoingWebhook::PER_USER_LIMIT . '件以上のWebhookを登録することはできません。');
+        }
+
+        Auth::user()->outgoingWebhooks()->create($validated);
+
+        return redirect()->route('setting.outgoing-webhooks')->with('status', '登録しました。');
+    }
+
+    public function edit(OutgoingWebhook $webhook)
+    {
+        return view('setting.outgoing-webhook.edit')->with(compact('webhook'));
+    }
+
+    public function update(OutgoingWebhook $webhook, Request $request)
+    {
+        $validated = $request->validate([
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('outgoing_webhooks', 'name')->where(function ($query) use ($webhook) {
+                    return $query->where('user_id', Auth::id())->where('id', '<>', $webhook->id);
+                })
+            ],
+            'url' => 'required|url|max:2000',
+            'is_active' => 'nullable|boolean',
+            'on_checkin_created' => 'nullable|boolean',
+            'on_checkin_updated' => 'nullable|boolean',
+            'on_checkin_deleted' => 'nullable|boolean',
+        ], [], [
+            'name' => '名前',
+            'url' => 'URL',
+        ]);
+
+        $webhook->update($validated);
+
+        return redirect()->route('setting.outgoing-webhooks')->with('status', '更新しました。');
+    }
+
+    public function destroy(OutgoingWebhook $webhook)
+    {
+        $webhook->delete();
+
+        return redirect()->route('setting.outgoing-webhooks')->with('status', '削除しました。');
+    }
+}

--- a/app/Http/Controllers/Setting/OutgoingWebhookController.php
+++ b/app/Http/Controllers/Setting/OutgoingWebhookController.php
@@ -57,8 +57,9 @@ class OutgoingWebhookController extends Controller
     public function edit(OutgoingWebhook $webhook)
     {
         $this->authorize('view', $webhook);
+        $deliveries = $webhook->deliveries()->orderByDesc('created_at')->limit(10)->get();
 
-        return view('setting.outgoing-webhook.edit')->with(compact('webhook'));
+        return view('setting.outgoing-webhook.edit')->with(compact('webhook', 'deliveries'));
     }
 
     public function update(OutgoingWebhook $webhook, Request $request)

--- a/app/Jobs/DeliverOutgoingWebhook.php
+++ b/app/Jobs/DeliverOutgoingWebhook.php
@@ -34,6 +34,10 @@ class DeliverOutgoingWebhook implements ShouldQueue
      */
     public function handle(Client $client): void
     {
+        if (!$this->webhook->is_active) {
+            return;
+        }
+
         try {
             $headers = [
                 'Content-Type' => 'application/json',

--- a/app/Jobs/DeliverOutgoingWebhook.php
+++ b/app/Jobs/DeliverOutgoingWebhook.php
@@ -5,6 +5,7 @@ namespace App\Jobs;
 
 use App\OutgoingWebhook;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\SerializesModels;
@@ -14,6 +15,7 @@ class DeliverOutgoingWebhook implements ShouldQueue
     use Queueable, SerializesModels;
 
     public int $tries = 4;
+    public int $backoff = 300;
     public bool $deleteWhenMissingModels = true;
 
     /**
@@ -25,11 +27,6 @@ class DeliverOutgoingWebhook implements ShouldQueue
         private readonly string $deliveryId,
         private readonly string $body
     ) {
-    }
-
-    public function backoff(): array
-    {
-        return [60, 300, 1800];
     }
 
     /**
@@ -49,18 +46,17 @@ class DeliverOutgoingWebhook implements ShouldQueue
                 'headers' => $headers,
                 'body' => $this->body,
                 'timeout' => 30,
-                'http_errors' => false,
             ]);
-            $isSuccess = 200 <= $response->getStatusCode() && $response->getStatusCode() <= 299;
             $this->recordDelivery(
-                $isSuccess,
+                true,
                 $response->getStatusCode(),
                 substr($response->getBody()->getContents(), 0, 1024),
             );
-
-            if (!$isSuccess) {
-                $this->fail("Delivery failed with status code {$response->getStatusCode()}");
-            }
+        } catch (RequestException $e) {
+            $statusCode = $e->getResponse()?->getStatusCode();
+            $responseBody = $e->hasResponse() ? substr($e->getResponse()->getBody()->getContents(), 0, 1024) : null;
+            $this->recordDelivery(false, $statusCode, $responseBody);
+            throw $e;
         } catch (\Throwable $e) {
             $this->recordDelivery(false, null, 'Delivery failed due to an internal server error');
             throw $e;

--- a/app/Jobs/DeliverOutgoingWebhook.php
+++ b/app/Jobs/DeliverOutgoingWebhook.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\OutgoingWebhook;
+use GuzzleHttp\Client;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\SerializesModels;
+
+class DeliverOutgoingWebhook implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public int $tries = 4;
+    public bool $deleteWhenMissingModels = true;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        private readonly OutgoingWebhook $webhook,
+        private readonly string $eventName,
+        private readonly string $deliveryId,
+        private readonly string $body
+    ) {
+    }
+
+    public function backoff(): array
+    {
+        return [60, 300, 1800];
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(Client $client): void
+    {
+        try {
+            $headers = [
+                'Content-Type' => 'application/json',
+                'User-Agent' => 'Tissue/1.0 (webhook; +https://github.com/shikorism/tissue)',
+                'Tissue-Event' => $this->eventName,
+                'Tissue-Delivery' => $this->deliveryId,
+            ];
+
+            $response = $client->post($this->webhook->url, [
+                'headers' => $headers,
+                'body' => $this->body,
+                'timeout' => 30,
+                'http_errors' => false,
+            ]);
+            $isSuccess = 200 <= $response->getStatusCode() && $response->getStatusCode() <= 299;
+            $this->recordDelivery(
+                $isSuccess,
+                $response->getStatusCode(),
+                substr($response->getBody()->getContents(), 0, 1024),
+            );
+
+            if (!$isSuccess) {
+                $this->fail("Delivery failed with status code {$response->getStatusCode()}");
+            }
+        } catch (\Throwable $e) {
+            $this->recordDelivery(false, null, 'Delivery failed due to an internal server error');
+            throw $e;
+        }
+    }
+
+    private function recordDelivery(bool $isSuccess, ?int $statusCode, ?string $responseBody): void
+    {
+        $this->webhook->deliveries()->create([
+            'user_id' => $this->webhook->user_id,
+            'delivery_id' => $this->deliveryId,
+            'event' => $this->eventName,
+            'is_success' => $isSuccess,
+            'status_code' => $statusCode,
+            'request_body' => $this->body,
+            'response_body' => $responseBody,
+            'delivered_at' => now(),
+        ]);
+    }
+}

--- a/app/Listeners/DispatchOutgoingWebhook.php
+++ b/app/Listeners/DispatchOutgoingWebhook.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\CheckinCreated;
+use App\Events\CheckinDeleted;
+use App\Events\CheckinUpdated;
+use App\Http\Resources\EjaculationResource;
+use App\Jobs\DeliverOutgoingWebhook;
+use App\OutgoingWebhook;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Str;
+
+class DispatchOutgoingWebhook
+{
+    public function handle(CheckinCreated|CheckinUpdated|CheckinDeleted $event): void
+    {
+        $eventName = match ($event::class) {
+            CheckinCreated::class => 'checkin.created',
+            CheckinUpdated::class => 'checkin.updated',
+            CheckinDeleted::class => 'checkin.deleted',
+        };
+        $subscriptionColumn = match ($event::class) {
+            CheckinCreated::class => 'on_checkin_created',
+            CheckinUpdated::class => 'on_checkin_updated',
+            CheckinDeleted::class => 'on_checkin_deleted',
+        };
+
+        $webhooks = $event->ejaculation->user->outgoingWebhooks
+            ->where('is_active', true)
+            ->where($subscriptionColumn, true);
+        if ($webhooks->isEmpty()) {
+            return;
+        }
+
+        $deliveryId = Str::uuid()->toString();
+        $template = [
+            'event' => $eventName,
+            'delivery_id' => $deliveryId,
+            'webhook_id' => null,
+            'triggered_at' => now()->toIso8601String(),
+            'payload' => (new EjaculationResource($event->ejaculation))->jsonSerialize(),
+        ];
+
+        foreach ($webhooks as $webhook) {
+            $body = $template;
+            $body['webhook_id'] = $webhook->id;
+
+            DeliverOutgoingWebhook::dispatch(
+                $webhook,
+                $eventName,
+                $deliveryId,
+                json_encode($body, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+            );
+        }
+    }
+}

--- a/app/Listeners/DispatchOutgoingWebhook.php
+++ b/app/Listeners/DispatchOutgoingWebhook.php
@@ -36,12 +36,16 @@ class DispatchOutgoingWebhook
         }
 
         $deliveryId = Str::uuid()->toString();
+        $payload = match ($event::class) {
+            CheckinDeleted::class => ['id' => $event->ejaculation->id],
+            default => (new EjaculationResource($event->ejaculation))->jsonSerialize(),
+        };
         $template = [
             'event' => $eventName,
             'delivery_id' => $deliveryId,
             'webhook_id' => null,
             'triggered_at' => now()->toIso8601String(),
-            'payload' => (new EjaculationResource($event->ejaculation))->jsonSerialize(),
+            'payload' => $payload,
         ];
 
         foreach ($webhooks as $webhook) {

--- a/app/OutgoingWebhook.php
+++ b/app/OutgoingWebhook.php
@@ -6,5 +6,24 @@ use Illuminate\Database\Eloquent\Model;
 
 class OutgoingWebhook extends Model
 {
-    //
+    /** @var int ユーザーごとの作成数制限 */
+    const PER_USER_LIMIT = 3;
+
+    protected $fillable = [
+        'name',
+        'is_active',
+        'on_checkin_created',
+        'on_checkin_updated',
+        'on_checkin_deleted',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function deliveries()
+    {
+        return $this->hasMany(OutgoingWebhookDelivery::class);
+    }
 }

--- a/app/OutgoingWebhook.php
+++ b/app/OutgoingWebhook.php
@@ -11,6 +11,7 @@ class OutgoingWebhook extends Model
 
     protected $fillable = [
         'name',
+        'url',
         'is_active',
         'on_checkin_created',
         'on_checkin_updated',

--- a/app/OutgoingWebhook.php
+++ b/app/OutgoingWebhook.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class OutgoingWebhook extends Model
+{
+    //
+}

--- a/app/OutgoingWebhook.php
+++ b/app/OutgoingWebhook.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class OutgoingWebhook extends Model
 {
+    use HasFactory;
+
     /** @var int ユーザーごとの作成数制限 */
     const PER_USER_LIMIT = 3;
 

--- a/app/OutgoingWebhookDelivery.php
+++ b/app/OutgoingWebhookDelivery.php
@@ -6,5 +6,25 @@ use Illuminate\Database\Eloquent\Model;
 
 class OutgoingWebhookDelivery extends Model
 {
-    //
+    protected $fillable = [
+        'outgoing_webhook_id',
+        'user_id',
+        'status',
+        'delivery_id',
+        'event',
+        'is_success',
+        'status_code',
+        'request_body',
+        'response_body',
+        'delivered_at',
+    ];
+
+    protected $casts = [
+        'delivered_at' => 'datetime',
+    ];
+
+    public function outgoingWebhook()
+    {
+        return $this->belongsTo(OutgoingWebhook::class);
+    }
 }

--- a/app/OutgoingWebhookDelivery.php
+++ b/app/OutgoingWebhookDelivery.php
@@ -9,7 +9,6 @@ class OutgoingWebhookDelivery extends Model
     protected $fillable = [
         'outgoing_webhook_id',
         'user_id',
-        'status',
         'delivery_id',
         'event',
         'is_success',

--- a/app/OutgoingWebhookDelivery.php
+++ b/app/OutgoingWebhookDelivery.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class OutgoingWebhookDelivery extends Model
+{
+    //
+}

--- a/app/Policies/OutgoingWebhookPolicy.php
+++ b/app/Policies/OutgoingWebhookPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\OutgoingWebhook;
+use App\User;
+use Illuminate\Auth\Access\Response;
+
+class OutgoingWebhookPolicy
+{
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, OutgoingWebhook $outgoingWebhook): bool
+    {
+        return $user->id === $outgoingWebhook->user_id;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, OutgoingWebhook $outgoingWebhook): bool
+    {
+        return $user->id === $outgoingWebhook->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, OutgoingWebhook $outgoingWebhook): bool
+    {
+        return $user->id === $outgoingWebhook->user_id;
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Events\CheckinCreated;
+use App\Events\CheckinDeleted;
+use App\Events\CheckinUpdated;
+use App\Listeners\DispatchOutgoingWebhook;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -20,7 +24,16 @@ class EventServiceProvider extends ServiceProvider
         ],
         'App\Events\LinkDiscovered' => [
             'App\Listeners\LinkCollector'
-        ]
+        ],
+        CheckinCreated::class => [
+            DispatchOutgoingWebhook::class,
+        ],
+        CheckinUpdated::class => [
+            DispatchOutgoingWebhook::class,
+        ],
+        CheckinDeleted::class => [
+            DispatchOutgoingWebhook::class,
+        ],
     ];
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -98,6 +98,11 @@ class User extends Authenticatable
         return $this->hasMany(Collection::class)->chaperone();
     }
 
+    public function outgoingWebhooks()
+    {
+        return $this->hasMany(OutgoingWebhook::class);
+    }
+
     public function checkinSummary(): ?array
     {
         $total = $this->ejaculations()->count();

--- a/compose.yaml
+++ b/compose.yaml
@@ -28,6 +28,10 @@ services:
     <<: *php
     command: php artisan schedule:work
     ports: []
+  worker:
+    <<: *php
+    command: php artisan queue:listen -v
+    ports: []
   front:
     image: tissue-dev-web
     command: sh -c "pnpm i && pnpm run dev --host --port 4546"

--- a/database/factories/OutgoingWebhookFactory.php
+++ b/database/factories/OutgoingWebhookFactory.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\OutgoingWebhook>
+ */
+class OutgoingWebhookFactory extends Factory
+{
+    public function definition()
+    {
+        return [
+            'name' => 'Test Webhook',
+            'url' => 'https://example.com/webhook',
+            'is_active' => true,
+            'on_checkin_created' => false,
+            'on_checkin_updated' => false,
+            'on_checkin_deleted' => false,
+        ];
+    }
+}

--- a/database/migrations/2026_04_14_081912_create_jobs_table.php
+++ b/database/migrations/2026_04_14_081912_create_jobs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('jobs');
+    }
+};

--- a/database/migrations/2026_04_15_091739_create_outgoing_webhooks_table.php
+++ b/database/migrations/2026_04_15_091739_create_outgoing_webhooks_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('outgoing_webhooks', function (Blueprint $table) {
+            $table->id();
+            $table->integer('user_id');
+            $table->string('name');
+            $table->boolean('is_active')->default(true);
+            $table->boolean('on_checkin_created')->default(false);
+            $table->boolean('on_checkin_updated')->default(false);
+            $table->boolean('on_checkin_deleted')->default(false);
+            $table->timestamps();
+
+            $table->index('user_id');
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('outgoing_webhooks');
+    }
+};

--- a/database/migrations/2026_04_15_091739_create_outgoing_webhooks_table.php
+++ b/database/migrations/2026_04_15_091739_create_outgoing_webhooks_table.php
@@ -14,6 +14,7 @@ return new class() extends Migration {
             $table->id();
             $table->integer('user_id');
             $table->string('name');
+            $table->text('url');
             $table->boolean('is_active')->default(true);
             $table->boolean('on_checkin_created')->default(false);
             $table->boolean('on_checkin_updated')->default(false);

--- a/database/migrations/2026_04_16_002044_create_outgoing_webhook_deliveries_table.php
+++ b/database/migrations/2026_04_16_002044_create_outgoing_webhook_deliveries_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('outgoing_webhook_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('outgoing_webhook_id'); // ログ保全のため外部キーにしない
+            $table->integer('user_id'); // ログ保全のため外部キーにしない
+            $table->uuid('delivery_id');
+            $table->string('event');
+            $table->boolean('is_success');
+            $table->integer('status_code')->nullable();
+            $table->text('request_body');
+            $table->text('response_body')->nullable();
+            $table->dateTime('delivered_at');
+            $table->timestamps();
+
+            $table->index('outgoing_webhook_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('outgoing_webhook_deliveries');
+    }
+};

--- a/database/migrations/2026_04_18_095739_create_failed_jobs_table.php
+++ b/database/migrations/2026_04_18_095739_create_failed_jobs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('failed_jobs');
+    }
+};

--- a/docker/production/sample/compose.yaml
+++ b/docker/production/sample/compose.yaml
@@ -21,3 +21,7 @@ services:
   scheduler:
     <<: *php
     command: php artisan schedule:work
+
+  worker:
+    <<: *php
+    command: php artisan queue:work

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   title: Tissue API
   description: |
@@ -1109,6 +1109,144 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/CollectionItem'
+webhooks:
+  checkin.created:
+    post:
+      summary: checkin.created
+      description: |
+        ### チェックインの登録
+
+        ユーザーがチェックインを登録した際に配信されるイベントです。
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - event
+                - delivery_id
+                - webhook_id
+                - triggered_at
+                - payload
+              properties:
+                event:
+                  type: string
+                  description: イベント名
+                  example: checkin.created
+                delivery_id:
+                  type: string
+                  format: uuid
+                  description: イベントごとの一意なID
+                webhook_id:
+                  type: integer
+                  description: Webhook設定のID
+                triggered_at:
+                  type: string
+                  format: date-time
+                  description: イベントの発生日時
+                payload:
+                  $ref: '#/components/schemas/Checkin'
+      responses:
+        2XX:
+          description: 200番台のステータスコードを返すと、成功として記録されます。
+        default:
+          description: |
+            それ以外のステータスコードを返すと、失敗として記録されます。
+            失敗時は5分おきに、最大3回リトライされます。
+  checkin.updated:
+    post:
+      summary: checkin.updated
+      description: |
+        ### チェックインの更新
+
+        ユーザーがチェックインを更新した際に配信されるイベントです。
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - event
+                - delivery_id
+                - webhook_id
+                - triggered_at
+                - payload
+              properties:
+                event:
+                  type: string
+                  description: イベント名
+                  example: checkin.updated
+                delivery_id:
+                  type: string
+                  format: uuid
+                  description: イベントごとの一意なID
+                webhook_id:
+                  type: integer
+                  description: Webhook設定のID
+                triggered_at:
+                  type: string
+                  format: date-time
+                  description: イベントの発生日時
+                payload:
+                  $ref: '#/components/schemas/Checkin'
+      responses:
+        2XX:
+          description: 200番台のステータスコードを返すと、成功として記録されます。
+        default:
+          description: |
+            それ以外のステータスコードを返すと、失敗として記録されます。
+            失敗時は5分おきに、最大3回リトライされます。
+  checkin.deleted:
+    post:
+      summary: checkin.deleted
+      description: |
+        ### チェックインの削除
+
+        ユーザーがチェックインを削除した際に配信されるイベントです。
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - event
+                - delivery_id
+                - webhook_id
+                - triggered_at
+                - payload
+              properties:
+                event:
+                  type: string
+                  description: イベント名
+                  example: checkin.deleted
+                delivery_id:
+                  type: string
+                  format: uuid
+                  description: イベントごとの一意なID
+                webhook_id:
+                  type: integer
+                  description: Webhook設定のID
+                triggered_at:
+                  type: string
+                  format: date-time
+                  description: イベントの発生日時
+                payload:
+                  type: object
+                  description: チェックインデータ
+                  required:
+                    - id
+                  properties:
+                    id:
+                      type: integer
+                      format: int64
+                      description: チェックインID
+      responses:
+        2XX:
+          description: 200番台のステータスコードを返すと、成功として記録されます。
+        default:
+          description: |
+            それ以外のステータスコードを返すと、失敗として記録されます。
+            失敗時は5分おきに、最大3回リトライされます。
 components:
   schemas:
     User:

--- a/resources/views/setting/base.blade.php
+++ b/resources/views/setting/base.blade.php
@@ -23,7 +23,9 @@
                 <div class="list-group mt-4">
                     <div class="list-group-item disabled font-weight-bold">アプリ連携</div>
                     <a class="list-group-item list-group-item-action {{ Route::currentRouteName() === 'setting.webhooks' ? 'active' : '' }}"
-                       href="{{ route('setting.webhooks') }}"><i class="ti ti-webhook mr-1"></i> Webhook</a>
+                       href="{{ route('setting.webhooks') }}"><i class="ti ti-webhook mr-1"></i> Incoming Webhook</a>
+                    <a class="list-group-item list-group-item-action {{ str_starts_with(Route::currentRouteName(), 'setting.outgoing-webhooks') ? 'active' : '' }}"
+                       href="{{ route('setting.outgoing-webhooks') }}"><i class="ti ti-webhook mr-1"></i> Outgoing Webhook</a>
                     <a class="list-group-item list-group-item-action {{ Route::currentRouteName() === 'setting.tokens' ? 'active' : '' }}"
                        href="{{ route('setting.tokens') }}"><i class="ti ti-key mr-1"></i> 個人用アクセストークン</a>
                 </div>

--- a/resources/views/setting/outgoing-webhook/create.blade.php
+++ b/resources/views/setting/outgoing-webhook/create.blade.php
@@ -1,0 +1,59 @@
+@extends('setting.base')
+
+@section('title', 'Outgoing Webhook')
+
+@section('tab-content')
+    <h3><span class="text-secondary">Outgoing Webhook / </span>新規登録</h3>
+    <hr>
+    <form action="{{ route('setting.outgoing-webhooks.store') }}" method="post">
+        {{ csrf_field() }}
+
+        <div class="form-group">
+            <label for="name">名前 (メモ)</label>
+            <input id="name" class="form-control {{ $errors->has('name') ? ' is-invalid' : '' }}" name="name" type="text" value="{{ old('name') }}" autocomplete="off" required>
+            <small class="form-text text-muted">後で分かるように名前を付けておきましょう。</small>
+            @if ($errors->has('name'))
+                <div class="invalid-feedback">{{ $errors->first('name') }}</div>
+            @endif
+        </div>
+
+        <div class="form-group">
+            <label for="url">送信先URL</label>
+            <input id="url" class="form-control {{ $errors->has('url') ? ' is-invalid' : '' }}" name="url" type="text" value="{{ old('url') }}" required>
+            @if ($errors->has('url'))
+                <div class="invalid-feedback">{{ $errors->first('url') }}</div>
+            @endif
+        </div>
+
+        <div class="mb-3">
+            <p class="mb-1">購読するイベント</p>
+            <p class="mb-2 small text-muted">ここで指定したイベントの発生時に通知が送信されます。</p>
+
+            <div class="custom-control custom-checkbox mb-1">
+                <input type="hidden" name="on_checkin_created" value="0">
+                <input id="on_checkin_created" name="on_checkin_created" type="checkbox" class="custom-control-input" value="1" {{ old('on_checkin_created', false) ? 'checked' : '' }}>
+                <label class="custom-control-label" for="on_checkin_created">チェックインの登録</label>
+            </div>
+            <div class="custom-control custom-checkbox mb-1">
+                <input type="hidden" name="on_checkin_updated" value="0">
+                <input id="on_checkin_updated" name="on_checkin_updated" type="checkbox" class="custom-control-input" value="1" {{ old('on_checkin_updated', false) ? 'checked' : '' }}>
+                <label class="custom-control-label" for="on_checkin_updated">チェックインの編集</label>
+            </div>
+            <div class="custom-control custom-checkbox mb-1">
+                <input type="hidden" name="on_checkin_deleted" value="0">
+                <input id="on_checkin_deleted" name="on_checkin_deleted" type="checkbox" class="custom-control-input" value="1" {{ old('on_checkin_deleted', false) ? 'checked' : '' }}>
+                <label class="custom-control-label" for="on_checkin_deleted">チェックインの削除</label>
+            </div>
+        </div>
+
+        <hr>
+
+        <div class="custom-control custom-checkbox mb-3">
+            <input type="hidden" name="is_active" value="0">
+            <input id="is_active" name="is_active" type="checkbox" class="custom-control-input" value="1" {{ old('is_active', true) ? 'checked' : '' }}>
+            <label class="custom-control-label" for="is_active">有効</label>
+        </div>
+
+        <button class="btn btn-primary" type="submit">登録</button>
+    </form>
+@endsection

--- a/resources/views/setting/outgoing-webhook/edit.blade.php
+++ b/resources/views/setting/outgoing-webhook/edit.blade.php
@@ -1,0 +1,78 @@
+@extends('setting.base')
+
+@section('title', 'Outgoing Webhook')
+
+@section('tab-content')
+    <h3><span class="text-secondary">Outgoing Webhook / </span>編集</h3>
+    <hr>
+    <form action="{{ route('setting.outgoing-webhooks.update', ['webhook' => $webhook->id]) }}" method="post">
+        {{ method_field('PUT') }}
+        {{ csrf_field() }}
+
+        <div class="form-group">
+            <label for="name">名前 (メモ)</label>
+            <input id="name" class="form-control {{ $errors->has('name') ? ' is-invalid' : '' }}" name="name" type="text" value="{{ old('name', $webhook->name) }}" autocomplete="off" required>
+            <small class="form-text text-muted">後で分かるように名前を付けておきましょう。</small>
+            @if ($errors->has('name'))
+                <div class="invalid-feedback">{{ $errors->first('name') }}</div>
+            @endif
+        </div>
+
+        <div class="form-group">
+            <label for="url">送信先URL</label>
+            <input id="url" class="form-control {{ $errors->has('url') ? ' is-invalid' : '' }}" name="url" type="text" value="{{ old('url', $webhook->url) }}" required>
+            @if ($errors->has('url'))
+                <div class="invalid-feedback">{{ $errors->first('url') }}</div>
+            @endif
+        </div>
+
+        <div class="mb-3">
+            <p class="mb-1">購読するイベント</p>
+            <p class="mb-2 small text-muted">ここで指定したイベントの発生時に通知が送信されます。</p>
+
+            <div class="custom-control custom-checkbox mb-1">
+                <input type="hidden" name="on_checkin_created" value="0">
+                <input id="on_checkin_created" name="on_checkin_created" type="checkbox" class="custom-control-input" value="1" {{ old('on_checkin_created', $webhook->on_checkin_created) ? 'checked' : '' }}>
+                <label class="custom-control-label" for="on_checkin_created">チェックインの登録</label>
+            </div>
+            <div class="custom-control custom-checkbox mb-1">
+                <input type="hidden" name="on_checkin_updated" value="0">
+                <input id="on_checkin_updated" name="on_checkin_updated" type="checkbox" class="custom-control-input" value="1" {{ old('on_checkin_updated', $webhook->on_checkin_updated) ? 'checked' : '' }}>
+                <label class="custom-control-label" for="on_checkin_updated">チェックインの編集</label>
+            </div>
+            <div class="custom-control custom-checkbox mb-1">
+                <input type="hidden" name="on_checkin_deleted" value="0">
+                <input id="on_checkin_deleted" name="on_checkin_deleted" type="checkbox" class="custom-control-input" value="1" {{ old('on_checkin_deleted', $webhook->on_checkin_deleted) ? 'checked' : '' }}>
+                <label class="custom-control-label" for="on_checkin_deleted">チェックインの削除</label>
+            </div>
+        </div>
+
+        <hr>
+
+        <div class="custom-control custom-checkbox mb-3">
+            <input type="hidden" name="is_active" value="0">
+            <input id="is_active" name="is_active" type="checkbox" class="custom-control-input" value="1" {{ old('is_active', $webhook->is_active) ? 'checked' : '' }}>
+            <label class="custom-control-label" for="is_active">有効</label>
+        </div>
+
+        <div class="d-flex justify-content-between">
+            <button class="btn btn-primary" type="submit">更新</button>
+            <button class="btn btn-outline-danger" type="button" data-toggle="modal" data-target="#deleteModal">削除</button>
+        </div>
+    </form>
+
+    @component('components.modal', ['id' => 'deleteModal'])
+        @slot('title')
+            削除確認
+        @endslot
+        Webhookを削除してもよろしいですか？
+        @slot('footer')
+            <form action="{{ route('setting.outgoing-webhooks.destroy', ['webhook' => $webhook->id]) }}" method="post">
+                {{ csrf_field() }}
+                {{ method_field('DELETE') }}
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">キャンセル</button>
+                <button type="submit" class="btn btn-danger">削除</button>
+            </form>
+        @endslot
+    @endcomponent
+@endsection

--- a/resources/views/setting/outgoing-webhook/edit.blade.php
+++ b/resources/views/setting/outgoing-webhook/edit.blade.php
@@ -61,6 +61,33 @@
         </div>
     </form>
 
+    <h3 class="mt-5">送信履歴</h3>
+    <hr>
+    <p>直近10件のWebhook送信履歴を確認することができます。</p>
+    @forelse($webhook->deliveries()->orderBy('id', 'desc')->limit(10)->get() as $delivery)
+        <div class="card mb-3">
+            <div class="card-body">
+                <p class="mb-1"><b>送信日時</b>: {{ $delivery->created_at->format('Y/m/d H:i:s') }}</p>
+                <p class="mb-1"><b>結果</b>:
+                    @if ($delivery->is_success)
+                        <span class="text-success font-weight-bold">成功</span>
+                    @else
+                        <span class="text-danger font-weight-bold">失敗</span>
+                    @endif
+                </p>
+                <p class="mb-1"><b>イベント</b>: <code class="px-2 py-1 bg-light border rounded">{{ $delivery->event }}</code></p>
+                <p class="mb-1"><b>Delivery ID</b>: <code class="px-2 py-1 bg-light border rounded">{{ $delivery->delivery_id }}</code></p>
+                <p class="mb-1"><b>リクエストボディ</b>:</p>
+                <pre class="p-2 bg-light border rounded">{{ json_encode(json_decode($delivery->request_body, true), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) }}</pre>
+                <p class="mb-1"><b>ステータスコード</b>: <code class="px-2 py-1 bg-light border rounded">{{ $delivery->status_code ?? '-' }}</code></p>
+                <p class="mb-1"><b>レスポンスボディ</b>:</p>
+                <pre class="p-2 bg-light border rounded">{{ $delivery->response_body }}</pre>
+            </div>
+        </div>
+    @empty
+        <p class="font-weight-bold">送信履歴がありません。</p>
+    @endforelse
+
     @component('components.modal', ['id' => 'deleteModal'])
         @slot('title')
             削除確認

--- a/resources/views/setting/outgoing-webhook/edit.blade.php
+++ b/resources/views/setting/outgoing-webhook/edit.blade.php
@@ -64,7 +64,7 @@
     <h3 class="mt-5">送信履歴</h3>
     <hr>
     <p>直近10件のWebhook送信履歴を確認することができます。</p>
-    @forelse($webhook->deliveries()->orderBy('id', 'desc')->limit(10)->get() as $delivery)
+    @forelse($deliveries as $delivery)
         <div class="card mb-3">
             <div class="card-body">
                 <p class="mb-1"><b>送信日時</b>: {{ $delivery->created_at->format('Y/m/d H:i:s') }}</p>

--- a/resources/views/setting/outgoing-webhook/index.blade.php
+++ b/resources/views/setting/outgoing-webhook/index.blade.php
@@ -1,0 +1,41 @@
+@extends('setting.base')
+
+@section('title', 'Outgoing Webhook')
+
+@section('tab-content')
+    <h3>Outgoing Webhook</h3>
+    <hr>
+    <p>Webhookを利用することで、チェックインをさまざまなシステムに連携することができます。APIドキュメントは<a href="{{ url('/apidoc.html') }}">こちら</a>から参照いただけます。</p>
+    <h4>新規登録</h4>
+    <div class="card mt-3">
+        <div class="card-body">
+            <h6 class="font-weight-bold">おことわり</h6>
+            <p>Webhook APIは予告なく仕様変更を行う場合がございます。また、登録したWebhookに起因してサーバに過剰な負荷が発生した場合、管理者の裁量によって予告なく無効化する場合があります。</p>
+            <hr>
+            <p class="mb-0">
+                @if (count($webhooks) >= $webhooksLimit)
+                    <a class="btn btn-primary disabled">新規登録</a>
+                    <span class="ml-2 text-danger">1ユーザーが登録可能なWebhookは、{{ $webhooksLimit }}件までに制限されています。</span>
+                @else
+                    <a class="btn btn-primary" href="{{ route('setting.outgoing-webhooks.create') }}">新規登録</a>
+                @endif
+            </p>
+        </div>
+    </div>
+    @if (!$webhooks->isEmpty())
+        <h4 class="mt-4">登録済みのWebhook</h4>
+        <div class="list-group mt-3">
+        @foreach ($webhooks as $webhook)
+            <div class="list-group-item d-flex justify-content-between align-items-center">
+                <div class="flex-grow-1 mr-2">
+                    <div><span class="mr-1 ti {{ $webhook->is_active ? 'ti-player-play-filled text-success' : 'ti-player-pause-filled text-secondary' }}"></span>{{ $webhook->name }}</div>
+                    <div class="text-secondary small text-break">{{ $webhook->url }}</div>
+                </div>
+                <div class="ml-2">
+                    <a class="btn btn-outline-secondary" href="{{ route('setting.outgoing-webhooks.edit', ['webhook' => $webhook->id]) }}">編集</a>
+                </div>
+            </div>
+        @endforeach
+        </div>
+    @endif
+@endsection

--- a/resources/views/setting/webhooks.blade.php
+++ b/resources/views/setting/webhooks.blade.php
@@ -1,6 +1,6 @@
 @extends('setting.base')
 
-@section('title', 'Webhook')
+@section('title', 'Incoming Webhook')
 
 @section('tab-content')
     <h3>Incoming Webhook</h3>

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,12 @@ Route::middleware('auth')->group(function () {
     Route::get('/setting/webhooks', 'SettingController@webhooks')->name('setting.webhooks');
     Route::post('/setting/webhooks', 'SettingController@storeWebhooks')->name('setting.webhooks.store');
     Route::delete('/setting/webhooks/{webhook}', 'SettingController@destroyWebhooks')->name('setting.webhooks.destroy');
+    Route::get('/setting/outgoing-webhooks', 'Setting\OutgoingWebhookController@index')->name('setting.outgoing-webhooks');
+    Route::get('/setting/outgoing-webhooks/create', 'Setting\OutgoingWebhookController@create')->name('setting.outgoing-webhooks.create');
+    Route::post('/setting/outgoing-webhooks', 'Setting\OutgoingWebhookController@store')->name('setting.outgoing-webhooks.store');
+    Route::get('/setting/outgoing-webhooks/{webhook}', 'Setting\OutgoingWebhookController@edit')->name('setting.outgoing-webhooks.edit');
+    Route::put('/setting/outgoing-webhooks/{webhook}', 'Setting\OutgoingWebhookController@update')->name('setting.outgoing-webhooks.update');
+    Route::delete('/setting/outgoing-webhooks/{webhook}', 'Setting\OutgoingWebhookController@destroy')->name('setting.outgoing-webhooks.destroy');
     Route::get('/setting/tokens', 'Setting\TokenController@index')->name('setting.tokens');
     Route::post('/setting/tokens', 'Setting\TokenController@store')->name('setting.tokens.store');
     Route::delete('/setting/tokens/{id}', 'Setting\TokenController@revoke')->name('setting.tokens.revoke');

--- a/tests/Feature/OutgoingWebhook/DeliverOutgoingWebhookTest.php
+++ b/tests/Feature/OutgoingWebhook/DeliverOutgoingWebhookTest.php
@@ -54,6 +54,19 @@ class DeliverOutgoingWebhookTest extends TestCase
         ]);
     }
 
+    public function testDoesNotDeliverWhenWebhookWasDeactivatedAfterDispatch()
+    {
+        $user = User::factory()->create();
+        $webhook = OutgoingWebhook::factory()->create(['user_id' => $user->id]);
+        $serializedJob = serialize($this->makeJob($webhook));
+        $webhook->update(['is_active' => false]);
+
+        $client = new Client(['handler' => HandlerStack::create(new MockHandler())]);
+        unserialize($serializedJob)->handle($client);
+
+        $this->assertDatabaseCount('outgoing_webhook_deliveries', 0);
+    }
+
     public function testServerErrorRecordsFailureAndRethrows()
     {
         $user = User::factory()->create();

--- a/tests/Feature/OutgoingWebhook/DeliverOutgoingWebhookTest.php
+++ b/tests/Feature/OutgoingWebhook/DeliverOutgoingWebhookTest.php
@@ -1,0 +1,144 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature\OutgoingWebhook;
+
+use App\Jobs\DeliverOutgoingWebhook;
+use App\OutgoingWebhook;
+use App\User;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class DeliverOutgoingWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    private function makeJob(OutgoingWebhook $webhook, string $body = '{}', string $event = 'checkin.created', ?string $deliveryId = null): DeliverOutgoingWebhook
+    {
+        return new DeliverOutgoingWebhook($webhook, $event, $deliveryId ?? (string) Str::uuid(), $body);
+    }
+
+    public function testSuccessfulDeliveryRecordsSuccess()
+    {
+        $user = User::factory()->create();
+        $webhook = OutgoingWebhook::factory()->create(['user_id' => $user->id]);
+
+        $mock = new MockHandler([new Response(200, [], 'ok')]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $deliveryId = (string) Str::uuid();
+        $this->makeJob($webhook, deliveryId: $deliveryId)->handle($client);
+
+        $this->assertDatabaseHas('outgoing_webhook_deliveries', [
+            'outgoing_webhook_id' => $webhook->id,
+            'user_id' => $user->id,
+            'event' => 'checkin.created',
+            'delivery_id' => $deliveryId,
+            'is_success' => true,
+            'status_code' => 200,
+            'response_body' => 'ok',
+        ]);
+    }
+
+    public function testServerErrorRecordsFailureAndRethrows()
+    {
+        $user = User::factory()->create();
+        $webhook = OutgoingWebhook::factory()->create(['user_id' => $user->id]);
+
+        $mock = new MockHandler([new Response(500, [], 'Internal Server Error')]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        try {
+            $this->makeJob($webhook)->handle($client);
+            $this->fail('Expected RequestException was not thrown');
+        } catch (RequestException) {
+        }
+
+        $this->assertDatabaseHas('outgoing_webhook_deliveries', [
+            'outgoing_webhook_id' => $webhook->id,
+            'is_success' => false,
+            'status_code' => 500,
+        ]);
+    }
+
+    public function testConnectionErrorRecordsFailureAndRethrows()
+    {
+        $user = User::factory()->create();
+        $webhook = OutgoingWebhook::factory()->create(['user_id' => $user->id]);
+
+        $mock = new MockHandler([
+            new ConnectException('Connection refused', new Request('POST', $webhook->url)),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        try {
+            $this->makeJob($webhook)->handle($client);
+            $this->fail('Expected ConnectException was not thrown');
+        } catch (ConnectException) {
+        }
+
+        // Guzzle 7 では ConnectException は TransferException を継承（RequestException ではない）
+        // → catch (\Throwable) に落ちるため response_body は汎用メッセージになる
+        $this->assertDatabaseHas('outgoing_webhook_deliveries', [
+            'outgoing_webhook_id' => $webhook->id,
+            'is_success' => false,
+            'status_code' => null,
+            'response_body' => 'Delivery failed due to an internal server error',
+        ]);
+    }
+
+    public function testResponseBodyIsTruncatedTo1024Chars()
+    {
+        $user = User::factory()->create();
+        $webhook = OutgoingWebhook::factory()->create(['user_id' => $user->id]);
+        $longBody = str_repeat('a', 2000);
+
+        $mock = new MockHandler([new Response(200, [], $longBody)]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $this->makeJob($webhook)->handle($client);
+
+        $delivery = $webhook->deliveries()->first();
+        $this->assertEquals(1024, strlen($delivery->response_body));
+    }
+
+    public function testSendsCorrectHeaders()
+    {
+        $user = User::factory()->create();
+        $webhook = OutgoingWebhook::factory()->create(['user_id' => $user->id]);
+
+        $capturedRequest = null;
+        $mock = new MockHandler([new Response(200)]);
+        $stack = HandlerStack::create($mock);
+        $stack->push(function (callable $next) use (&$capturedRequest) {
+            return function ($request, $options) use ($next, &$capturedRequest) {
+                $capturedRequest = $request;
+
+                return $next($request, $options);
+            };
+        });
+        $client = new Client(['handler' => $stack]);
+
+        $deliveryId = (string) Str::uuid();
+        $this->makeJob($webhook, '{}', 'checkin.created', $deliveryId)->handle($client);
+
+        $this->assertSame('application/json', $capturedRequest->getHeaderLine('Content-Type'));
+        $this->assertSame('checkin.created', $capturedRequest->getHeaderLine('Tissue-Event'));
+        $this->assertSame($deliveryId, $capturedRequest->getHeaderLine('Tissue-Delivery'));
+        $this->assertStringContainsString('Tissue/', $capturedRequest->getHeaderLine('User-Agent'));
+    }
+}

--- a/tests/Feature/OutgoingWebhook/DispatchOutgoingWebhookTest.php
+++ b/tests/Feature/OutgoingWebhook/DispatchOutgoingWebhookTest.php
@@ -1,0 +1,153 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature\OutgoingWebhook;
+
+use App\Ejaculation;
+use App\Events\CheckinCreated;
+use App\Events\CheckinDeleted;
+use App\Events\CheckinUpdated;
+use App\Jobs\DeliverOutgoingWebhook;
+use App\OutgoingWebhook;
+use App\User;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+class DispatchOutgoingWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function testDispatchesJobOnCheckinCreated()
+    {
+        Bus::fake();
+        $user = User::factory()->create();
+        OutgoingWebhook::factory()->create(['user_id' => $user->id, 'on_checkin_created' => true]);
+        $ejaculation = Ejaculation::factory()->create(['user_id' => $user->id]);
+
+        CheckinCreated::dispatch($ejaculation);
+
+        Bus::assertDispatched(DeliverOutgoingWebhook::class);
+    }
+
+    public function testDispatchesJobOnCheckinUpdated()
+    {
+        Bus::fake();
+        $user = User::factory()->create();
+        OutgoingWebhook::factory()->create(['user_id' => $user->id, 'on_checkin_updated' => true]);
+        $ejaculation = Ejaculation::factory()->create(['user_id' => $user->id]);
+
+        CheckinUpdated::dispatch($ejaculation);
+
+        Bus::assertDispatched(DeliverOutgoingWebhook::class);
+    }
+
+    public function testDispatchesJobOnCheckinDeleted()
+    {
+        Bus::fake();
+        $user = User::factory()->create();
+        OutgoingWebhook::factory()->create(['user_id' => $user->id, 'on_checkin_deleted' => true]);
+        $ejaculation = Ejaculation::factory()->create(['user_id' => $user->id]);
+
+        CheckinDeleted::dispatch($ejaculation);
+
+        Bus::assertDispatched(DeliverOutgoingWebhook::class);
+    }
+
+    public function testDoesNotDispatchWhenFlagDisabled()
+    {
+        Bus::fake();
+        $user = User::factory()->create();
+        OutgoingWebhook::factory()->create(['user_id' => $user->id, 'on_checkin_created' => false]);
+        $ejaculation = Ejaculation::factory()->create(['user_id' => $user->id]);
+
+        CheckinCreated::dispatch($ejaculation);
+
+        Bus::assertNotDispatched(DeliverOutgoingWebhook::class);
+    }
+
+    public function testDoesNotDispatchWhenWebhookIsInactive()
+    {
+        Bus::fake();
+        $user = User::factory()->create();
+        OutgoingWebhook::factory()->create([
+            'user_id' => $user->id,
+            'is_active' => false,
+            'on_checkin_created' => true,
+        ]);
+        $ejaculation = Ejaculation::factory()->create(['user_id' => $user->id]);
+
+        CheckinCreated::dispatch($ejaculation);
+
+        Bus::assertNotDispatched(DeliverOutgoingWebhook::class);
+    }
+
+    public function testDoesNotDispatchForOtherUsersWebhook()
+    {
+        Bus::fake();
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        OutgoingWebhook::factory()->create(['user_id' => $otherUser->id, 'on_checkin_created' => true]);
+        $ejaculation = Ejaculation::factory()->create(['user_id' => $user->id]);
+
+        CheckinCreated::dispatch($ejaculation);
+
+        Bus::assertNotDispatched(DeliverOutgoingWebhook::class);
+    }
+
+    public function testDispatchesOneJobPerWebhook()
+    {
+        Bus::fake();
+        $user = User::factory()->create();
+        OutgoingWebhook::factory()->count(2)->create(['user_id' => $user->id, 'on_checkin_created' => true]);
+        $ejaculation = Ejaculation::factory()->create(['user_id' => $user->id]);
+
+        CheckinCreated::dispatch($ejaculation);
+
+        Bus::assertDispatchedTimes(DeliverOutgoingWebhook::class, 2);
+    }
+
+    public function testSharedDeliveryIdAcrossMultipleWebhooks()
+    {
+        config(['queue.default' => 'sync']);
+        $user = User::factory()->create();
+        OutgoingWebhook::factory()->count(2)->create(['user_id' => $user->id, 'on_checkin_created' => true]);
+        $ejaculation = Ejaculation::factory()->create(['user_id' => $user->id]);
+
+        $mock = new MockHandler([new Response(200), new Response(200)]);
+        $this->app->bind(Client::class, fn () => new Client(['handler' => HandlerStack::create($mock)]));
+
+        CheckinCreated::dispatch($ejaculation);
+
+        $deliveries = \App\OutgoingWebhookDelivery::all();
+        $this->assertCount(2, $deliveries);
+        $this->assertEquals(1, $deliveries->pluck('delivery_id')->unique()->count());
+    }
+
+    public function testCheckinDeletedPayloadContainsIdOnly()
+    {
+        config(['queue.default' => 'sync']);
+        $user = User::factory()->create();
+        $webhook = OutgoingWebhook::factory()->create(['user_id' => $user->id, 'on_checkin_deleted' => true]);
+        $ejaculation = Ejaculation::factory()->create(['user_id' => $user->id]);
+
+        $mock = new MockHandler([new Response(200)]);
+        $this->app->bind(Client::class, fn () => new Client(['handler' => HandlerStack::create($mock)]));
+
+        CheckinDeleted::dispatch($ejaculation);
+
+        $body = json_decode($webhook->deliveries()->first()->request_body, true);
+        $this->assertEquals(['id' => $ejaculation->id], $body['payload']);
+        $this->assertSame('checkin.deleted', $body['event']);
+    }
+}


### PR DESCRIPTION
## 概要
チェックインの作成・更新・削除を、外部サービスにWebhookで通知する機能を追加します。

<img width="1434" height="1180" alt="image" src="https://github.com/user-attachments/assets/d8cbd783-4a96-482d-b352-eacd8d746606" />

- 通知はキューを経由し、非同期で配信します。
- 登録数は 3 hooks/user に制限しています。サーバーがどれくらい耐えられるか分からないため。

## 変更の背景・Issueへのリンク
- resolve #219 

## 補足情報 (optional)
- **本番環境のデプロイ構成に worker サービスの追加が必要です**。(例は `docker/production/sample/compose.yaml` を参照)
- 旧チェックイン削除のAjax APIで削除するとイベントが発火されません。後でAPIごと消す。

## チェックリスト
- [x] ローカル環境での動作確認を行いました
- [x] 必要に応じてテストを追加し、全てのテストが成功していることを確認しました
- [x] (公開APIの変更を行った場合) openapi.yaml を更新しました
- [ ] (開発環境に対する破壊的な変更を行った場合) CHANGELOG_FOR_DEV.md を更新しました
