### PR TITLE
node.js 24.18.0

### DIFF
--- a/docker/development/web.dockerfile
+++ b/docker/development/web.dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.20.0-bullseye as node
+FROM node:24.18.0-bullseye as node
 
 FROM php:8.2.26-apache
 

--- a/docker/production/foundation.dockerfile
+++ b/docker/production/foundation.dockerfile
@@ -12,7 +12,7 @@ COPY . /app
 
 RUN composer install -n --no-dev --prefer-dist --optimize-autoloader
 
-FROM node:22.20.0-bullseye
+FROM node:24.18.0-bullseye
 
 WORKDIR /app
 COPY --from=php /app /app


### PR DESCRIPTION
## 概要
node v24系にアップデート。

## 変更の背景・Issueへのリンク
一部パッケージの要求バージョンを満たせなくなったため。

## 補足情報 (optional)
- 前回: https://github.com/shikorism/tissue/pull/1604

## チェックリスト
- [x] ローカル環境での動作確認を行いました
- [x] 必要に応じてテストを追加し、全てのテストが成功していることを確認しました
- [ ] (公開APIの変更を行った場合) openapi.yaml を更新しました
- [ ] (開発環境に対する破壊的な変更を行った場合) CHANGELOG_FOR_DEV.md を更新しました
