### PR TITLE
DockerfileおよびCI環境をPHP 8.4にアップデート

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,9 @@ commands:
       - checkout
       - run: sudo apt update
       - run: sudo apt install -y libpq-dev
-      - run: sudo pecl install -f xdebug
+      - run: |
+          sudo -E install-php-extensions xdebug
+          sudo docker-php-ext-enable xdebug
   restore_composer:
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   build:
     docker:
-      - image: cimg/php:8.3-browsers
+      - image: cimg/php:8.4-browsers
         environment:
           APP_DEBUG: true
           APP_ENV: testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   build:
     docker:
-      - image: cimg/php:8.2-browsers
+      - image: cimg/php:8.3-browsers
         environment:
           APP_DEBUG: true
           APP_ENV: testing

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ a.k.a. shikorism.net
 
 ## 実行環境
 
-- PHP 8.2
+- PHP 8.3
 - PostgreSQL 14
 
 ## 開発環境の構築

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ a.k.a. shikorism.net
 
 ## 実行環境
 
-- PHP 8.3
+- PHP 8.4
 - PostgreSQL 14
 
 ## 開発環境の構築

--- a/app/Http/Controllers/Api/V1/UserStats/MostlyUsedLinks.php
+++ b/app/Http/Controllers/Api/V1/UserStats/MostlyUsedLinks.php
@@ -49,7 +49,7 @@ class MostlyUsedLinks extends Controller
         return response()->json($this->countMostFrequentlyUsedOkazu($user, $since, $until));
     }
 
-    private function countMostFrequentlyUsedOkazu(User $user, CarbonInterface $dateSince = null, CarbonInterface $dateUntil = null)
+    private function countMostFrequentlyUsedOkazu(User $user, ?CarbonInterface $dateSince = null, ?CarbonInterface $dateUntil = null)
     {
         $sql = <<<SQL
 SELECT normalized_link as link, count(*) as count

--- a/app/MetadataResolver/DeniedHostException.php
+++ b/app/MetadataResolver/DeniedHostException.php
@@ -12,7 +12,7 @@ class DeniedHostException extends Exception
 {
     private $url;
 
-    public function __construct(string $url, Throwable $previous = null)
+    public function __construct(string $url, ?Throwable $previous = null)
     {
         parent::__construct("Access denied by system policy: $url", 0, $previous);
         $this->url = $url;

--- a/app/MetadataResolver/DisallowedByProviderException.php
+++ b/app/MetadataResolver/DisallowedByProviderException.php
@@ -12,7 +12,7 @@ class DisallowedByProviderException extends RuntimeException
 {
     private $url;
 
-    public function __construct(string $url, Throwable $previous = null)
+    public function __construct(string $url, ?Throwable $previous = null)
     {
         parent::__construct("Access denied by robots.txt: $url", 0, $previous);
         $this->url = $url;

--- a/app/MetadataResolver/ResolverCircuitBreakException.php
+++ b/app/MetadataResolver/ResolverCircuitBreakException.php
@@ -9,7 +9,7 @@ use Throwable;
  */
 class ResolverCircuitBreakException extends \RuntimeException
 {
-    public function __construct(int $errorCount, string $url, Throwable $previous = null)
+    public function __construct(int $errorCount, string $url, ?Throwable $previous = null)
     {
         parent::__construct("{$errorCount}回失敗しているためメタデータの取得を中断しました: {$url}", 0, $previous);
     }

--- a/app/Utilities/Formatter.php
+++ b/app/Utilities/Formatter.php
@@ -157,7 +157,7 @@ class Formatter
      * @param string|null $fromEncoding `$input` の文字コード (nullの場合はdefault_charsetに準ずる、通常はUTF-8)
      * @return string エンティティ化された文字列
      */
-    public function htmlEntities(string $input, string $fromEncoding = null): string
+    public function htmlEntities(string $input, ?string $fromEncoding = null): string
     {
         // 非Unicode文字列は上手く処理できないので、UTF-8に正規化する
         $input = mb_convert_encoding($input, 'UTF-8', $fromEncoding);

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "~8.2.0",
+        "php": "~8.3.0",
         "ext-dom": "*",
         "ext-intl": "*",
         "ext-json": "*",
@@ -90,7 +90,7 @@
         "sort-packages": true,
         "optimize-autoloader": true,
         "platform": {
-            "php": "8.2"
+            "php": "8.3"
         },
         "allow-plugins": {
             "symfony/thanks": false

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "~8.3.0",
+        "php": "~8.4.0",
         "ext-dom": "*",
         "ext-intl": "*",
         "ext-json": "*",
@@ -90,7 +90,7 @@
         "sort-packages": true,
         "optimize-autoloader": true,
         "platform": {
-            "php": "8.3"
+            "php": "8.4"
         },
         "allow-plugins": {
             "symfony/thanks": false

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb23768b5b925ed566a8f8f804eb9b44",
+    "content-hash": "67fd208780b37d2b9e13cb1cac38e0ea",
     "packages": [
         {
             "name": "anhskohbo/no-captcha",
@@ -755,12 +755,12 @@
             "version": "v6.11.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
+                "url": "https://github.com/googleapis/php-jwt.git",
                 "reference": "8f718f4dfc9c5d5f0c994cdfd103921b43592712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/8f718f4dfc9c5d5f0c994cdfd103921b43592712",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/8f718f4dfc9c5d5f0c994cdfd103921b43592712",
                 "reference": "8f718f4dfc9c5d5f0c994cdfd103921b43592712",
                 "shasum": ""
             },
@@ -12150,7 +12150,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.2.0",
+        "php": "~8.3.0",
         "ext-dom": "*",
         "ext-intl": "*",
         "ext-json": "*",
@@ -12160,7 +12160,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.2"
+        "php": "8.3"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67fd208780b37d2b9e13cb1cac38e0ea",
+    "content-hash": "ca39a4415922cdf65e2bf016d8ecb2c5",
     "packages": [
         {
             "name": "anhskohbo/no-captcha",
@@ -12150,7 +12150,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.3.0",
+        "php": "~8.4.0",
         "ext-dom": "*",
         "ext-intl": "*",
         "ext-json": "*",
@@ -12160,7 +12160,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.3"
+        "php": "8.4"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/docker/development/web.dockerfile
+++ b/docker/development/web.dockerfile
@@ -1,6 +1,6 @@
 FROM node:24.18.0-bookworm as node
 
-FROM php:8.3.32-apache-bookworm
+FROM php:8.4.23-apache-bookworm
 
 ENV APACHE_DOCUMENT_ROOT /var/www/html/public
 

--- a/docker/development/web.dockerfile
+++ b/docker/development/web.dockerfile
@@ -1,6 +1,6 @@
-FROM node:24.18.0-bullseye as node
+FROM node:24.18.0-bookworm as node
 
-FROM php:8.2.26-apache
+FROM php:8.3.32-apache-bookworm
 
 ENV APACHE_DOCUMENT_ROOT /var/www/html/public
 

--- a/docker/production/config/php.ini
+++ b/docker/production/config/php.ini
@@ -144,6 +144,11 @@
 ;   Development Value: 5
 ;   Production Value: 5
 
+; session.sid_length
+;   Default Value: 32
+;   Development Value: 26
+;   Production Value: 26
+
 ; short_open_tag
 ;   Default Value: On
 ;   Development Value: Off
@@ -153,6 +158,11 @@
 ;   Default Value: "EGPCS"
 ;   Development Value: "GPCS"
 ;   Production Value: "GPCS"
+
+; zend.assertions
+;   Default Value: 1
+;   Development Value: 1
+;   Production Value: -1
 
 ; zend.exception_ignore_args
 ;   Default Value: Off
@@ -1590,32 +1600,13 @@ session.sid_bits_per_character = 5
 ; -1: Do not compile at all
 ;  0: Jump over assertion at run-time
 ;  1: Execute assertions
-; Changing from or to a negative value is only possible in php.ini! (For turning assertions on and off at run-time, see assert.active, when zend.assertions = 1)
+; Changing from or to a negative value is only possible in php.ini!
+; (For turning assertions on and off at run-time, toggle zend.assertions between the values 1 and 0)
 ; Default Value: 1
 ; Development Value: 1
 ; Production Value: -1
 ; https://php.net/zend.assertions
 zend.assertions = -1
-
-; Assert(expr); active by default.
-; https://php.net/assert.active
-;assert.active = On
-
-; Throw an AssertionError on failed assertions
-; https://php.net/assert.exception
-;assert.exception = On
-
-; Issue a PHP warning for each failed assertion. (Overridden by assert.exception if active)
-; https://php.net/assert.warning
-;assert.warning = On
-
-; Don't bail out by default.
-; https://php.net/assert.bail
-;assert.bail = Off
-
-; User-function to be called if an assertion fails.
-; https://php.net/assert.callback
-;assert.callback = 0
 
 [COM]
 ; path to a file containing GUIDs, IIDs or filenames of files with TypeLibs
@@ -1848,10 +1839,6 @@ ldap.max_links = -1
 ; Allows exclusion of large files from being cached. By default all files
 ; are cached.
 ;opcache.max_file_size=0
-
-; Check the cache checksum each N requests.
-; The default value of "0" means that the checks are disabled.
-;opcache.consistency_checks=0
 
 ; How long to wait (in seconds) for a scheduled restart to begin if the cache
 ; is not being accessed.

--- a/docker/production/config/php.ini
+++ b/docker/production/config/php.ini
@@ -107,7 +107,7 @@
 ; error_reporting
 ;   Default Value: E_ALL
 ;   Development Value: E_ALL
-;   Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
+;   Production Value: E_ALL & ~E_DEPRECATED
 
 ; log_errors
 ;   Default Value: Off
@@ -138,16 +138,6 @@
 ;   Default Value: 100
 ;   Development Value: 1000
 ;   Production Value: 1000
-
-; session.sid_bits_per_character
-;   Default Value: 4
-;   Development Value: 5
-;   Production Value: 5
-
-; session.sid_length
-;   Default Value: 32
-;   Development Value: 26
-;   Production Value: 26
 
 ; short_open_tag
 ;   Default Value: On
@@ -454,7 +444,7 @@ memory_limit = 128M
 ; operators. The error level constants are below here for convenience as well as
 ; some common settings and their meanings.
 ; By default, PHP is set to take action on all errors, notices and warnings EXCEPT
-; those related to E_NOTICE and E_STRICT, which together cover best practices and
+; those related to E_NOTICE, which together cover best practices and
 ; recommended coding standards in PHP. For performance reasons, this is the
 ; recommend error reporting setting. Your production server shouldn't be wasting
 ; resources complaining about best practices and coding standards. That's what
@@ -474,9 +464,6 @@ memory_limit = 128M
 ;                     intentional (e.g., using an uninitialized variable and
 ;                     relying on the fact it is automatically initialized to an
 ;                     empty string)
-; E_STRICT          - run-time notices, enable to have PHP suggest changes
-;                     to your code which will ensure the best interoperability
-;                     and forward compatibility of your code
 ; E_CORE_ERROR      - fatal errors that occur during PHP's initial startup
 ; E_CORE_WARNING    - warnings (non-fatal errors) that occur during PHP's
 ;                     initial startup
@@ -492,13 +479,12 @@ memory_limit = 128M
 ; Common Values:
 ;   E_ALL (Show all errors, warnings and notices including coding standards.)
 ;   E_ALL & ~E_NOTICE  (Show all errors, except for notices)
-;   E_ALL & ~E_NOTICE & ~E_STRICT  (Show all errors, except for notices and coding standards warnings.)
 ;   E_COMPILE_ERROR|E_RECOVERABLE_ERROR|E_ERROR|E_CORE_ERROR  (Show only errors)
 ; Default Value: E_ALL
 ; Development Value: E_ALL
-; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
+; Production Value: E_ALL & ~E_DEPRECATED
 ; https://php.net/error-reporting
-error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+error_reporting = E_ALL & ~E_DEPRECATED
 
 ; This directive controls whether or not and where PHP will output errors,
 ; notices and warnings too. Error output is very useful during development, but
@@ -930,12 +916,6 @@ default_socket_timeout = 60
 ;   Be sure to appropriately set the extension_dir directive.
 ;
 ;extension=bz2
-
-; The ldap extension must be before curl if OpenSSL 1.0.2 and OpenLDAP is used
-; otherwise it results in segfault when unloading after using SASL.
-; See https://github.com/php/php-src/issues/8620 for more info.
-;extension=ldap
-
 ;extension=curl
 ;extension=ffi
 ;extension=ftp
@@ -944,17 +924,14 @@ default_socket_timeout = 60
 ;extension=gettext
 ;extension=gmp
 ;extension=intl
-;extension=imap
+;extension=ldap
 ;extension=mbstring
 ;extension=exif      ; Must be after mbstring as it depends on it
 ;extension=mysqli
-;extension=oci8_12c  ; Use with Oracle Database 12c Instant Client
-;extension=oci8_19  ; Use with Oracle Database 19 Instant Client
 ;extension=odbc
 ;extension=openssl
 ;extension=pdo_firebird
 ;extension=pdo_mysql
-;extension=pdo_oci
 ;extension=pdo_odbc
 ;extension=pdo_pgsql
 ;extension=pdo_sqlite
@@ -1024,13 +1001,6 @@ date.timezone = "Asia/Tokyo"
 ; To use an output encoding conversion, iconv's output handler must be set
 ; otherwise output encoding conversion cannot be performed.
 ;iconv.output_encoding =
-
-[imap]
-; rsh/ssh logins are disabled by default. Use this INI entry if you want to
-; enable them. Note that the IMAP library does not filter mailbox names before
-; passing them to rsh/ssh command, thus passing untrusted data to this function
-; with rsh/ssh enabled is insecure.
-;imap.enable_insecure_rsh=0
 
 [intl]
 ;intl.default_locale =
@@ -1252,66 +1222,6 @@ mysqlnd.collect_memory_statistics = Off
 ; key.
 ;mysqlnd.sha256_server_public_key =
 
-[OCI8]
-
-; Connection: Enables privileged connections using external
-; credentials (OCI_SYSOPER, OCI_SYSDBA)
-; https://php.net/oci8.privileged-connect
-;oci8.privileged_connect = Off
-
-; Connection: The maximum number of persistent OCI8 connections per
-; process. Using -1 means no limit.
-; https://php.net/oci8.max-persistent
-;oci8.max_persistent = -1
-
-; Connection: The maximum number of seconds a process is allowed to
-; maintain an idle persistent connection. Using -1 means idle
-; persistent connections will be maintained forever.
-; https://php.net/oci8.persistent-timeout
-;oci8.persistent_timeout = -1
-
-; Connection: The number of seconds that must pass before issuing a
-; ping during oci_pconnect() to check the connection validity. When
-; set to 0, each oci_pconnect() will cause a ping. Using -1 disables
-; pings completely.
-; https://php.net/oci8.ping-interval
-;oci8.ping_interval = 60
-
-; Connection: Set this to a user chosen connection class to be used
-; for all pooled server requests with Oracle Database Resident
-; Connection Pooling (DRCP).  To use DRCP, this value should be set to
-; the same string for all web servers running the same application,
-; the database pool must be configured, and the connection string must
-; specify to use a pooled server.
-;oci8.connection_class =
-
-; High Availability: Using On lets PHP receive Fast Application
-; Notification (FAN) events generated when a database node fails. The
-; database must also be configured to post FAN events.
-;oci8.events = Off
-
-; Tuning: This option enables statement caching, and specifies how
-; many statements to cache. Using 0 disables statement caching.
-; https://php.net/oci8.statement-cache-size
-;oci8.statement_cache_size = 20
-
-; Tuning: Enables row prefetching and sets the default number of
-; rows that will be fetched automatically after statement execution.
-; https://php.net/oci8.default-prefetch
-;oci8.default_prefetch = 100
-
-; Tuning: Sets the amount of LOB data that is internally returned from
-; Oracle Database when an Oracle LOB locator is initially retrieved as
-; part of a query. Setting this can improve performance by reducing
-; round-trips.
-; https://php.net/oci8.prefetch-lob-size
-; oci8.prefetch_lob_size = 0
-
-; Compatibility. Using On means oci_close() will not close
-; oci_connect() and oci_new_connect() connections.
-; https://php.net/oci8.old-oci-close-semantics
-;oci8.old_oci_close_semantics = Off
-
 [PostgreSQL]
 ; Allow or prevent persistent links.
 ; https://php.net/pgsql.allow-persistent
@@ -1500,15 +1410,6 @@ session.cache_expire = 180
 ; https://php.net/session.use-trans-sid
 session.use_trans_sid = 0
 
-; Set session ID character length. This value could be between 22 to 256.
-; Shorter length than default is supported only for compatibility reason.
-; Users should use 32 or more chars.
-; https://php.net/session.sid-length
-; Default Value: 32
-; Development Value: 26
-; Production Value: 26
-session.sid_length = 26
-
 ; The URL rewriter will look for URLs in a defined set of HTML tags.
 ; <form> is special; if you include them here, the rewriter will
 ; add a hidden <input> field with the info which is otherwise appended
@@ -1533,18 +1434,6 @@ session.trans_sid_tags = "a=href,area=href,frame=src,form="
 ; Development Value: ""
 ; Production Value: ""
 ;session.trans_sid_hosts=""
-
-; Define how many bits are stored in each character when converting
-; the binary hash data to something readable.
-; Possible values:
-;   4  (4 bits: 0-9, a-f)
-;   5  (5 bits: 0-9, a-v)
-;   6  (6 bits: 0-9, a-z, A-Z, "-", ",")
-; Default Value: 4
-; Development Value: 5
-; Production Value: 5
-; https://php.net/session.hash-bits-per-character
-session.sid_bits_per_character = 5
 
 ; Enable upload progress tracking in $_SESSION
 ; Default Value: On
@@ -1714,7 +1603,7 @@ mbstring.language = Japanese
 ; With mbstring support this will automatically be converted into the encoding
 ; given by corresponding encode setting. When empty mbstring.internal_encoding
 ; is used. For the decode settings you can distinguish between motorola and
-; intel byte order. A decode setting cannot be empty.
+; intel byte order. A decode setting must not be empty.
 ; https://php.net/exif.encode-unicode
 ;exif.encode_unicode = ISO-8859-15
 

--- a/docker/production/foundation.dockerfile
+++ b/docker/production/foundation.dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3.32-cli-bookworm as php
+FROM php:8.4.23-cli-bookworm as php
 
 RUN apt-get update \
     && apt-get install -y git libpq-dev unzip libicu-dev \

--- a/docker/production/foundation.dockerfile
+++ b/docker/production/foundation.dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.26-cli-bullseye as php
+FROM php:8.3.32-cli-bookworm as php
 
 RUN apt-get update \
     && apt-get install -y git libpq-dev unzip libicu-dev \
@@ -12,7 +12,7 @@ COPY . /app
 
 RUN composer install -n --no-dev --prefer-dist --optimize-autoloader
 
-FROM node:24.18.0-bullseye
+FROM node:24.18.0-bookworm
 
 WORKDIR /app
 COPY --from=php /app /app

--- a/docker/production/php.dockerfile
+++ b/docker/production/php.dockerfile
@@ -2,7 +2,7 @@ ARG TISSUE_FOUNDATION_IMAGE_NAME
 
 FROM ${TISSUE_FOUNDATION_IMAGE_NAME} as foundation
 
-FROM php:8.3.32-fpm-bookworm
+FROM php:8.4.23-fpm-bookworm
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libpq-dev libicu-dev \

--- a/docker/production/php.dockerfile
+++ b/docker/production/php.dockerfile
@@ -2,7 +2,7 @@ ARG TISSUE_FOUNDATION_IMAGE_NAME
 
 FROM ${TISSUE_FOUNDATION_IMAGE_NAME} as foundation
 
-FROM php:8.2.26-fpm-bullseye
+FROM php:8.3.32-fpm-bookworm
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libpq-dev libicu-dev \


### PR DESCRIPTION
## 概要
PHPを8.2→8.4にアップデートします。

Laravel 11のサポート上限が8.4系なので、今のLaravelでアップデートできる上限となります。

## 変更の背景・Issueへのリンク
さすがに8.2はもう古いやん

## 補足情報 (optional)
- 前回: https://github.com/shikorism/tissue/pull/1341

## チェックリスト
- [x] ローカル環境での動作確認を行いました
- [x] 必要に応じてテストを追加し、全てのテストが成功していることを確認しました
- [ ] (公開APIの変更を行った場合) openapi.yaml を更新しました
- [ ] (開発環境に対する破壊的な変更を行った場合) CHANGELOG_FOR_DEV.md を更新しました
